### PR TITLE
Error on clashing CRB

### DIFF
--- a/deploy/charts/mariadb-operator/templates/rbac.yaml
+++ b/deploy/charts/mariadb-operator/templates/rbac.yaml
@@ -399,7 +399,7 @@ roleRef:
   name: {{ $fullName }}
 subjects:
 - kind: ServiceAccount
-  name: {{ $fullName }}
+  name: {{ include "mariadb-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -412,7 +412,7 @@ roleRef:
   name: {{ $fullName }}
 subjects:
 - kind: ServiceAccount
-  name: {{ $fullName }}
+  name: {{ include "mariadb-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -425,6 +425,6 @@ roleRef:
   name: system:auth-delegator
 subjects:
 - kind: ServiceAccount
-  name: {{ $fullName }}
+  name: {{ include "mariadb-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy/charts/mariadb-operator/templates/serviceaccount.yaml
+++ b/deploy/charts/mariadb-operator/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "mariadb-operator.fullname" . }}
+  name: {{ include "mariadb-operator.serviceAccountName" . }}
   labels:
     {{- include "mariadb-operator.labels" . | nindent 4 }}
     {{- with .Values.serviceAccount.extraLabels }}

--- a/docs/GALERA.md
+++ b/docs/GALERA.md
@@ -374,7 +374,7 @@ mariadb-operator:auth-delegator                        ClusterRole/system:auth-d
 
 `mariadb-galera:auth-delegator` is the `ClusterRoleBinding` bound to the `mariadb-galera` `ServiceAccount` which is created on the flight by the operator as part of the reconciliation logic. You may check the `mariadb-operator` logs to see if there are any issues reconciling it.
 
-Bear in mind that `ClusterRoleBinding` are cluster-wide resources that are not garbage collected when the `MariaDB` owner object is deleted, which means that creating and deleting `MariaDBs` could leave leftovers in your cluster. These leftovers can lead to RBAC misconfigurations, as the `ClusterRoleBinding` might not be pointing to the right `ServiceAccount`. To overcome this, you can override the `ClusterRoleBinding` name setting the `spec.galera.agent.kubernetesAuth.authDelegatorRoleName` field.
+Bear in mind that `ClusterRoleBindings` are cluster-wide resources that are not garbage collected when the `MariaDB` owner object is deleted, which means that creating and deleting `MariaDBs` could leave leftovers in your cluster. These leftovers can lead to RBAC misconfigurations, as the `ClusterRoleBinding` might not be pointing to the right `ServiceAccount`. To overcome this, you can override the `ClusterRoleBinding` name setting the `spec.galera.agent.kubernetesAuth.authDelegatorRoleName` field.
 
 #### Timeout waiting for Pod to be Synced
 

--- a/docs/GALERA.md
+++ b/docs/GALERA.md
@@ -50,7 +50,6 @@ spec:
       port: 5555
       kubernetesAuth:
         enabled: true
-        authDelegatorRoleName: mariadb-galera-auth
       gracefulShutdownTimeout: 5s
     recovery:
       enabled: true

--- a/docs/GALERA.md
+++ b/docs/GALERA.md
@@ -363,7 +363,7 @@ NAME                    CREATED AT
 system:auth-delegator   2023-08-03T19:12:37Z
 
 kubectl get clusterrolebinding | grep mariadb | grep auth-delegator
-mariadb-galera-auth:auth-delegator                     ClusterRole/system:auth-delegator                                                  108m
+mariadb-galera:auth-delegator                     ClusterRole/system:auth-delegator                                                  108m
 mariadb-operator:auth-delegator                        ClusterRole/system:auth-delegator                                                  112m
 ```
 `mariadb-operator:auth-delegator` is the `ClusterRoleBinding` bound to the `mariadb-operator` `ServiceAccount` which is created by the helm chart, so you can re-install the helm release in order to recreate it:
@@ -372,7 +372,9 @@ mariadb-operator:auth-delegator                        ClusterRole/system:auth-d
  helm upgrade --install mariadb-operator mariadb-operator/mariadb-operator
 ```
 
-`mariadb-galera-auth:auth-delegator` is the `ClusterRoleBinding` bound to the `mariadb-galera` `ServiceAccount` which is created on the flight by the operator as part of the reconciliation logic. You may check the `mariadb-operator` logs to see if there are any issues reconciling it.
+`mariadb-galera:auth-delegator` is the `ClusterRoleBinding` bound to the `mariadb-galera` `ServiceAccount` which is created on the flight by the operator as part of the reconciliation logic. You may check the `mariadb-operator` logs to see if there are any issues reconciling it.
+
+Bear in mind that `ClusterRoleBinding` are cluster-wide resources that are not garbage collected when the `MariaDB` owner object is deleted, which means that creating and deleting `MariaDBs` could leave leftovers in your cluster. These leftovers can lead to RBAC misconfigurations, as the `ClusterRoleBinding` might not be pointing to the right `ServiceAccount`. To overcome this, you can override the `ClusterRoleBinding` name setting the `spec.galera.agent.kubernetesAuth.authDelegatorRoleName` field.
 
 #### Timeout waiting for Pod to be Synced
 

--- a/examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml
@@ -39,7 +39,6 @@ spec:
       port: 5555
       kubernetesAuth:
         enabled: true
-        authDelegatorRoleName: mariadb-galera-auth
       gracefulShutdownTimeout: 5s
     recovery:
       enabled: true


### PR DESCRIPTION
Related to:
- https://github.com/mariadb-operator/mariadb-operator/issues/179

Return an error when a ClusterRoleBinding owned by a different MariaDB already exists