### PR TITLE
healthcheck.sh for liveness/readiness

### DIFF
--- a/controllers/suite_test_data.go
+++ b/controllers/suite_test_data.go
@@ -99,9 +99,9 @@ func createTestData(ctx context.Context, k8sClient client.Client) {
 					ProbeHandler: v1.ProbeHandler{
 						Exec: &v1.ExecAction{
 							Command: []string{
-								"bash",
-								"-c",
-								"mariadb -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SELECT 1;\"",
+								"healthcheck.sh",
+								"--connect",
+								"--innodb_initialized",
 							},
 						},
 					},
@@ -113,9 +113,9 @@ func createTestData(ctx context.Context, k8sClient client.Client) {
 					ProbeHandler: v1.ProbeHandler{
 						Exec: &v1.ExecAction{
 							Command: []string{
-								"bash",
-								"-c",
-								"mariadb -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SELECT 1;\"",
+								"healthcheck.sh",
+								"--connect",
+								"--innodb_initialized",
 							},
 						},
 					},

--- a/examples/manifests/mariadb_v1alpha1_mariadb.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb.yaml
@@ -67,9 +67,9 @@ spec:
   livenessProbe:
     exec:
       command:
-        - bash
-        - -c
-        - mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
+        - healthcheck.sh
+        - --connect
+        - --innodb_initialized
     initialDelaySeconds: 20
     periodSeconds: 10
     timeoutSeconds: 5
@@ -77,9 +77,9 @@ spec:
   readinessProbe:
     exec:
       command:
-        - bash
-        - -c
-        - mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
+        - healthcheck.sh
+        - --connect
+        - --innodb_initialized
     initialDelaySeconds: 20
     periodSeconds: 10
     timeoutSeconds: 5

--- a/pkg/builder/statefulset_container_builder.go
+++ b/pkg/builder/statefulset_container_builder.go
@@ -338,9 +338,9 @@ var (
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{
-					"bash",
-					"-c",
-					"mariadb -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SELECT 1;\"",
+					"healthcheck.sh",
+					"--connect",
+					"--innodb_initialized",
 				},
 			},
 		},
@@ -352,9 +352,10 @@ var (
 		ProbeHandler: corev1.ProbeHandler{
 			Exec: &corev1.ExecAction{
 				Command: []string{
-					"bash",
-					"-c",
-					"mariadb -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SHOW STATUS LIKE 'wsrep_ready'\" | grep -c ON",
+					"healthcheck.sh",
+					"--connect",
+					"--innodb_initialized",
+					"--galera_online",
 				},
 			},
 		},


### PR DESCRIPTION
Per
https://mariadb.org/mariadb-server-docker-official-images-healthcheck-without-mysqladmin/, mysql isn't included in mariadb:11.0+ images. And without enforcing a tcp option there are initialization stages that may report true ahead of the actual readiness.

ref: https://mariadb.com/kb/en/using-healthcheck-sh-script/