### PR TITLE
231: Fix broken replication issue

### DIFF
--- a/controllers/pod_replication_controller.go
+++ b/controllers/pod_replication_controller.go
@@ -82,7 +82,7 @@ func (r *PodReplicationController) ReconcilePodReady(ctx context.Context, pod co
 		}
 		return nil
 	}
-	if err := r.replConfig.ConfigureReplica(ctx, mariadb, client, *index, *mariadb.Status.CurrentPrimaryPodIndex); err != nil {
+	if err := r.replConfig.ConfigureReplica(ctx, mariadb, client, *index, *mariadb.Status.CurrentPrimaryPodIndex, false); err != nil {
 		return fmt.Errorf("error configuring replication in replica '%d': %v", *index, err)
 	}
 	return nil

--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -61,15 +61,17 @@ func (r *ReplicationConfig) ConfigurePrimary(ctx context.Context, mariadb *maria
 }
 
 func (r *ReplicationConfig) ConfigureReplica(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB, client *mariadbclient.Client,
-	replicaPodIndex, primaryPodIndex int) error {
+	replicaPodIndex, primaryPodIndex int, resetSlavePos bool) error {
 	if err := client.ResetMaster(ctx); err != nil {
 		return fmt.Errorf("error resetting master: %v", err)
 	}
 	if err := client.StopAllSlaves(ctx); err != nil {
 		return fmt.Errorf("error stopping slaves: %v", err)
 	}
-	if err := client.ResetSlavePos(ctx); err != nil {
-		return fmt.Errorf("error resetting slave position: %v", err)
+	if resetSlavePos {
+		if err := client.ResetSlavePos(ctx); err != nil {
+			return fmt.Errorf("error resetting slave position: %v", err)
+		}
 	}
 	if err := client.EnableReadOnly(ctx); err != nil {
 		return fmt.Errorf("error enabling read_only: %v", err)

--- a/pkg/controller/replication/controller.go
+++ b/pkg/controller/replication/controller.go
@@ -208,7 +208,7 @@ func (r *ReplicationReconciler) reconcileReplicas(ctx context.Context, req *reco
 		}
 
 		logger.V(1).Info("Configuring replica", "pod-index", i)
-		if err := r.replConfig.ConfigureReplica(ctx, req.mariadb, client, i, *req.mariadb.Replication().Primary.PodIndex); err != nil {
+		if err := r.replConfig.ConfigureReplica(ctx, req.mariadb, client, i, *req.mariadb.Replication().Primary.PodIndex, false); err != nil {
 			return fmt.Errorf("error configuring replica '%d': %v", i, err)
 		}
 	}

--- a/pkg/controller/replication/switchover.go
+++ b/pkg/controller/replication/switchover.go
@@ -260,7 +260,7 @@ func (r *ReplicationReconciler) connectReplicasToNewPrimary(ctx context.Context,
 			}
 
 			logger.V(1).Info("Connecting replica to new primary", "replica", i)
-			if err := r.replConfig.ConfigureReplica(ctx, mariadb, replClient, i, *mariadb.Replication().Primary.PodIndex); err != nil {
+			if err := r.replConfig.ConfigureReplica(ctx, mariadb, replClient, i, *mariadb.Replication().Primary.PodIndex, true); err != nil {
 				errChan <- fmt.Errorf("error configuring replica vars in replica '%d': %v", i, err)
 				return
 			}
@@ -310,6 +310,7 @@ func (r *ReplicationReconciler) changeCurrentPrimaryToReplica(ctx context.Contex
 		currentPrimaryClient,
 		currentPrimary,
 		newPrimary,
+		true,
 	)
 }
 


### PR DESCRIPTION
This PR fixes issue [231](https://github.com/mariadb-operator/mariadb-operator/issues/231) by not resetting `gtid_slave_pos` in `reconcilePodReady ` and `reconcileReplicas` methods 

Closes https://github.com/mariadb-operator/mariadb-operator/issues/231