### PR TITLE
Support for scale subresource

### DIFF
--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -213,7 +213,7 @@ type MariaDBSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Galera *Galera `json:"galera,omitempty"`
-	// Replicas indicates the number of instances.
+	// Replicas indicates the number of desired instances.
 	// +kubebuilder:default=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
 	Replicas int32 `json:"replicas,omitempty"`
@@ -266,6 +266,9 @@ type MariaDBStatus struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors={"urn:alm:descriptor:io.kubernetes.conditions"}
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	// Replicas indicates the number of current instances.
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
+	Replicas int32 `json:"replicas,omitempty"`
 	// CurrentPrimaryPodIndex is the primary Pod index.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status
@@ -310,6 +313,7 @@ func (s *MariaDBStatus) FillWithDefaults(mariadb *MariaDB) {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=mdb
 // +kubebuilder:subresource:status
+// +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status"
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message"
 // +kubebuilder:printcolumn:name="Primary Pod",type="string",JSONPath=".status.currentPrimary"

--- a/bundle/manifests/mariadb-operator-enterprise.clusterserviceversion.yaml
+++ b/bundle/manifests/mariadb-operator-enterprise.clusterserviceversion.yaml
@@ -280,7 +280,7 @@ metadata:
     categories: Database
     certified: "true"
     containerImage: mariadb/mariadb-operator-enterprise:v0.0.23
-    createdAt: "2023-12-17T11:15:16Z"
+    createdAt: "2023-12-17T12:06:51Z"
     operators.openshift.io/valid-subscription: '["MariaDB Enterprise Server License"]'
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -1123,7 +1123,7 @@ spec:
       - description: ReadinessProbe to be used in the Container.
         displayName: Readiness Probe
         path: readinessProbe
-      - description: Replicas indicates the number of instances.
+      - description: Replicas indicates the number of desired instances.
         displayName: Replicas
         path: replicas
         x-descriptors:

--- a/bundle/manifests/mariadb.mmontes.io_mariadbs.yaml
+++ b/bundle/manifests/mariadb.mmontes.io_mariadbs.yaml
@@ -6718,7 +6718,7 @@ spec:
                 type: object
               replicas:
                 default: 1
-                description: Replicas indicates the number of instances.
+                description: Replicas indicates the number of desired instances.
                 format: int32
                 type: integer
               replication:
@@ -9941,6 +9941,10 @@ spec:
                       file (grastate.dat).
                     type: object
                 type: object
+              replicas:
+                description: Replicas indicates the number of current instances.
+                format: int32
+                type: integer
             type: object
         required:
         - spec
@@ -9948,6 +9952,9 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}
 status:
   acceptedNames:

--- a/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
+++ b/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
@@ -6719,7 +6719,7 @@ spec:
                 type: object
               replicas:
                 default: 1
-                description: Replicas indicates the number of instances.
+                description: Replicas indicates the number of desired instances.
                 format: int32
                 type: integer
               replication:
@@ -9942,6 +9942,10 @@ spec:
                       file (grastate.dat).
                     type: object
                 type: object
+              replicas:
+                description: Replicas indicates the number of current instances.
+                format: int32
+                type: integer
             type: object
         required:
         - spec
@@ -9949,4 +9953,7 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}

--- a/config/manifests/bases/mariadb-operator-enterprise.clusterserviceversion.yaml
+++ b/config/manifests/bases/mariadb-operator-enterprise.clusterserviceversion.yaml
@@ -1080,7 +1080,7 @@ spec:
       - description: ReadinessProbe to be used in the Container.
         displayName: Readiness Probe
         path: readinessProbe
-      - description: Replicas indicates the number of instances.
+      - description: Replicas indicates the number of desired instances.
         displayName: Replicas
         path: replicas
         x-descriptors:

--- a/deploy/charts/mariadb-operator/crds/crds.yaml
+++ b/deploy/charts/mariadb-operator/crds/crds.yaml
@@ -10328,7 +10328,7 @@ spec:
                 type: object
               replicas:
                 default: 1
-                description: Replicas indicates the number of instances.
+                description: Replicas indicates the number of desired instances.
                 format: int32
                 type: integer
               replication:
@@ -13551,6 +13551,10 @@ spec:
                       file (grastate.dat).
                     type: object
                 type: object
+              replicas:
+                description: Replicas indicates the number of current instances.
+                format: int32
+                type: integer
             type: object
         required:
         - spec
@@ -13558,6 +13562,9 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/deploy/crds/crds.yaml
+++ b/deploy/crds/crds.yaml
@@ -10328,7 +10328,7 @@ spec:
                 type: object
               replicas:
                 default: 1
-                description: Replicas indicates the number of instances.
+                description: Replicas indicates the number of desired instances.
                 format: int32
                 type: integer
               replication:
@@ -13551,6 +13551,10 @@ spec:
                       file (grastate.dat).
                     type: object
                 type: object
+              replicas:
+                description: Replicas indicates the number of current instances.
+                format: int32
+                type: integer
             type: object
         required:
         - spec
@@ -13558,6 +13562,9 @@ spec:
     served: true
     storage: true
     subresources:
+      scale:
+        specReplicasPath: .spec.replicas
+        statusReplicasPath: .status.replicas
       status: {}
 ---
 apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
Add support for the [scale subresource](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource).

This enables autoscaling via resources like `HorizontalPodAutoscaler` and allows to scale manually via `kubectl autoscale`:
```bash
kubectl scale mdb mariadb-repl --replicas=3
```