### PR TITLE
feat(chart): liveness, readiness & startupProbes for webhook & operator

### DIFF
--- a/deploy/charts/mariadb-operator/templates/deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/deployment.yaml
@@ -88,6 +88,21 @@ spec:
           securityContext:
             {{ toYaml . | nindent 12 }}
           {{ end }}
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          startupProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 10
       {{- if .Values.extraVolumes }}
       volumes:
       {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/deploy/charts/mariadb-operator/templates/webhook-deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-deployment.yaml
@@ -77,6 +77,18 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
           {{ with .Values.webhook.resources }}
           resources:
             {{ toYaml . | nindent 12 }}


### PR DESCRIPTION
This feature adds probes to all pods.

currently hardcoded, do you which me to make them configureable? I didn't want to add them to the values file.