### PR TITLE
Fix annotations and labels reconciliation for services

### DIFF
--- a/pkg/controller/service/controller.go
+++ b/pkg/controller/service/controller.go
@@ -36,7 +36,12 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, desiredSvc *corev1.Se
 	existingSvc.Spec.Ports = desiredSvc.Spec.Ports
 	existingSvc.Spec.Selector = desiredSvc.Spec.Selector
 	existingSvc.Spec.Type = desiredSvc.Spec.Type
-	existingSvc.Annotations = desiredSvc.Annotations
-	existingSvc.Labels = desiredSvc.Labels
+	for k, v := range desiredSvc.Annotations {
+		existingSvc.Annotations[k] = v
+	}
+	for k, v := range desiredSvc.Labels {
+		existingSvc.Labels[k] = v
+	}
+
 	return r.Patch(ctx, &existingSvc, patch)
 }


### PR DESCRIPTION
Now specified labels and annotations will be merged with the service, but not replaced.

This is possible fix for https://github.com/mariadb-operator/mariadb-operator/issues/256

Alternatively it might be better to use three-way-merge technics to determine managed and non-managed fields by mariadb-operator.