### PR TITLE
OLM release as a separate GHA workflow

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -81,8 +81,3 @@ jobs:
         with:
           charts_dir: deploy/charts
           charts_repo_url: https://mariadb-operator.github.io/mariadb-operator
-
-      - name: Dispatch helm workflow
-        run: gh workflow run bundle.yaml --repo mariadb-operator/mariadb-operator-helm -f version=$(make helm-chart-version)
-        env:
-          GITHUB_TOKEN: "${{ secrets.GHA_TOKEN }}"

--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -1,0 +1,21 @@
+name: OLM
+
+on:
+  push:
+    tags:
+      - "helm-chart-*"
+
+jobs:
+  olm:
+    name: OLM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Dispatch helm workflow
+        run: gh workflow run bundle.yaml --repo mariadb-operator/mariadb-operator-helm -f version=$(make helm-chart-version)
+        env:
+          GITHUB_TOKEN: "${{ secrets.GHA_TOKEN }}"


### PR DESCRIPTION
This will release the OLM operator when the chart releaser action pushes a tag.