### PR TITLE
Add externaltrafficpolicy service compatibility

### DIFF
--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -72,7 +72,6 @@ type ServiceTemplate struct {
 	Annotations map[string]string  `json:"annotations,omitempty"`
 	ExternalTrafficPolicy *string `json:"externalTrafficPolicy,omitempty"`
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
-	LoadBalancerIp *string `json:"loadBalancerIp,omitempty"`
 }
 
 // MariaDBSpec defines the desired state of MariaDB

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -70,7 +70,9 @@ func (p *PodDisruptionBudget) Validate() error {
 type ServiceTemplate struct {
 	Type        corev1.ServiceType `json:"type,omitempty"`
 	Annotations map[string]string  `json:"annotations,omitempty"`
-	ExternalTrafficPolicy [string]string `json:"externaltrafficpolicy,omitempty"`
+	externalTrafficPolicy string `json:"externalTrafficPolicy,omitempty"`
+	loadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
+	loadBalancerIp string `json:"loadBalancerIp,omitempty"`
 }
 
 // MariaDBSpec defines the desired state of MariaDB

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -70,9 +70,9 @@ func (p *PodDisruptionBudget) Validate() error {
 type ServiceTemplate struct {
 	Type        corev1.ServiceType `json:"type,omitempty"`
 	Annotations map[string]string  `json:"annotations,omitempty"`
-	ExternalTrafficPolicy string `json:"externalTrafficPolicy,omitempty"`
+	ExternalTrafficPolicy *string `json:"externalTrafficPolicy,omitempty"`
 	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
-	LoadBalancerIp string `json:"loadBalancerIp,omitempty"`
+	LoadBalancerIp *string `json:"loadBalancerIp,omitempty"`
 }
 
 // MariaDBSpec defines the desired state of MariaDB

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -68,10 +68,10 @@ func (p *PodDisruptionBudget) Validate() error {
 }
 
 type ServiceTemplate struct {
-	Type        corev1.ServiceType `json:"type,omitempty"`
-	Annotations map[string]string  `json:"annotations,omitempty"`
-	ExternalTrafficPolicy *string `json:"externalTrafficPolicy,omitempty"`
-	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
+	Type        corev1.ServiceType                            `json:"type,omitempty"`
+	Annotations map[string]string                             `json:"annotations,omitempty"`
+	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicy `json:"externalTrafficPolicy,omitempty"`
+	LoadBalancerSourceRanges []string                         `json:"loadBalancerSourceRanges,omitempty"`
 }
 
 // MariaDBSpec defines the desired state of MariaDB

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -70,9 +70,9 @@ func (p *PodDisruptionBudget) Validate() error {
 type ServiceTemplate struct {
 	Type        corev1.ServiceType `json:"type,omitempty"`
 	Annotations map[string]string  `json:"annotations,omitempty"`
-	externalTrafficPolicy string `json:"externalTrafficPolicy,omitempty"`
-	loadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
-	loadBalancerIp string `json:"loadBalancerIp,omitempty"`
+	ExternalTrafficPolicy string `json:"externalTrafficPolicy,omitempty"`
+	LoadBalancerSourceRanges []string `json:"loadBalancerSourceRanges,omitempty"`
+	LoadBalancerIp string `json:"loadBalancerIp,omitempty"`
 }
 
 // MariaDBSpec defines the desired state of MariaDB

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -70,6 +70,7 @@ func (p *PodDisruptionBudget) Validate() error {
 type ServiceTemplate struct {
 	Type        corev1.ServiceType `json:"type,omitempty"`
 	Annotations map[string]string  `json:"annotations,omitempty"`
+	ExternalTrafficPolicy [string]string `json:"externaltrafficpolicy,omitempty"`
 }
 
 // MariaDBSpec defines the desired state of MariaDB

--- a/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
+++ b/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
@@ -6310,9 +6310,6 @@ spec:
                   loadbalancersourceranges:
                     description: restricts traffic through the load balancer to the IPs specified in this field. 
                     type: array
-                  loadbalancerip:
-                    description: enables you to choose a specific IP address for the load balancer. 
-                    type: string
                 type: object
               readinessProbe:
                 description: Probe describes a health check to be performed against
@@ -6645,9 +6642,6 @@ spec:
                   loadbalancersourceranges:
                     description: restricts traffic through the load balancer to the IPs specified in this field. 
                     type: array
-                  loadbalancerip:
-                    description: enables you to choose a specific IP address for the load balancer. 
-                    type: string
                 type: object
               securityContext:
                 description: SecurityContext holds security configuration that will
@@ -6831,9 +6825,6 @@ spec:
                   loadbalancersourceranges:
                     description: restricts traffic through the load balancer to the IPs specified in this field. 
                     type: array
-                  loadbalancerip:
-                    description: enables you to choose a specific IP address for the load balancer. 
-                    type: string
                 type: object
               tolerations:
                 items:

--- a/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
+++ b/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
@@ -6300,6 +6300,19 @@ spec:
                     description: Service Type string describes ingress methods for
                       a service
                     type: string
+                  externaltrafficpolicy:
+                    description: denotes if this Service desires to route external traffic to node-local 
+                      or cluster-wide endpoints. There are two available options. Cluster (default) and Local. 
+                      Cluster obscures the client source IP and may cause a second hop to another node, 
+                      but should have good overall load-spreading. Local preserves the client source IP 
+                      and avoids a second hop for LoadBalancer and NodePort type Services, but risks potentially imbalanced traffic spreading.
+                    type: string
+                  loadbalancersourceranges:
+                    description: restricts traffic through the load balancer to the IPs specified in this field. 
+                    type: array
+                  loadbalancerip:
+                    description: enables you to choose a specific IP address for the load balancer. 
+                    type: string
                 type: object
               readinessProbe:
                 description: Probe describes a health check to be performed against
@@ -6622,6 +6635,19 @@ spec:
                     description: Service Type string describes ingress methods for
                       a service
                     type: string
+                  externaltrafficpolicy:
+                    description: denotes if this Service desires to route external traffic to node-local 
+                      or cluster-wide endpoints. There are two available options. Cluster (default) and Local. 
+                      Cluster obscures the client source IP and may cause a second hop to another node, 
+                      but should have good overall load-spreading. Local preserves the client source IP 
+                      and avoids a second hop for LoadBalancer and NodePort type Services, but risks potentially imbalanced traffic spreading.
+                    type: string
+                  loadbalancersourceranges:
+                    description: restricts traffic through the load balancer to the IPs specified in this field. 
+                    type: array
+                  loadbalancerip:
+                    description: enables you to choose a specific IP address for the load balancer. 
+                    type: string
                 type: object
               securityContext:
                 description: SecurityContext holds security configuration that will
@@ -6794,6 +6820,19 @@ spec:
                   type:
                     description: Service Type string describes ingress methods for
                       a service
+                    type: string
+                  externaltrafficpolicy:
+                    description: denotes if this Service desires to route external traffic to node-local 
+                      or cluster-wide endpoints. There are two available options. Cluster (default) and Local. 
+                      Cluster obscures the client source IP and may cause a second hop to another node, 
+                      but should have good overall load-spreading. Local preserves the client source IP 
+                      and avoids a second hop for LoadBalancer and NodePort type Services, but risks potentially imbalanced traffic spreading.
+                    type: string
+                  loadbalancersourceranges:
+                    description: restricts traffic through the load balancer to the IPs specified in this field. 
+                    type: array
+                  loadbalancerip:
+                    description: enables you to choose a specific IP address for the load balancer. 
                     type: string
                 type: object
               tolerations:

--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -450,7 +450,6 @@ func (r *MariaDBReconciler) reconcileDefaultService(ctx context.Context, mariadb
 		opts.Annotations = mariadb.Spec.Service.Annotations
 		opts.ExternalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
 		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
-		opts.LoadBalancerIp = mariadb.Spec.Service.loadBalancerIp	
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {
@@ -530,7 +529,6 @@ func (r *MariaDBReconciler) reconcilePrimaryService(ctx context.Context, mariadb
 		opts.Annotations = mariadb.Spec.PrimaryService.Annotations
 		opts.ExternalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
 		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
-		opts.LoadBalancerIp = mariadb.Spec.Service.loadBalancerIp
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {
@@ -555,7 +553,6 @@ func (r *MariaDBReconciler) reconcileSecondaryService(ctx context.Context, maria
 		opts.Annotations = mariadb.Spec.SecondaryService.Annotations
 		opts.ExternalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
 		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
-		opts.LoadBalancerIp = mariadb.Spec.Service.loadBalancerIp
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {

--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -448,6 +448,9 @@ func (r *MariaDBReconciler) reconcileDefaultService(ctx context.Context, mariadb
 	if mariadb.Spec.Service != nil {
 		opts.Type = mariadb.Spec.Service.Type
 		opts.Annotations = mariadb.Spec.Service.Annotations
+		opts.externalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
+		opts.loadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
+		opts.loadBalancerIp = mariadb.Spec.Service.loadBalancerIp	
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {
@@ -525,6 +528,9 @@ func (r *MariaDBReconciler) reconcilePrimaryService(ctx context.Context, mariadb
 	if mariadb.Spec.PrimaryService != nil {
 		opts.Type = mariadb.Spec.PrimaryService.Type
 		opts.Annotations = mariadb.Spec.PrimaryService.Annotations
+		opts.externalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
+		opts.loadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
+		opts.loadBalancerIp = mariadb.Spec.Service.loadBalancerIp
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {
@@ -547,6 +553,9 @@ func (r *MariaDBReconciler) reconcileSecondaryService(ctx context.Context, maria
 	if mariadb.Spec.SecondaryService != nil {
 		opts.Type = mariadb.Spec.SecondaryService.Type
 		opts.Annotations = mariadb.Spec.SecondaryService.Annotations
+		opts.externalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
+		opts.loadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
+		opts.loadBalancerIp = mariadb.Spec.Service.loadBalancerIp
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {

--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -448,8 +448,8 @@ func (r *MariaDBReconciler) reconcileDefaultService(ctx context.Context, mariadb
 	if mariadb.Spec.Service != nil {
 		opts.Type = mariadb.Spec.Service.Type
 		opts.Annotations = mariadb.Spec.Service.Annotations
-		opts.ExternalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
-		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
+		opts.ExternalTrafficPolicy = mariadb.Spec.Service.ExternalTrafficPolicy
+		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.LoadBalancerSourceRanges
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {
@@ -527,8 +527,8 @@ func (r *MariaDBReconciler) reconcilePrimaryService(ctx context.Context, mariadb
 	if mariadb.Spec.PrimaryService != nil {
 		opts.Type = mariadb.Spec.PrimaryService.Type
 		opts.Annotations = mariadb.Spec.PrimaryService.Annotations
-		opts.ExternalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
-		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
+		opts.ExternalTrafficPolicy = mariadb.Spec.Service.ExternalTrafficPolicy
+		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.LoadBalancerSourceRanges
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {
@@ -551,8 +551,8 @@ func (r *MariaDBReconciler) reconcileSecondaryService(ctx context.Context, maria
 	if mariadb.Spec.SecondaryService != nil {
 		opts.Type = mariadb.Spec.SecondaryService.Type
 		opts.Annotations = mariadb.Spec.SecondaryService.Annotations
-		opts.ExternalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
-		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
+		opts.ExternalTrafficPolicy = mariadb.Spec.Service.ExternalTrafficPolicy
+		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.LoadBalancerSourceRanges
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {

--- a/controllers/mariadb_controller.go
+++ b/controllers/mariadb_controller.go
@@ -448,9 +448,9 @@ func (r *MariaDBReconciler) reconcileDefaultService(ctx context.Context, mariadb
 	if mariadb.Spec.Service != nil {
 		opts.Type = mariadb.Spec.Service.Type
 		opts.Annotations = mariadb.Spec.Service.Annotations
-		opts.externalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
-		opts.loadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
-		opts.loadBalancerIp = mariadb.Spec.Service.loadBalancerIp	
+		opts.ExternalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
+		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
+		opts.LoadBalancerIp = mariadb.Spec.Service.loadBalancerIp	
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {
@@ -528,9 +528,9 @@ func (r *MariaDBReconciler) reconcilePrimaryService(ctx context.Context, mariadb
 	if mariadb.Spec.PrimaryService != nil {
 		opts.Type = mariadb.Spec.PrimaryService.Type
 		opts.Annotations = mariadb.Spec.PrimaryService.Annotations
-		opts.externalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
-		opts.loadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
-		opts.loadBalancerIp = mariadb.Spec.Service.loadBalancerIp
+		opts.ExternalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
+		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
+		opts.LoadBalancerIp = mariadb.Spec.Service.loadBalancerIp
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {
@@ -553,9 +553,9 @@ func (r *MariaDBReconciler) reconcileSecondaryService(ctx context.Context, maria
 	if mariadb.Spec.SecondaryService != nil {
 		opts.Type = mariadb.Spec.SecondaryService.Type
 		opts.Annotations = mariadb.Spec.SecondaryService.Annotations
-		opts.externalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
-		opts.loadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
-		opts.loadBalancerIp = mariadb.Spec.Service.loadBalancerIp
+		opts.ExternalTrafficPolicy = mariadb.Spec.Service.externalTrafficPolicy
+		opts.LoadBalancerSourceRanges = mariadb.Spec.Service.loadBalancerSourceRanges
+		opts.LoadBalancerIp = mariadb.Spec.Service.loadBalancerIp
 	}
 	desiredSvc, err := r.Builder.BuildService(mariadb, key, opts)
 	if err != nil {

--- a/pkg/builder/service_builder.go
+++ b/pkg/builder/service_builder.go
@@ -57,9 +57,12 @@ func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.Names
 	if opts.PublishNotReadyAddresses != nil {
 		svc.Spec.PublishNotReadyAddresses = *opts.PublishNotReadyAddresses
 	}
+	if opts.ExternalTrafficPolicy != nil {
+		svc.Spec.PublishNotReadyAddresses = *opts.ExternalTrafficPolicy
+	}
 	if !opts.ExcludeSelectorLabels {
 		svc.Spec.Selector = selectorLabels
-	}
+	} 
 	if err := controllerutil.SetControllerReference(mariadb, svc, b.scheme); err != nil {
 		return nil, fmt.Errorf("error setting controller reference to Service: %v", err)
 	}

--- a/pkg/builder/service_builder.go
+++ b/pkg/builder/service_builder.go
@@ -29,9 +29,9 @@ type ServiceOpts struct {
 	Ports                    []corev1.ServicePort
 	ClusterIP                *string
 	PublishNotReadyAddresses *bool
-	externalTrafficPolicy    string
-	loadBalancerSourceRanges []string
-	loadBalancerIp           string
+	ExternalTrafficPolicy    string
+	LoadBalancerSourceRanges []string
+	LoadBalancerIp           string
 }
 
 func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.NamespacedName,
@@ -60,14 +60,14 @@ func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.Names
 	if opts.PublishNotReadyAddresses != nil {
 		svc.Spec.PublishNotReadyAddresses = *opts.PublishNotReadyAddresses
 	}
-	if opts.externalTrafficPolicy != nil {
-		svc.Spec.externalTrafficPolicy = *opts.externalTrafficPolicy
+	if opts.ExternalTrafficPolicy != nil {
+		svc.Spec.ExternalTrafficPolicy = *opts.ExternalTrafficPolicy
 	}
-	if opts.loadBalancerIp != nil {
-		svc.Spec.loadBalancerIp = *opts.loadBalancerIp
+	if opts.LoadBalancerIp != nil {
+		svc.Spec.LoadBalancerIp = *opts.LoadBalancerIp
 	}
-	if opts.loadBalancerSourceRanges != nil {
-		svc.Spec.loadBalancerSourceRanges = *opts.loadBalancerSourceRanges
+	if opts.LoadBalancerSourceRanges != nil {
+		svc.Spec.LoadBalancerSourceRanges = *opts.LoadBalancerSourceRanges
 	}
 	if !opts.ExcludeSelectorLabels {
 		svc.Spec.Selector = selectorLabels

--- a/pkg/builder/service_builder.go
+++ b/pkg/builder/service_builder.go
@@ -29,6 +29,9 @@ type ServiceOpts struct {
 	Ports                    []corev1.ServicePort
 	ClusterIP                *string
 	PublishNotReadyAddresses *bool
+	externalTrafficPolicy    string
+	loadBalancerSourceRanges []string
+	loadBalancerIp           string
 }
 
 func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.NamespacedName,
@@ -57,8 +60,14 @@ func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.Names
 	if opts.PublishNotReadyAddresses != nil {
 		svc.Spec.PublishNotReadyAddresses = *opts.PublishNotReadyAddresses
 	}
-	if opts.ExternalTrafficPolicy != nil {
-		svc.Spec.PublishNotReadyAddresses = *opts.ExternalTrafficPolicy
+	if opts.externalTrafficPolicy != nil {
+		svc.Spec.externalTrafficPolicy = *opts.externalTrafficPolicy
+	}
+	if opts.loadBalancerIp != nil {
+		svc.Spec.loadBalancerIp = *opts.loadBalancerIp
+	}
+	if opts.loadBalancerSourceRanges != nil {
+		svc.Spec.loadBalancerSourceRanges = *opts.loadBalancerSourceRanges
 	}
 	if !opts.ExcludeSelectorLabels {
 		svc.Spec.Selector = selectorLabels

--- a/pkg/builder/service_builder.go
+++ b/pkg/builder/service_builder.go
@@ -29,9 +29,9 @@ type ServiceOpts struct {
 	Ports                    []corev1.ServicePort
 	ClusterIP                *string
 	PublishNotReadyAddresses *bool
-	ExternalTrafficPolicy    string
+	ExternalTrafficPolicy    *string
 	LoadBalancerSourceRanges []string
-	LoadBalancerIp           string
+	LoadBalancerIp           *string
 }
 
 func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.NamespacedName,

--- a/pkg/builder/service_builder.go
+++ b/pkg/builder/service_builder.go
@@ -31,7 +31,6 @@ type ServiceOpts struct {
 	PublishNotReadyAddresses *bool
 	ExternalTrafficPolicy    *string
 	LoadBalancerSourceRanges []string
-	LoadBalancerIp           *string
 }
 
 func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.NamespacedName,
@@ -62,9 +61,6 @@ func (b *Builder) BuildService(mariadb *mariadbv1alpha1.MariaDB, key types.Names
 	}
 	if opts.ExternalTrafficPolicy != nil {
 		svc.Spec.ExternalTrafficPolicy = *opts.ExternalTrafficPolicy
-	}
-	if opts.LoadBalancerIp != nil {
-		svc.Spec.LoadBalancerIp = *opts.LoadBalancerIp
 	}
 	if opts.LoadBalancerSourceRanges != nil {
 		svc.Spec.LoadBalancerSourceRanges = *opts.LoadBalancerSourceRanges

--- a/pkg/builder/service_builder.go
+++ b/pkg/builder/service_builder.go
@@ -29,7 +29,7 @@ type ServiceOpts struct {
 	Ports                    []corev1.ServicePort
 	ClusterIP                *string
 	PublishNotReadyAddresses *bool
-	ExternalTrafficPolicy    *string
+	ExternalTrafficPolicy    corev1.ServiceExternalTrafficPolicy
 	LoadBalancerSourceRanges []string
 }
 


### PR DESCRIPTION
Fixes https://github.com/mariadb-operator/mariadb-operator/issues/210

Add service External_Traffic_Policy allows source ip preservation when service type = loadbalancer