### PR TITLE
Removed Galera storage class from defaults letting Kubernetes use the default one

### DIFF
--- a/api/v1alpha1/backup_webhook_test.go
+++ b/api/v1alpha1/backup_webhook_test.go
@@ -29,7 +29,6 @@ import (
 var _ = Describe("Backup webhook", func() {
 	Context("When creating a Backup", func() {
 		It("Should validate", func() {
-			storageClassName := "standard"
 			// TODO: migrate to Ginkgo v2 and use Ginkgo table tests
 			// https://github.com/mariadb-operator/mariadb-operator/issues/3
 			tt := []struct {
@@ -76,7 +75,6 @@ var _ = Describe("Backup webhook", func() {
 							},
 							Storage: BackupStorage{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{
-									StorageClassName: &storageClassName,
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
 											"storage": resource.MustParse("100Mi"),
@@ -117,7 +115,6 @@ var _ = Describe("Backup webhook", func() {
 							},
 							Storage: BackupStorage{
 								PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{
-									StorageClassName: &storageClassName,
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
 											"storage": resource.MustParse("100Mi"),
@@ -165,7 +162,6 @@ var _ = Describe("Backup webhook", func() {
 				Name:      "backup-update",
 				Namespace: testNamespace,
 			}
-			storageClassName := "standard"
 			backup := Backup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      key.Name,
@@ -174,7 +170,6 @@ var _ = Describe("Backup webhook", func() {
 				Spec: BackupSpec{
 					Storage: BackupStorage{
 						PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{
-							StorageClassName: &storageClassName,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"storage": resource.MustParse("100Mi"),

--- a/api/v1alpha1/mariadb_galera_types.go
+++ b/api/v1alpha1/mariadb_galera_types.go
@@ -197,13 +197,12 @@ func (g *GaleraSpec) FillWithDefaults() {
 }
 
 var (
-	fiveSeconds      = metav1.Duration{Duration: 5 * time.Second}
-	oneMinute        = metav1.Duration{Duration: 1 * time.Minute}
-	fiveMinutes      = metav1.Duration{Duration: 5 * time.Minute}
-	threeMinutes     = metav1.Duration{Duration: 3 * time.Minute}
-	sst              = SSTMariaBackup
-	replicaThreads   = 1
-	storageClassName = "default"
+	fiveSeconds    = metav1.Duration{Duration: 5 * time.Second}
+	oneMinute      = metav1.Duration{Duration: 1 * time.Minute}
+	fiveMinutes    = metav1.Duration{Duration: 5 * time.Minute}
+	threeMinutes   = metav1.Duration{Duration: 3 * time.Minute}
+	sst            = SSTMariaBackup
+	replicaThreads = 1
 
 	// DefaultGaleraSpec provides sensible defaults for the GaleraSpec.
 	DefaultGaleraSpec = GaleraSpec{
@@ -243,7 +242,6 @@ var (
 					"storage": resource.MustParse("50Mi"),
 				},
 			},
-			StorageClassName: &storageClassName,
 			AccessModes: []corev1.PersistentVolumeAccessMode{
 				corev1.ReadWriteOnce,
 			},

--- a/api/v1alpha1/mariadb_webhook_test.go
+++ b/api/v1alpha1/mariadb_webhook_test.go
@@ -293,7 +293,6 @@ var _ = Describe("MariaDB webhook", func() {
 		})
 
 		It("Should default Galera", func() {
-			storageClassName := "standard"
 			mariadb := MariaDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mariadb-galera-default-webhook",
@@ -315,7 +314,6 @@ var _ = Describe("MariaDB webhook", func() {
 					},
 					Port: 3306,
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &storageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),
@@ -343,7 +341,6 @@ var _ = Describe("MariaDB webhook", func() {
 		It("Should validate", func() {
 			By("Creating MariaDB")
 			test := "test"
-			storageClassName := "standard"
 			mariadb := MariaDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "mariadb-update-webhook",
@@ -391,7 +388,6 @@ var _ = Describe("MariaDB webhook", func() {
 						Key: "password",
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &storageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),
@@ -584,7 +580,6 @@ var _ = Describe("MariaDB webhook", func() {
 				Namespace: testNamespace,
 			}
 			test := "test"
-			storageClassName := "standard"
 			mariaDb := MariaDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      noSwitchoverKey.Name,
@@ -613,7 +608,6 @@ var _ = Describe("MariaDB webhook", func() {
 					},
 
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &storageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),
@@ -659,7 +653,6 @@ var _ = Describe("MariaDB webhook", func() {
 						Key: "password",
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &storageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),

--- a/controllers/backup_controller_test.go
+++ b/controllers/backup_controller_test.go
@@ -49,7 +49,6 @@ var _ = Describe("Backup controller", func() {
 					},
 					Storage: mariadbv1alpha1.BackupStorage{
 						PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{
-							StorageClassName: &testStorageClassName,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"storage": resource.MustParse("100Mi"),
@@ -108,7 +107,6 @@ var _ = Describe("Backup controller", func() {
 					},
 					Storage: mariadbv1alpha1.BackupStorage{
 						PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{
-							StorageClassName: &testStorageClassName,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"storage": resource.MustParse("100Mi"),

--- a/controllers/mariadb_controller_test.go
+++ b/controllers/mariadb_controller_test.go
@@ -595,7 +595,6 @@ var _ = Describe("MariaDB Galera", func() {
 						},
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &testStorageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),
@@ -625,7 +624,6 @@ var _ = Describe("MariaDB Galera", func() {
 								PodSyncTimeout:          &recoveryTimeout,
 							},
 							VolumeClaimTemplate: &corev1.PersistentVolumeClaimSpec{
-								StorageClassName: &testStorageClassName,
 								Resources: corev1.ResourceRequirements{
 									Requests: corev1.ResourceList{
 										"storage": resource.MustParse("10Mi"),

--- a/controllers/mariadb_controller_test.go
+++ b/controllers/mariadb_controller_test.go
@@ -92,7 +92,6 @@ var _ = Describe("MariaDB", func() {
 					},
 					Storage: mariadbv1alpha1.BackupStorage{
 						PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{
-							StorageClassName: &testStorageClassName,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"storage": resource.MustParse("100Mi"),
@@ -144,7 +143,6 @@ var _ = Describe("MariaDB", func() {
 						Key: testPwdSecretKey,
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &testStorageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),
@@ -194,7 +192,6 @@ var _ = Describe("MariaDB", func() {
 						},
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &testStorageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),
@@ -252,7 +249,6 @@ var _ = Describe("MariaDB", func() {
 						Key: testPwdSecretKey,
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &testStorageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),
@@ -305,7 +301,6 @@ var _ = Describe("MariaDB", func() {
 						Key: testPwdSecretKey,
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &testStorageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),
@@ -388,7 +383,6 @@ var _ = Describe("MariaDB replication", func() {
 						},
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &testStorageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -51,7 +51,6 @@ var _ = Describe("Restore controller", func() {
 					},
 					Storage: mariadbv1alpha1.BackupStorage{
 						PersistentVolumeClaim: &corev1.PersistentVolumeClaimSpec{
-							StorageClassName: &testStorageClassName,
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									"storage": resource.MustParse("100Mi"),
@@ -98,7 +97,6 @@ var _ = Describe("Restore controller", func() {
 						Key: testPwdSecretKey,
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-						StorageClassName: &testStorageClassName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								"storage": resource.MustParse("100Mi"),

--- a/controllers/suite_test_data.go
+++ b/controllers/suite_test_data.go
@@ -39,9 +39,8 @@ const (
 )
 
 var (
-	testNamespace        = "default"
-	testStorageClassName = "standard"
-	testMariaDbName      = "mariadb-test"
+	testNamespace   = "default"
+	testMariaDbName = "mariadb-test"
 
 	testUser           = "test"
 	testPwdSecretKey   = "passsword"
@@ -148,7 +147,6 @@ func createTestData(ctx context.Context, k8sClient client.Client) {
 				},
 			},
 			VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
-				StorageClassName: &testStorageClassName,
 				Resources: corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						"storage": resource.MustParse("100Mi"),

--- a/docs/GALERA.md
+++ b/docs/GALERA.md
@@ -28,7 +28,7 @@ spec:
 ...
 ```
 
-This relies on sensible defaults set by either the operator or the webhook, such as the `default` `StorageClass`, which may not be suitable for your Kubernetes cluster. This can be solved by overriding the defaults, as in this other [example](../examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml), so you have fine grained control over the Galera configuration:
+This relies on sensible defaults set by either the operator or the webhook, which may not be suitable for your Kubernetes cluster. This can be solved by overriding the defaults, as in this other [example](../examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml), so you have fine grained control over the Galera configuration:
 
 ```yaml
 apiVersion: mariadb.mmontes.io/v1alpha1
@@ -66,7 +66,6 @@ spec:
       resources:
         requests:
           storage: 50Mi
-      storageClassName: standard
       accessModes:
         - ReadWriteOnce
 ...

--- a/examples/flux/tenants/photoprism/photoprism-mariadb.yaml
+++ b/examples/flux/tenants/photoprism/photoprism-mariadb.yaml
@@ -30,7 +30,6 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
 

--- a/examples/manifests/mariadb_v1alpha1_backup.yaml
+++ b/examples/manifests/mariadb_v1alpha1_backup.yaml
@@ -10,7 +10,6 @@ spec:
       resources:
         requests:
           storage: 100Mi
-      storageClassName: standard
       accessModes:
         - ReadWriteOnce
   resources:

--- a/examples/manifests/mariadb_v1alpha1_backup_scheduled.yaml
+++ b/examples/manifests/mariadb_v1alpha1_backup_scheduled.yaml
@@ -14,7 +14,6 @@ spec:
       resources:
         requests:
           storage: 100Mi
-      storageClassName: standard
       accessModes:
         - ReadWriteOnce
   resources:

--- a/examples/manifests/mariadb_v1alpha1_mariadb.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb.yaml
@@ -24,7 +24,6 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
   volumes: 

--- a/examples/manifests/mariadb_v1alpha1_mariadb_config.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_config.yaml
@@ -18,7 +18,6 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
 

--- a/examples/manifests/mariadb_v1alpha1_mariadb_connection.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_connection.yaml
@@ -34,7 +34,6 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
 

--- a/examples/manifests/mariadb_v1alpha1_mariadb_from_backup.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_from_backup.yaml
@@ -24,7 +24,6 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
 

--- a/examples/manifests/mariadb_v1alpha1_mariadb_from_nfs.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_from_nfs.yaml
@@ -24,7 +24,6 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
 

--- a/examples/manifests/mariadb_v1alpha1_mariadb_from_pvc.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_from_pvc.yaml
@@ -24,7 +24,6 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
 

--- a/examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml
@@ -56,7 +56,6 @@ spec:
       resources:
         requests:
           storage: 50Mi
-      storageClassName: standard
       accessModes:
         - ReadWriteOnce
 
@@ -95,7 +94,6 @@ spec:
     resources:
       requests:
         storage: 1Gi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
 

--- a/examples/manifests/mariadb_v1alpha1_mariadb_galera_minimal.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_galera_minimal.yaml
@@ -23,6 +23,5 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce

--- a/examples/manifests/mariadb_v1alpha1_mariadb_metadata.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_metadata.yaml
@@ -25,6 +25,5 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce

--- a/examples/manifests/mariadb_v1alpha1_mariadb_metrics.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_metrics.yaml
@@ -18,7 +18,6 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
 

--- a/examples/manifests/mariadb_v1alpha1_mariadb_minimal.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_minimal.yaml
@@ -18,6 +18,5 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce

--- a/examples/manifests/mariadb_v1alpha1_mariadb_replication.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_replication.yaml
@@ -75,7 +75,6 @@ spec:
     resources:
       requests:
         storage: 100Mi
-    storageClassName: standard
     accessModes:
       - ReadWriteOnce
 


### PR DESCRIPTION
Related to:
- https://github.com/mariadb-operator/mariadb-operator/issues/155