### PR TITLE
feat(ipv6): mariadb bind on all interface (ipv4/ipv6)

### DIFF
--- a/controllers/mariadb_controller_test.go
+++ b/controllers/mariadb_controller_test.go
@@ -413,7 +413,7 @@ var _ = Describe("MariaDB replication", func() {
 					},
 					MyCnf: func() *string {
 						cfg := `[mariadb]
-						bind-address=0.0.0.0
+						bind-address=*
 						default_storage_engine=InnoDB
 						binlog_format=row
 						innodb_autoinc_lock_mode=2
@@ -625,7 +625,7 @@ var _ = Describe("MariaDB Galera", func() {
 					},
 					MyCnf: func() *string {
 						cfg := `[mariadb]
-						bind-address=0.0.0.0
+						bind-address=*
 						default_storage_engine=InnoDB
 						binlog_format=row
 						innodb_autoinc_lock_mode=2

--- a/controllers/suite_test_data.go
+++ b/controllers/suite_test_data.go
@@ -164,7 +164,7 @@ func createTestData(ctx context.Context, k8sClient client.Client) {
 			},
 			MyCnf: func() *string {
 				cfg := `[mariadb]
-				bind-address=0.0.0.0
+				bind-address=*
 				default_storage_engine=InnoDB
 				binlog_format=row
 				innodb_autoinc_lock_mode=2

--- a/examples/manifests/config/mariadb-my-cnf-configmap.yaml
+++ b/examples/manifests/config/mariadb-my-cnf-configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   config: |
     [mariadb]
-    bind-address=0.0.0.0
+    bind-address=*
     default_storage_engine=InnoDB
     binlog_format=row
     innodb_autoinc_lock_mode=2

--- a/examples/manifests/mariadb_v1alpha1_mariadb.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb.yaml
@@ -35,7 +35,7 @@ spec:
 
   myCnf: |
     [mariadb]
-    bind-address=0.0.0.0
+    bind-address=*
     default_storage_engine=InnoDB
     binlog_format=row
     innodb_autoinc_lock_mode=2

--- a/examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_galera.yaml
@@ -76,7 +76,7 @@ spec:
 
   myCnf: |
     [mariadb]
-    bind-address=0.0.0.0
+    bind-address=*
     default_storage_engine=InnoDB
     binlog_format=row
     innodb_autoinc_lock_mode=2

--- a/examples/manifests/mariadb_v1alpha1_mariadb_replication.yaml
+++ b/examples/manifests/mariadb_v1alpha1_mariadb_replication.yaml
@@ -69,7 +69,7 @@ spec:
 
   myCnf: |
     [mariadb]
-    bind-address=0.0.0.0
+    bind-address=*
     default_storage_engine=InnoDB
     binlog_format=row
     innodb_autoinc_lock_mode=2


### PR DESCRIPTION
Hello,

This PR make the MariaDB-Operator IPv6 ready by binding on all interfaces (IPv4/IPv6) 