### PR TITLE
Add args option to restore jobs

### DIFF
--- a/api/v1alpha1/restore_types.go
+++ b/api/v1alpha1/restore_types.go
@@ -16,6 +16,10 @@ type RestoreSpec struct {
 	// +kubebuilder:validation:Required
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	MariaDBRef MariaDBRef `json:"mariaDbRef" webhook:"inmutable"`
+	// Args to be used in the Restore container.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	Args []string `json:"args,omitempty"`
 	// LogLevel to be used n the Backup Job. It defaults to 'info'.
 	// +optional
 	// +kubebuilder:default=info

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1538,6 +1538,11 @@ func (in *RestoreSpec) DeepCopyInto(out *RestoreSpec) {
 	*out = *in
 	in.RestoreSource.DeepCopyInto(&out.RestoreSource)
 	out.MariaDBRef = in.MariaDBRef
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = new(v1.ResourceRequirements)

--- a/config/crd/bases/mariadb.mmontes.io_restores.yaml
+++ b/config/crd/bases/mariadb.mmontes.io_restores.yaml
@@ -879,6 +879,11 @@ spec:
                         type: array
                     type: object
                 type: object
+              args:
+                description: Args to be used in the Restore container.
+                items:
+                  type: string
+                type: array
               backoffLimit:
                 default: 5
                 description: BackoffLimit defines the maximum number of attempts to

--- a/controller/restore_controller_test.go
+++ b/controller/restore_controller_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Restore controller", func() {
 						},
 						TargetRecoveryTime: &metav1.Time{Time: time.Now()},
 					},
+					Args: []string{"--verbose"},
 				},
 			}
 			Expect(k8sClient.Create(testCtx, restore)).To(Succeed())

--- a/deploy/charts/mariadb-operator/crds/crds.yaml
+++ b/deploy/charts/mariadb-operator/crds/crds.yaml
@@ -15220,6 +15220,11 @@ spec:
                         type: array
                     type: object
                 type: object
+              args:
+                description: Args to be used in the Restore container.
+                items:
+                  type: string
+                type: array
               backoffLimit:
                 default: 5
                 description: BackoffLimit defines the maximum number of attempts to

--- a/deploy/crds/crds.yaml
+++ b/deploy/crds/crds.yaml
@@ -15220,6 +15220,11 @@ spec:
                         type: array
                     type: object
                 type: object
+              args:
+                description: Args to be used in the Restore container.
+                items:
+                  type: string
+                type: array
               backoffLimit:
                 default: 5
                 description: BackoffLimit defines the maximum number of attempts to

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -751,6 +751,7 @@ _Appears in:_
 | `volume` _[VolumeSource](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#volumesource-v1-core)_ | Volume is a Kubernetes Volume object that contains a backup. |
 | `targetRecoveryTime` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#time-v1-meta)_ | TargetRecoveryTime is a RFC3339 (1970-01-01T00:00:00Z) date and time that defines the point in time recovery objective. It is used to determine the closest restoration source in time. |
 | `mariaDbRef` _[MariaDBRef](#mariadbref)_ | MariaDBRef is a reference to a MariaDB object. |
+| `args` _string array_ | Args to be used in the Restore container. |
 | `logLevel` _string_ | LogLevel to be used n the Backup Job. It defaults to 'info'. |
 | `backoffLimit` _integer_ | BackoffLimit defines the maximum number of attempts to successfully perform a Backup. |
 | `restartPolicy` _[RestartPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#restartpolicy-v1-core)_ | RestartPolicy to be added to the Backup Job. |

--- a/examples/manifests/mariadb_v1alpha1_restore.yaml
+++ b/examples/manifests/mariadb_v1alpha1_restore.yaml
@@ -7,6 +7,8 @@ spec:
     name: mariadb
   backupRef:
     name: backup
+  args:
+    - "--verbose"
   resources:
     requests:
       cpu: 100m

--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -153,6 +153,7 @@ func (b *Builder) BuildRestoreJob(key types.NamespacedName, restore *mariadbv1al
 		command.WithBackupUserEnv(batchUserEnv),
 		command.WithBackupPasswordEnv(batchPasswordEnv),
 		command.WithBackupLogLevel(restore.Spec.LogLevel),
+		command.WithBackupDumpOpts(restore.Spec.Args),
 	}
 	cmdOpts = append(cmdOpts, s3Opts(restore.Spec.S3)...)
 

--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -199,6 +199,10 @@ func (b *BackupCommand) MariadbOperatorRestore() *Command {
 }
 
 func (b *BackupCommand) MariadbRestore(mariadb *mariadbv1alpha1.MariaDB) *Command {
+	dumpOpts := ""
+	if b.BackupOpts.DumpOpts != nil {
+		dumpOpts = strings.Join(b.BackupOpts.DumpOpts, " ")
+	}
 	cmds := []string{
 		"set -euo pipefail",
 		fmt.Sprintf(
@@ -206,8 +210,9 @@ func (b *BackupCommand) MariadbRestore(mariadb *mariadbv1alpha1.MariaDB) *Comman
 			b.getTargetFilePath(),
 		),
 		fmt.Sprintf(
-			"mariadb %s < %s",
+			"mariadb %s %s < %s",
 			ConnectionFlags(&b.BackupOpts.CommandOpts, mariadb),
+			dumpOpts,
 			b.getTargetFilePath(),
 		),
 	}


### PR DESCRIPTION
Closes #238 

Add an 'args' option to the CRDs for restore jobs, similar to the existing option for backup jobs.