### PR TITLE
Add prefix for S3 backup/restore

### DIFF
--- a/api/v1alpha1/base_types.go
+++ b/api/v1alpha1/base_types.go
@@ -266,6 +266,10 @@ type S3 struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	TLS *TLS `json:"tls,omitempty"`
+	// Prefix allows backups to be placed under a specific prefix in the bucket.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	Prefix string `json:"prefix"`
 }
 
 // RestoreSource defines a source for restoring a MariaDB.

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -24,6 +24,7 @@ var (
 	s3Region       string
 	s3TLS          bool
 	s3CACertPath   string
+	s3Prefix       string
 	maxRetention   time.Duration
 )
 
@@ -47,6 +48,7 @@ func init() {
 	RootCmd.PersistentFlags().BoolVar(&s3TLS, "s3-tls", false, "Enable S3 TLS connections.")
 	RootCmd.PersistentFlags().StringVar(&s3CACertPath, "s3-ca-cert-path", "s3/pki/tls.crt",
 		"Path to the CA to be trusted when connecting to S3.")
+	RootCmd.PersistentFlags().StringVar(&s3Prefix, "s3-prefix", "", "S3 bucket prefix name to use.")
 
 	RootCmd.Flags().DurationVar(&maxRetention, "max-retention", 30*24*time.Hour,
 		"Defines the retention policy for backups. Older backups will be deleted.")
@@ -151,6 +153,7 @@ func getBackupStorage() (backup.BackupStorage, error) {
 func getS3BackupStorage() (backup.BackupStorage, error) {
 	opts := []backup.S3BackupStorageOpt{
 		backup.WithRegion(s3Region),
+		backup.WithPrefix(s3Prefix),
 	}
 	if s3TLS {
 		opts = append(opts, backup.WithTLS(s3CACertPath))

--- a/config/crd/bases/mariadb.mmontes.io_backups.yaml
+++ b/config/crd/bases/mariadb.mmontes.io_backups.yaml
@@ -1258,6 +1258,10 @@ spec:
                       endpoint:
                         description: Endpoint is the S3 API endpoint without scheme.
                         type: string
+                      prefix:
+                        description: Prefix allows backups to be placed under a specific
+                          prefix in the bucket.
+                        type: string
                       region:
                         description: Region is the S3 region name to use.
                         type: string

--- a/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
+++ b/config/crd/bases/mariadb.mmontes.io_mariadbs.yaml
@@ -928,6 +928,10 @@ spec:
                       endpoint:
                         description: Endpoint is the S3 API endpoint without scheme.
                         type: string
+                      prefix:
+                        description: Prefix allows backups to be placed under a specific
+                          prefix in the bucket.
+                        type: string
                       region:
                         description: Region is the S3 region name to use.
                         type: string

--- a/config/crd/bases/mariadb.mmontes.io_restores.yaml
+++ b/config/crd/bases/mariadb.mmontes.io_restores.yaml
@@ -1033,6 +1033,10 @@ spec:
                   endpoint:
                     description: Endpoint is the S3 API endpoint without scheme.
                     type: string
+                  prefix:
+                    description: Prefix allows backups to be placed under a specific
+                      prefix in the bucket.
+                    type: string
                   region:
                     description: Region is the S3 region name to use.
                     type: string

--- a/deploy/charts/mariadb-operator/crds/crds.yaml
+++ b/deploy/charts/mariadb-operator/crds/crds.yaml
@@ -1257,6 +1257,10 @@ spec:
                       endpoint:
                         description: Endpoint is the S3 API endpoint without scheme.
                         type: string
+                      prefix:
+                        description: Prefix allows backups to be placed under a specific
+                          prefix in the bucket.
+                        type: string
                       region:
                         description: Region is the S3 region name to use.
                         type: string
@@ -4653,6 +4657,10 @@ spec:
                         type: string
                       endpoint:
                         description: Endpoint is the S3 API endpoint without scheme.
+                        type: string
+                      prefix:
+                        description: Prefix allows backups to be placed under a specific
+                          prefix in the bucket.
                         type: string
                       region:
                         description: Region is the S3 region name to use.
@@ -14861,6 +14869,10 @@ spec:
                     type: string
                   endpoint:
                     description: Endpoint is the S3 API endpoint without scheme.
+                    type: string
+                  prefix:
+                    description: Prefix allows backups to be placed under a specific
+                      prefix in the bucket.
                     type: string
                   region:
                     description: Region is the S3 region name to use.

--- a/deploy/crds/crds.yaml
+++ b/deploy/crds/crds.yaml
@@ -1257,6 +1257,10 @@ spec:
                       endpoint:
                         description: Endpoint is the S3 API endpoint without scheme.
                         type: string
+                      prefix:
+                        description: Prefix allows backups to be placed under a specific
+                          prefix in the bucket.
+                        type: string
                       region:
                         description: Region is the S3 region name to use.
                         type: string
@@ -4653,6 +4657,10 @@ spec:
                         type: string
                       endpoint:
                         description: Endpoint is the S3 API endpoint without scheme.
+                        type: string
+                      prefix:
+                        description: Prefix allows backups to be placed under a specific
+                          prefix in the bucket.
                         type: string
                       region:
                         description: Region is the S3 region name to use.
@@ -14861,6 +14869,10 @@ spec:
                     type: string
                   endpoint:
                     description: Endpoint is the S3 API endpoint without scheme.
+                    type: string
+                  prefix:
+                    description: Prefix allows backups to be placed under a specific
+                      prefix in the bucket.
                     type: string
                   region:
                     description: Region is the S3 region name to use.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -773,6 +773,7 @@ _Appears in:_
 | `secretAccessKeySecretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ | AccessKeyIdSecretKeyRef is a reference to a Secret key containing the S3 secret key. |
 | `sessionTokenSecretKeyRef` _[SecretKeySelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#secretkeyselector-v1-core)_ | SessionTokenSecretKeyRef is a reference to a Secret key containing the S3 session token. |
 | `tls` _[TLS](#tls)_ | TLS provides the configuration required to establish TLS connections with S3. |
+| `prefix` _string_ | Prefix allows backups to be placed under a specific prefix in the bucket. |
 
 
 #### SQLTemplate

--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -295,6 +295,7 @@ func s3Opts(s3 *mariadbv1alpha1.S3) []command.BackupOpt {
 			s3.Bucket,
 			s3.Endpoint,
 			s3.Region,
+			s3.Prefix,
 		),
 	}
 	if s3.TLS != nil && s3.TLS.Enabled {

--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -22,6 +22,7 @@ type BackupOpts struct {
 	S3Region             string
 	S3TLS                bool
 	S3CACertPath         string
+	S3Prefix             string
 	LogLevel             string
 	DumpOpts             []string
 }
@@ -47,12 +48,13 @@ func WithBackupTargetTime(t time.Time) BackupOpt {
 	}
 }
 
-func WithS3(bucket, endpoint, region string) BackupOpt {
+func WithS3(bucket, endpoint, region, prefix string) BackupOpt {
 	return func(bo *BackupOpts) {
 		bo.S3 = true
 		bo.S3Bucket = bucket
 		bo.S3Endpoint = endpoint
 		bo.S3Region = region
+		bo.S3Prefix = prefix
 	}
 }
 
@@ -250,6 +252,12 @@ func (b *BackupCommand) s3Args() []string {
 				b.S3CACertPath,
 			)
 		}
+	}
+	if b.S3Prefix != "" {
+		args = append(args,
+			"--s3-prefix",
+			b.S3Prefix,
+		)
 	}
 	return args
 }


### PR DESCRIPTION
Closes https://github.com/mariadb-operator/mariadb-operator/issues/344

Something we noticed while setting things up is that backups in S3 buckets are stored only in the root, without any reference to the database name. This adds a `prefix` field to the S3 config so that backups can be placed wherever one might want them.

It might be of interest to have some kind of default path that contains more things to identify the backup, though I don't have any strong opinions about how that should look.