### PR TITLE
feat: add optional username to User CRD

### DIFF
--- a/api/v1alpha1/user_types.go
+++ b/api/v1alpha1/user_types.go
@@ -30,6 +30,8 @@ type UserSpec struct {
 	PasswordSecretKeyRef corev1.SecretKeySelector `json:"passwordSecretKeyRef" webhook:"inmutable"`
 	// +kubebuilder:default=10
 	MaxUserConnections int32 `json:"maxUserConnections,omitempty" webhook:"inmutable"`
+	// +kubebuilder:validation:MaxLength=80
+	Name string `json:"name,omitempty" webhook:"inmutable"`
 }
 
 // UserStatus defines the observed state of User

--- a/config/crd/bases/mariadb.mmontes.io_users.yaml
+++ b/config/crd/bases/mariadb.mmontes.io_users.yaml
@@ -68,6 +68,9 @@ spec:
                 default: 10
                 format: int32
                 type: integer
+              name:
+                maxLength: 80
+                type: string
               passwordSecretKeyRef:
                 description: SecretKeySelector selects a key of a Secret.
                 properties:

--- a/controllers/user_controller.go
+++ b/controllers/user_controller.go
@@ -90,11 +90,17 @@ func (wr *wrappedUserReconciler) Reconcile(ctx context.Context, mdbClient *maria
 	if err != nil {
 		return fmt.Errorf("error reading user password secret: %v", err)
 	}
+
+	name := wr.user.Name
+	if wr.user.Spec.Name != "" {
+		name = wr.user.Spec.Name
+	}
+
 	opts := mariadbclient.CreateUserOpts{
 		IdentifiedBy:       password,
 		MaxUserConnections: wr.user.Spec.MaxUserConnections,
 	}
-	if err := mdbClient.CreateUser(ctx, wr.user.Name, opts); err != nil {
+	if err := mdbClient.CreateUser(ctx, name, opts); err != nil {
 		return fmt.Errorf("error creating user in MariaDB: %v", err)
 	}
 	return nil

--- a/deploy/charts/mariadb-operator/crds/crds.yaml
+++ b/deploy/charts/mariadb-operator/crds/crds.yaml
@@ -8142,6 +8142,9 @@ spec:
                 default: 10
                 format: int32
                 type: integer
+              name:
+                maxLength: 80
+                type: string
               passwordSecretKeyRef:
                 description: SecretKeySelector selects a key of a Secret.
                 properties:

--- a/deploy/crds/crds.yaml
+++ b/deploy/crds/crds.yaml
@@ -8142,6 +8142,9 @@ spec:
                 default: 10
                 format: int32
                 type: integer
+              name:
+                maxLength: 80
+                type: string
               passwordSecretKeyRef:
                 description: SecretKeySelector selects a key of a Secret.
                 properties:


### PR DESCRIPTION
Solves #86 by adding an optional `name` field on User.spec.

Works well on my end, although it seems like this field is not inmutable. I managed to change the name value and patch the CRD, which created a new user in the database while keeping the first one. Is the `webhook:"inmutable"`` tag not enough ?

This is my first time writing Go code so I may be wrong about how tags work in Go.

I added a 80 characters limit to the user names following [the MariaDB documentation](https://mariadb.com/kb/en/identifier-names/#maximum-length).