### PR TITLE
Added MARIADB_ROOT_HOST explicitly to not rely on defaults

### DIFF
--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -227,6 +227,10 @@ func buildStatefulSetEnv(mariadb *mariadbv1alpha1.MariaDB) []v1.EnvVar {
 			},
 		},
 		{
+			Name:  "MARIADB_ROOT_HOST",
+			Value: "%",
+		},
+		{
 			Name:  "MYSQL_INITDB_SKIP_TZINFO",
 			Value: "1",
 		},


### PR DESCRIPTION
Related to:
- https://github.com/mariadb-operator/mariadb-operator/issues/89