### PR TITLE
Use [mariadb] as group for MariaDB server

### DIFF
--- a/controllers/mariadb_controller_test.go
+++ b/controllers/mariadb_controller_test.go
@@ -393,7 +393,7 @@ var _ = Describe("MariaDB replication", func() {
 						},
 					},
 					MyCnf: func() *string {
-						cfg := `[mysqld]
+						cfg := `[mariadb]
 						bind-address=0.0.0.0
 						default_storage_engine=InnoDB
 						binlog_format=row
@@ -599,7 +599,7 @@ var _ = Describe("MariaDB Galera", func() {
 						},
 					},
 					MyCnf: func() *string {
-						cfg := `[mysqld]
+						cfg := `[mariadb]
 						bind-address=0.0.0.0
 						default_storage_engine=InnoDB
 						binlog_format=row

--- a/controllers/suite_test_data.go
+++ b/controllers/suite_test_data.go
@@ -157,7 +157,7 @@ func createTestData(ctx context.Context, k8sClient client.Client) {
 				},
 			},
 			MyCnf: func() *string {
-				cfg := `[mysqld]
+				cfg := `[mariadb]
 				bind-address=0.0.0.0
 				default_storage_engine=InnoDB
 				binlog_format=row

--- a/examples/manifests/config/mariadb-my-cnf-configmap.yaml
+++ b/examples/manifests/config/mariadb-my-cnf-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mariadb-my-cnf
 data:
   config: |
-    [mysqld]
+    [mariadb]
     bind-address=0.0.0.0
     default_storage_engine=InnoDB
     binlog_format=row

--- a/examples/manifests/mariadb_v1alpha1_mariadb_replication.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_replication.yaml
@@ -64,7 +64,7 @@ spec:
     type: RollingUpdate
 
   myCnf: |
-    [mysqld]
+    [mariadb]
     bind-address=0.0.0.0
     default_storage_engine=InnoDB
     binlog_format=row


### PR DESCRIPTION
[mariadb] has been read by the MariaDB server for a long time.  (5.5 and probably 5.3)

As this operator is container to MariaDB use its a good place to remove some references to the diverging heritage of mysql.