### PR TITLE
examples: added quotes in liveness/readiness probes

### DIFF
--- a/examples/manifests/mariadb_v1alpha1_mariadb.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb.yaml
@@ -69,7 +69,7 @@ spec:
       command:
         - bash
         - -c
-        - mysql -u root -p${MARIADB_ROOT_PASSWORD} -e "SELECT 1;"
+        - mysql -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
     initialDelaySeconds: 20
     periodSeconds: 10
     timeoutSeconds: 5
@@ -79,7 +79,7 @@ spec:
       command:
         - bash
         - -c
-        - mysql -u root -p${MARIADB_ROOT_PASSWORD} -e "SELECT 1;"
+        - mysql -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
     initialDelaySeconds: 20
     periodSeconds: 10
     timeoutSeconds: 5


### PR DESCRIPTION
In the "plain" mariadb example manifest, we have a custom liveness/readiness probe.
The probes call the `mysql` tool passing the root password as a parameter: the password is not quoted.

If the (custom) root password contains spaces, the probes will fail.