### PR TITLE
Fix wrong status condition type for MariaDB restore

### DIFF
--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -414,13 +414,13 @@ func (r *MariaDBReconciler) patcher(ctx context.Context, mariaDb *mariadbv1alpha
 			})
 		} else {
 			c.SetCondition(metav1.Condition{
-				Type:    mariadbv1alpha1.ConditionTypeReady,
+				Type:    mariadbv1alpha1.ConditionTypeBootstrapped,
 				Status:  metav1.ConditionFalse,
 				Reason:  mariadbv1alpha1.ConditionReasonRestoreNotComplete,
 				Message: "Restoring backup",
 			})
 			c.SetCondition(metav1.Condition{
-				Type:    mariadbv1alpha1.ConditionTypeBootstrapped,
+				Type:    mariadbv1alpha1.ConditionTypeReady,
 				Status:  metav1.ConditionFalse,
 				Reason:  mariadbv1alpha1.ConditionReasonRestoreNotComplete,
 				Message: "Not ready",


### PR DESCRIPTION
It seems to me that there might be an issue with the condition types for the MariaDB resource during the backup restoration process. Could it be possible that the types were swapped?

I think that the type for the "Restoring backup" condition should be `Bootstrapped `as it is part of the bootstrapping process. Please let me know if I am mistaken.