### PR TITLE
In local development, report when local CIDR for KIND cannot be found

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -19,7 +19,7 @@ Run the operator locally in your machine using `go run`. It requires the followi
 - [go](https://go.dev/doc/install)
 - [docker](https://www.docker.com/)
 
-This flavour uses [KIND](https://kind.sigs.k8s.io/) and [Metallb](https://metallb.universe.tf/) under the hood to provision Kubernetes clusters and assign local IPs to `LoadBalancer` `Services`. It has some [limitations](https://kind.sigs.k8s.io/docs/user/loadbalancer/) in Mac and Windows which will make the operator unable to connect to MariaDB via the `LoadBalancer` `Service`, leading to errors when reconciling SQL-related resources. Alternatively, use the [devcontainer](#devcontainer) flavour.
+This flavour uses [KIND](https://kind.sigs.k8s.io/) and [MetalLB](https://metallb.universe.tf/) under the hood to provision Kubernetes clusters and assign local IPs to `LoadBalancer` `Services`. It has some [limitations](https://kind.sigs.k8s.io/docs/user/loadbalancer/) in Mac and Windows which will make the operator unable to connect to MariaDB via the `LoadBalancer` `Service`, leading to errors when reconciling SQL-related resources. Alternatively, use the [devcontainer](#devcontainer) flavour.
 
 ## Getting started
 
@@ -62,7 +62,7 @@ To start with, you will need a Kubernetes cluster for developing locally. You ca
 ```bash
 make cluster
 ```
-To decomission the cluster:
+To decommission the cluster:
 ```bash
 make cluster-delete
 ```
@@ -84,7 +84,7 @@ You can configure the network connectivity so the operator is able to resolve DN
 make net
 ```
 
-This connectivity leverages [Metallb](https://metallb.universe.tf/) to assign local IPs to the `LoadBalancer` `Services` for the operator to connect to MariaDB. For this to happen, these local IPs need to be within the docker CIDR, which can be queried using:
+This connectivity leverages [MetalLB](https://metallb.universe.tf/) to assign local IPs to the `LoadBalancer` `Services` for the operator to connect to MariaDB. For this to happen, these local IPs need to be within the docker CIDR, which can be queried using:
 ```bash
 make cidr
 172.18.0.0/16
@@ -141,6 +141,8 @@ make run
 ```bash
 make cluster
 make install
+make install-minio
 make net
 make test
 ```
+

--- a/hack/add_host.sh
+++ b/hack/add_host.sh
@@ -2,7 +2,8 @@
 
 set -euo pipefail
 
-IP=$1
+CIDR_PREFIX=$(go run ./hack/get_kind_cidr_prefix.go)
+IP="${CIDR_PREFIX}.0.$1"
 HOSTNAME=$2
 
 if grep -q "^$IP\s*$HOSTNAME" /etc/hosts; then

--- a/hack/display_cidr.sh
+++ b/hack/display_cidr.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+CIDR_PREFIX=$(go run ./hack/get_kind_cidr_prefix.go)
+echo "${CIDR_PREFIX}.0.0/16"

--- a/make/net.mk
+++ b/make/net.mk
@@ -3,18 +3,21 @@
 CIDR_PREFIX_PATH ?= /tmp/cidr-prefix.txt
 CIDR_PREFIX_CODE := $(shell go run ./hack/get_kind_cidr_prefix.go > $(CIDR_PREFIX_PATH); echo $$?)
 CIDR_PREFIX ?= ""
-ifeq ($(CIDR_PREFIX_CODE),0)
-	CIDR_PREFIX = $(shell cat $(CIDR_PREFIX_PATH))
-else
-  $(error Error getting CIDR prefix: $(shell cat $(CIDR_PREFIX_PATH)))
-endif
+
+.PHONY: check-cidr
+check-cidr: ## Stop when CIDR used by KIND is not present.
+	ifeq ($(CIDR_PREFIX_CODE),0)
+		CIDR_PREFIX = $(shell cat $(CIDR_PREFIX_PATH))
+	else
+		$(error Error getting CIDR prefix: $(shell cat $(CIDR_PREFIX_PATH)))
+	endif
 
 .PHONY: cidr
-cidr: ## Get CIDR used by KIND.
+cidr: check-cidr ## Get CIDR used by KIND.
 	@echo "$(CIDR_PREFIX).0.0/16"
 
 .PHONY: host-mariadb
-host-mariadb:  ## Add mariadb hosts to /etc/hosts.
+host-mariadb: check-cidr ## Add mariadb hosts to /etc/hosts.
 	@./hack/add_host.sh $(CIDR_PREFIX).0.10 mariadb-0.mariadb-internal.default.svc.cluster.local
 	@./hack/add_host.sh $(CIDR_PREFIX).0.11 mariadb-1.mariadb-internal.default.svc.cluster.local
 	@./hack/add_host.sh $(CIDR_PREFIX).0.12 mariadb-2.mariadb-internal.default.svc.cluster.local
@@ -25,11 +28,11 @@ host-mariadb:  ## Add mariadb hosts to /etc/hosts.
 	@./hack/add_host.sh $(CIDR_PREFIX).0.40 mariadb.mariadb.svc.cluster.local
 
 .PHONY: host-mariadb-test
-host-mariadb-test: ## Add mariadb test hosts to /etc/hosts.
+host-mariadb-test: check-cidr ## Add mariadb test hosts to /etc/hosts.
 	@./hack/add_host.sh ${CIDR_PREFIX}.0.100 mariadb-test.default.svc.cluster.local
 
 .PHONY: host-mariadb-repl
-host-mariadb-repl: ## Add mariadb repl hosts to /etc/hosts.
+host-mariadb-repl: check-cidr ## Add mariadb repl hosts to /etc/hosts.
 	@./hack/add_host.sh $(CIDR_PREFIX).0.110 mariadb-repl-0.mariadb-repl-internal.default.svc.cluster.local
 	@./hack/add_host.sh $(CIDR_PREFIX).0.111 mariadb-repl-1.mariadb-repl-internal.default.svc.cluster.local
 	@./hack/add_host.sh $(CIDR_PREFIX).0.112 mariadb-repl-2.mariadb-repl-internal.default.svc.cluster.local
@@ -39,7 +42,7 @@ host-mariadb-repl: ## Add mariadb repl hosts to /etc/hosts.
 	@./hack/add_host.sh $(CIDR_PREFIX).0.131 mariadb-repl-secondary.default.svc.cluster.local
 
 .PHONY: host-mariadb-galera
-host-mariadb-galera: ## Add mariadb galera hosts to /etc/hosts.
+host-mariadb-galera: check-cidr ## Add mariadb galera hosts to /etc/hosts.
 	@./hack/add_host.sh $(CIDR_PREFIX).0.140 mariadb-galera-0.mariadb-galera-internal.default.svc.cluster.local
 	@./hack/add_host.sh $(CIDR_PREFIX).0.141 mariadb-galera-1.mariadb-galera-internal.default.svc.cluster.local
 	@./hack/add_host.sh $(CIDR_PREFIX).0.142 mariadb-galera-2.mariadb-galera-internal.default.svc.cluster.local
@@ -49,9 +52,10 @@ host-mariadb-galera: ## Add mariadb galera hosts to /etc/hosts.
 	@./hack/add_host.sh $(CIDR_PREFIX).0.161 mariadb-galera-secondary.default.svc.cluster.local
 
 .PHONY: host-minio
-host-minio:
+host-minio: check-cidr ## Add minio hosts to /etc/hosts.
 	@./hack/add_host.sh $(CIDR_PREFIX).0.200 minio
 	@./hack/add_host.sh $(CIDR_PREFIX).0.201 minio-console
 
 .PHONY: net
 net: install-metallb host-mariadb host-mariadb-test host-mariadb-repl host-mariadb-galera host-minio ## Configure networking for local development.
+

--- a/make/net.mk
+++ b/make/net.mk
@@ -1,60 +1,48 @@
 ##@ Networking
 
-CIDR_PREFIX_PATH ?= /tmp/cidr-prefix.txt
-CIDR_PREFIX_CODE := $(shell go run ./hack/get_kind_cidr_prefix.go > $(CIDR_PREFIX_PATH); echo $$?)
-CIDR_PREFIX ?= ""
-
-.PHONY: check-cidr
-check-cidr: ## Stop when CIDR used by KIND is not present.
-	ifeq ($(CIDR_PREFIX_CODE),0)
-		CIDR_PREFIX = $(shell cat $(CIDR_PREFIX_PATH))
-	else
-		$(error Error getting CIDR prefix: $(shell cat $(CIDR_PREFIX_PATH)))
-	endif
-
 .PHONY: cidr
-cidr: check-cidr ## Get CIDR used by KIND.
-	@echo "$(CIDR_PREFIX).0.0/16"
+cidr: ## Get CIDR used by KIND.
+	@./hack/display_cidr.sh
 
 .PHONY: host-mariadb
-host-mariadb: check-cidr ## Add mariadb hosts to /etc/hosts.
-	@./hack/add_host.sh $(CIDR_PREFIX).0.10 mariadb-0.mariadb-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.11 mariadb-1.mariadb-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.12 mariadb-2.mariadb-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.13 mariadb-3.mariadb-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.20 mariadb.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.30 mariadb-primary.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.31 mariadb-secondary.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.40 mariadb.mariadb.svc.cluster.local
+host-mariadb: ## Add mariadb hosts to /etc/hosts.
+	@./hack/add_host.sh 10 mariadb-0.mariadb-internal.default.svc.cluster.local
+	@./hack/add_host.sh 11 mariadb-1.mariadb-internal.default.svc.cluster.local
+	@./hack/add_host.sh 12 mariadb-2.mariadb-internal.default.svc.cluster.local
+	@./hack/add_host.sh 13 mariadb-3.mariadb-internal.default.svc.cluster.local
+	@./hack/add_host.sh 20 mariadb.default.svc.cluster.local
+	@./hack/add_host.sh 30 mariadb-primary.default.svc.cluster.local
+	@./hack/add_host.sh 31 mariadb-secondary.default.svc.cluster.local
+	@./hack/add_host.sh 40 mariadb.mariadb.svc.cluster.local
 
 .PHONY: host-mariadb-test
-host-mariadb-test: check-cidr ## Add mariadb test hosts to /etc/hosts.
-	@./hack/add_host.sh ${CIDR_PREFIX}.0.100 mariadb-test.default.svc.cluster.local
+host-mariadb-test: ## Add mariadb test hosts to /etc/hosts.
+	@./hack/add_host.sh 100 mariadb-test.default.svc.cluster.local
 
 .PHONY: host-mariadb-repl
-host-mariadb-repl: check-cidr ## Add mariadb repl hosts to /etc/hosts.
-	@./hack/add_host.sh $(CIDR_PREFIX).0.110 mariadb-repl-0.mariadb-repl-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.111 mariadb-repl-1.mariadb-repl-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.112 mariadb-repl-2.mariadb-repl-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.113 mariadb-repl-3.mariadb-repl-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.120 mariadb-repl.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.130 mariadb-repl-primary.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.131 mariadb-repl-secondary.default.svc.cluster.local
+host-mariadb-repl: ## Add mariadb repl hosts to /etc/hosts.
+	@./hack/add_host.sh 110 mariadb-repl-0.mariadb-repl-internal.default.svc.cluster.local
+	@./hack/add_host.sh 111 mariadb-repl-1.mariadb-repl-internal.default.svc.cluster.local
+	@./hack/add_host.sh 112 mariadb-repl-2.mariadb-repl-internal.default.svc.cluster.local
+	@./hack/add_host.sh 113 mariadb-repl-3.mariadb-repl-internal.default.svc.cluster.local
+	@./hack/add_host.sh 120 mariadb-repl.default.svc.cluster.local
+	@./hack/add_host.sh 130 mariadb-repl-primary.default.svc.cluster.local
+	@./hack/add_host.sh 131 mariadb-repl-secondary.default.svc.cluster.local
 
 .PHONY: host-mariadb-galera
-host-mariadb-galera: check-cidr ## Add mariadb galera hosts to /etc/hosts.
-	@./hack/add_host.sh $(CIDR_PREFIX).0.140 mariadb-galera-0.mariadb-galera-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.141 mariadb-galera-1.mariadb-galera-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.142 mariadb-galera-2.mariadb-galera-internal.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.143 mariadb-galera-3.mariadb-galera-internal.default.svc.cluster.local	
-	@./hack/add_host.sh $(CIDR_PREFIX).0.150 mariadb-galera.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.160 mariadb-galera-primary.default.svc.cluster.local
-	@./hack/add_host.sh $(CIDR_PREFIX).0.161 mariadb-galera-secondary.default.svc.cluster.local
+host-mariadb-galera: ## Add mariadb galera hosts to /etc/hosts.
+	@./hack/add_host.sh 140 mariadb-galera-0.mariadb-galera-internal.default.svc.cluster.local
+	@./hack/add_host.sh 141 mariadb-galera-1.mariadb-galera-internal.default.svc.cluster.local
+	@./hack/add_host.sh 142 mariadb-galera-2.mariadb-galera-internal.default.svc.cluster.local
+	@./hack/add_host.sh 143 mariadb-galera-3.mariadb-galera-internal.default.svc.cluster.local	
+	@./hack/add_host.sh 150 mariadb-galera.default.svc.cluster.local
+	@./hack/add_host.sh 160 mariadb-galera-primary.default.svc.cluster.local
+	@./hack/add_host.sh 161 mariadb-galera-secondary.default.svc.cluster.local
 
 .PHONY: host-minio
-host-minio: check-cidr ## Add minio hosts to /etc/hosts.
-	@./hack/add_host.sh $(CIDR_PREFIX).0.200 minio
-	@./hack/add_host.sh $(CIDR_PREFIX).0.201 minio-console
+host-minio: ## Add minio hosts to /etc/hosts.
+	@./hack/add_host.sh 200 minio
+	@./hack/add_host.sh 201 minio-console
 
 .PHONY: net
 net: install-metallb host-mariadb host-mariadb-test host-mariadb-repl host-mariadb-galera host-minio ## Configure networking for local development.

--- a/pkg/docker/network.go
+++ b/pkg/docker/network.go
@@ -59,7 +59,7 @@ func GetCidrPrefix(cidr string) string {
 func GetDockerCidrPrefix(network string) (string, error) {
 	cidr, err := GetDockerCidr(network)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 	return GetCidrPrefix(cidr), nil
 }


### PR DESCRIPTION
When my building my (first) local development environment I could not get MetalLB configured because an error occurred in `GetDockerCidrPrefix`. This Pull Requests lets `GetDockerCidrPrefix` report that error. I've changed the Makefile a bit to only report the error when networking related components are used (i.e. you would be able to still run `make build` when you do not have KIND running).