### PR TITLE
Using read_only to lock primary during switchover

### DIFF
--- a/config/samples/mariadb_v1alpha1_mariadb_replication.yaml
+++ b/config/samples/mariadb_v1alpha1_mariadb_replication.yaml
@@ -41,7 +41,7 @@ spec:
           key: dsn
     replica:
       waitPoint: AfterCommit
-      gtid: SlavePos
+      gtid: CurrentPos
       connectionTimeout: 10s
       connectionRetries: 10
       syncTimeout: 10s

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -196,14 +196,6 @@ func (c *Client) DropDatabase(ctx context.Context, database string) error {
 	return c.Exec(ctx, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`;", database))
 }
 
-func (c *Client) LockTablesWithReadLock(ctx context.Context) error {
-	return c.Exec(ctx, "FLUSH TABLES WITH READ LOCK;")
-}
-
-func (c *Client) UnlockTables(ctx context.Context) error {
-	return c.Exec(ctx, "UNLOCK TABLES;")
-}
-
 func (c *Client) GlobalVar(ctx context.Context, variable string) (string, error) {
 	sql := fmt.Sprintf("SELECT @@global.%s;", variable)
 	row := c.db.QueryRowContext(ctx, sql)
@@ -227,6 +219,14 @@ func (c *Client) SetGlobalVars(ctx context.Context, keyVal map[string]string) er
 		}
 	}
 	return nil
+}
+
+func (c *Client) SetReadOnly(ctx context.Context) error {
+	return c.SetGlobalVar(ctx, "read_only", "1")
+}
+
+func (c *Client) DisableReadOnly(ctx context.Context) error {
+	return c.SetGlobalVar(ctx, "read_only", "0")
 }
 
 func (c *Client) ResetMaster(ctx context.Context) error {

--- a/pkg/controller/replication/switchover.go
+++ b/pkg/controller/replication/switchover.go
@@ -52,8 +52,8 @@ func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *re
 
 	phases := []switchoverPhase{
 		{
-			name:      "Lock current primary tables",
-			reconcile: r.lockCurrentPrimary,
+			name:      "Set read_only in current primary",
+			reconcile: r.currentPrimaryReadOnly,
 		},
 		{
 			name:      "Wait for replica sync",
@@ -98,7 +98,7 @@ func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *re
 	return nil
 }
 
-func (r *ReplicationReconciler) lockCurrentPrimary(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,
+func (r *ReplicationReconciler) currentPrimaryReadOnly(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,
 	clientSet *mariadbClientSet) error {
 	ready, err := r.currentPrimaryReady(ctx, mariadb)
 	if err != nil {
@@ -112,7 +112,7 @@ func (r *ReplicationReconciler) lockCurrentPrimary(ctx context.Context, mariadb 
 		return fmt.Errorf("error getting current primary client: %v", err)
 	}
 
-	return client.LockTablesWithReadLock(ctx)
+	return client.SetReadOnly(ctx)
 }
 
 func (r *ReplicationReconciler) waitForReplicaSync(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,


### PR DESCRIPTION
Closes https://github.com/mariadb-operator/mariadb-operator/issues/124