### PR TITLE
Add a webhook validation for root password

### DIFF
--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -431,6 +431,11 @@ func (m *MariaDB) IsRootPasswordEmpty() bool {
 	return m.Spec.RootEmptyPassword != nil && *m.Spec.RootEmptyPassword
 }
 
+// IsRootPasswordDefined indicates whether the MariaDB instance has a root password defined
+func (m *MariaDB) IsRootPasswordDefined() bool {
+	return m.Spec.RootPasswordSecretKeyRef != (corev1.SecretKeySelector{})
+}
+
 // IsEphemeralStorageEnabled indicates whether the MariaDB instance has ephemeral storage enabled
 func (m *MariaDB) IsEphemeralStorageEnabled() bool {
 	return m.Spec.EphemeralStorage != nil && *m.Spec.EphemeralStorage

--- a/api/v1alpha1/mariadb_webhook.go
+++ b/api/v1alpha1/mariadb_webhook.go
@@ -75,6 +75,7 @@ func (r *MariaDB) validate() error {
 		r.validateBootstrapFrom,
 		r.validatePodDisruptionBudget,
 		r.validateStorage,
+		r.validateRootPassword,
 	}
 	for _, fn := range validateFns {
 		if err := fn(); err != nil {
@@ -221,5 +222,16 @@ func (r *MariaDB) validateStorage() error {
 		)
 	}
 
+	return nil
+}
+
+func (r *MariaDB) validateRootPassword() error {
+	if r.IsRootPasswordEmpty() && r.IsRootPasswordDefined() {
+		return field.Invalid(
+			field.NewPath("spec").Child("rootEmptyPassword"),
+			r.Spec.RootEmptyPassword,
+			"'spec.rootEmptyPassword' must be disabled when 'spec.rootPasswordSecretKeyRef' is specified",
+		)
+	}
 	return nil
 }

--- a/api/v1alpha1/mariadb_webhook_test.go
+++ b/api/v1alpha1/mariadb_webhook_test.go
@@ -376,6 +376,52 @@ var _ = Describe("MariaDB webhook", func() {
 				},
 				false,
 			),
+			Entry(
+				"Invalid rootPasswordSecretKeyRef and rootEmptyPassword",
+				&MariaDB{
+					ObjectMeta: meta,
+					Spec: MariaDBSpec{
+						EphemeralStorage: ptr.To(true),
+						RootPasswordSecretKeyRef: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "secret",
+							},
+							Key: "root-password",
+						},
+						RootEmptyPassword: ptr.To(true),
+					},
+				},
+				true,
+			),
+			Entry(
+				"Valid rootPasswordSecretKeyRef",
+				&MariaDB{
+					ObjectMeta: meta,
+					Spec: MariaDBSpec{
+						EphemeralStorage: ptr.To(true),
+						RootPasswordSecretKeyRef: corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "secret",
+							},
+							Key: "root-password",
+						},
+						RootEmptyPassword: ptr.To(false),
+					},
+				},
+				false,
+			),
+			Entry(
+				"Valid rootEmptyPassword",
+				&MariaDB{
+					ObjectMeta: meta,
+					Spec: MariaDBSpec{
+						EphemeralStorage:         ptr.To(true),
+						RootPasswordSecretKeyRef: corev1.SecretKeySelector{},
+						RootEmptyPassword:        ptr.To(true),
+					},
+				},
+				false,
+			),
 		)
 
 		It("Should default replication", func() {


### PR DESCRIPTION
When rootEmptyPassword=true and rootPasswordSecretKeyRef are both defined, the secret will be ignored. This can be confusing for the user. Therefore, it is proposed to make both parameters mutually exclusive.

Webhook rejecting a manifest with rootEmptyPassword and rootPasswordSecretKeyRef both set:
`Error from server (Forbidden): error when creating "examples/manifests/mariadb_v1alpha1_mariadb_minimal.yaml": admission webhook "vmariadb.kb.io" denied the request: spec.rootEmptyPassword: Invalid value: true: 'spec.rootEmptyPassword' must be disabled when 'spec.rootPasswordSecretKeyRef' is specified`

When neither is defined, a root password will be randomly generated, eliminating the need for a validation webhook.