### PR TITLE
Fix primary defaults

### DIFF
--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -142,8 +142,13 @@ func (s *MariaDBStatus) UpdateCurrentPrimary(mariadb *MariaDB, index int) {
 
 // FillWithDefaults fills the current MariaDBStatus object with defaults.
 func (s *MariaDBStatus) FillWithDefaults(mariadb *MariaDB) {
-	if s.CurrentPrimaryPodIndex == nil && s.CurrentPrimary == nil {
-		s.UpdateCurrentPrimary(mariadb, 0)
+	if s.CurrentPrimaryPodIndex == nil {
+		index := 0
+		s.CurrentPrimaryPodIndex = &index
+	}
+	if s.CurrentPrimary == nil {
+		currentPrimary := statefulset.PodName(mariadb.ObjectMeta, *s.CurrentPrimaryPodIndex)
+		s.CurrentPrimary = &currentPrimary
 	}
 }
 


### PR DESCRIPTION
Upgrading the operator from `v0.0.19` to `v0.0.20` results in the following error when reconciling a `MariaDB` with Galera enabled:
```bash
'Error reconciling Service: ''status.currentPrimaryPodIndex'' must be set'
```
`MariaDB` status:
```yaml
status:
  conditions:
  - lastTransitionTime: "2023-08-31T17:56:27Z"
    message: 'Error reconciling Service: ''status.currentPrimaryPodIndex'' must be
      set'
    reason: Failed
    status: "False"
    type: Ready
  - lastTransitionTime: "2023-08-31T17:30:03Z"
    message: Galera ready
    reason: GaleraReady
    status: "True"
    type: GaleraReady
  - lastTransitionTime: "2023-08-31T17:30:03Z"
    message: Galera configured
    reason: GaleraConfigured
    status: "True"
    type: GaleraConfigured
  currentPrimary: All
``` 