### PR TITLE
set labels for svc so servicemonitor can find it

### DIFF
--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -283,6 +283,7 @@ func (r *MariaDBReconciler) reconcileService(ctx context.Context, mariadb *maria
 	existingSvc.Spec.Ports = desiredSvc.Spec.Ports
 	existingSvc.Spec.Type = desiredSvc.Spec.Type
 	existingSvc.Annotations = desiredSvc.Annotations
+	existingSvc.Labels = desiredSvc.Labels
 	return r.Patch(ctx, &existingSvc, patch)
 }
 

--- a/controllers/mariadb_controller_test.go
+++ b/controllers/mariadb_controller_test.go
@@ -54,6 +54,8 @@ var _ = Describe("MariaDB controller", func() {
 					return false
 				}
 				Expect(svc.ObjectMeta.Labels).NotTo(BeNil())
+				Expect(svc.ObjectMeta.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", testMariaDbName))
+				Expect(svc.ObjectMeta.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "mariadb"))
 				Expect(svc.ObjectMeta.Annotations).NotTo(BeNil())
 				return true
 			}, testTimeout, testInterval).Should(BeTrue())

--- a/pkg/builder/service_builder.go
+++ b/pkg/builder/service_builder.go
@@ -33,6 +33,7 @@ func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.Names
 		metadata.NewMetadataBuilder(key).
 			WithMariaDB(mariadb).
 			WithAnnotations(opts.Annotations).
+			WithLabels(opts.Selectorlabels).
 			Build()
 	selectorLabels :=
 		labels.NewLabelsBuilder().

--- a/pkg/builder/service_builder.go
+++ b/pkg/builder/service_builder.go
@@ -29,16 +29,16 @@ type ServiceOpts struct {
 
 func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.NamespacedName,
 	opts ServiceOpts) (*corev1.Service, error) {
-	objMeta :=
-		metadata.NewMetadataBuilder(key).
-			WithMariaDB(mariadb).
-			WithAnnotations(opts.Annotations).
-			WithLabels(opts.Selectorlabels).
-			Build()
 	selectorLabels :=
 		labels.NewLabelsBuilder().
 			WithMariaDBSelectorLabels(mariadb).
 			WithLabels(opts.Selectorlabels).
+			Build()
+	objMeta :=
+		metadata.NewMetadataBuilder(key).
+			WithMariaDB(mariadb).
+			WithAnnotations(opts.Annotations).
+			WithLabels(selectorLabels).
 			Build()
 	svc := &corev1.Service{
 		ObjectMeta: objMeta,


### PR DESCRIPTION
The Prometheus Operator can't currently pick up mariadb instances because the created mariadb service doesn't have the labels the ServiceMonitor looks for