### PR TITLE
Support for MariaDB 11

### DIFF
--- a/api/v1alpha1/mariadb_webhook_test.go
+++ b/api/v1alpha1/mariadb_webhook_test.go
@@ -302,7 +302,7 @@ var _ = Describe("MariaDB webhook", func() {
 					ContainerTemplate: ContainerTemplate{
 						Image: Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 							PullPolicy: corev1.PullIfNotPresent,
 						},
 					},
@@ -350,7 +350,7 @@ var _ = Describe("MariaDB webhook", func() {
 					ContainerTemplate: ContainerTemplate{
 						Image: Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 						Resources: &corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -589,7 +589,7 @@ var _ = Describe("MariaDB webhook", func() {
 					ContainerTemplate: ContainerTemplate{
 						Image: Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 					},
 					RootPasswordSecretKeyRef: corev1.SecretKeySelector{
@@ -635,7 +635,7 @@ var _ = Describe("MariaDB webhook", func() {
 					ContainerTemplate: ContainerTemplate{
 						Image: Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 					},
 					RootPasswordSecretKeyRef: corev1.SecretKeySelector{

--- a/controllers/mariadb_controller_test.go
+++ b/controllers/mariadb_controller_test.go
@@ -22,7 +22,7 @@ var _ = Describe("MariaDB", func() {
 	Context("When creating a MariaDB", func() {
 		It("Should reconcile", func() {
 			By("Expecting to have spec provided by user and defaults")
-			Expect(testMariaDb.Spec.Image.String()).To(Equal("mariadb:10.11.3"))
+			Expect(testMariaDb.Spec.Image.String()).To(Equal("mariadb:11.0.2"))
 			Expect(testMariaDb.Spec.Port).To(BeEquivalentTo(3306))
 
 			By("Expecting to create a ConfigMap eventually")
@@ -128,7 +128,7 @@ var _ = Describe("MariaDB", func() {
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Image: mariadbv1alpha1.Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 					},
 					BootstrapFrom: &mariadbv1alpha1.RestoreSource{
@@ -188,7 +188,7 @@ var _ = Describe("MariaDB", func() {
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Image: mariadbv1alpha1.Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 					},
 					VolumeClaimTemplate: corev1.PersistentVolumeClaimSpec{
@@ -234,7 +234,7 @@ var _ = Describe("MariaDB", func() {
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Image: mariadbv1alpha1.Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 					},
 					BootstrapFrom: &mariadbv1alpha1.RestoreSource{
@@ -291,7 +291,7 @@ var _ = Describe("MariaDB", func() {
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Image: mariadbv1alpha1.Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 					},
 					RootPasswordSecretKeyRef: corev1.SecretKeySelector{
@@ -356,7 +356,7 @@ var _ = Describe("MariaDB replication", func() {
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Image: mariadbv1alpha1.Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 					},
 					RootPasswordSecretKeyRef: corev1.SecretKeySelector{
@@ -562,7 +562,7 @@ var _ = Describe("MariaDB Galera", func() {
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Image: mariadbv1alpha1.Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 					},
 					RootPasswordSecretKeyRef: corev1.SecretKeySelector{

--- a/controllers/restore_controller_test.go
+++ b/controllers/restore_controller_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Restore controller", func() {
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Image: mariadbv1alpha1.Image{
 							Repository: "mariadb",
-							Tag:        "10.11.3",
+							Tag:        "11.0.2",
 						},
 					},
 					RootPasswordSecretKeyRef: corev1.SecretKeySelector{

--- a/controllers/suite_test_data.go
+++ b/controllers/suite_test_data.go
@@ -84,7 +84,7 @@ func createTestData(ctx context.Context, k8sClient client.Client) {
 			ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 				Image: mariadbv1alpha1.Image{
 					Repository: "mariadb",
-					Tag:        "10.11.3",
+					Tag:        "11.0.2",
 				},
 				SecurityContext: &corev1.SecurityContext{
 					AllowPrivilegeEscalation: func() *bool { b := false; return &b }(),
@@ -95,7 +95,7 @@ func createTestData(ctx context.Context, k8sClient client.Client) {
 							Command: []string{
 								"bash",
 								"-c",
-								"mysql -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SELECT 1;\"",
+								"mariadb -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SELECT 1;\"",
 							},
 						},
 					},
@@ -109,7 +109,7 @@ func createTestData(ctx context.Context, k8sClient client.Client) {
 							Command: []string{
 								"bash",
 								"-c",
-								"mysql -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SELECT 1;\"",
+								"mariadb -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SELECT 1;\"",
 							},
 						},
 					},

--- a/docs/GALERA.md
+++ b/docs/GALERA.md
@@ -153,7 +153,7 @@ kubectl get mariadb mariadb-galera -o jsonpath="{.status.conditions[?(@.type=='G
 
 kubectl get statefulsets -o wide
 NAME             READY   AGE   CONTAINERS      IMAGES
-mariadb-galera   3/3     58m   mariadb,agent   mariadb:10.11.3,ghcr.io/mariadb-operator/agent:v0.0.2
+mariadb-galera   3/3     58m   mariadb,agent   mariadb:11.0.2,ghcr.io/mariadb-operator/agent:v0.0.2
 
 kubectl get pods -o wide
 NAME                                        READY   STATUS    RESTARTS   AGE   IP           NODE          NOMINATED NODE   READINESS GATES

--- a/examples/flux/tenants/photoprism/photoprism-mariadb.yaml
+++ b/examples/flux/tenants/photoprism/photoprism-mariadb.yaml
@@ -21,7 +21,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb.yaml
@@ -15,7 +15,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306
@@ -68,7 +68,7 @@ spec:
       command:
         - bash
         - -c
-        - mysql -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
+        - mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
     initialDelaySeconds: 20
     periodSeconds: 10
     timeoutSeconds: 5
@@ -78,7 +78,7 @@ spec:
       command:
         - bash
         - -c
-        - mysql -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
+        - mariadb -u root -p"${MARIADB_ROOT_PASSWORD}" -e "SELECT 1;"
     initialDelaySeconds: 20
     periodSeconds: 10
     timeoutSeconds: 5

--- a/examples/manifests/mariadb_v1alpha1_mariadb_config.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_config.yaml
@@ -9,7 +9,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_connection.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_connection.yaml
@@ -25,7 +25,7 @@ spec:
       
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_from_backup.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_from_backup.yaml
@@ -15,7 +15,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_from_nfs.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_from_nfs.yaml
@@ -15,7 +15,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_from_pvc.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_from_pvc.yaml
@@ -15,7 +15,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml
@@ -20,7 +20,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_galera_minimal.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_galera_minimal.yaml
@@ -9,7 +9,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_metadata.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_metadata.yaml
@@ -16,7 +16,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_metrics.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_metrics.yaml
@@ -9,7 +9,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_minimal.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_minimal.yaml
@@ -9,7 +9,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/examples/manifests/mariadb_v1alpha1_mariadb_replication.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_replication.yaml
@@ -20,7 +20,7 @@ spec:
 
   image:
     repository: mariadb
-    tag: "10.11.3"
+    tag: "11.0.2"
     pullPolicy: IfNotPresent
 
   port: 3306

--- a/pkg/builder/statefulset_container_builder.go
+++ b/pkg/builder/statefulset_container_builder.go
@@ -312,7 +312,7 @@ var (
 				Command: []string{
 					"bash",
 					"-c",
-					"mysql -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SELECT 1;\"",
+					"mariadb -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SELECT 1;\"",
 				},
 			},
 		},
@@ -326,7 +326,7 @@ var (
 				Command: []string{
 					"bash",
 					"-c",
-					"mysql -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SHOW STATUS LIKE 'wsrep_ready'\" | grep -c ON",
+					"mariadb -u root -p\"${MARIADB_ROOT_PASSWORD}\" -e \"SHOW STATUS LIKE 'wsrep_ready'\" | grep -c ON",
 				},
 			},
 		},

--- a/pkg/command/sql/sql.go
+++ b/pkg/command/sql/sql.go
@@ -22,7 +22,7 @@ func (s *SqlCommand) ExecCommand(mariadb *mariadbv1alpha1.MariaDB) *command.Comm
 		"set -euo pipefail",
 		"echo '⚙️ Executing SQL script'",
 		fmt.Sprintf(
-			"mysql %s  < %s",
+			"mariadb %s < %s",
 			command.ConnectionFlags(&s.SqlOpts.CommandOpts, mariadb),
 			s.SqlFile,
 		),


### PR DESCRIPTION
Avoid relying on `mysql`, as it is no longer present in MariaDB 11. We can deal with the liveness/readiness probes separately in the following PR:
- https://github.com/mariadb-operator/mariadb-operator/pull/163

cc @grooverdan 