### PR TITLE
Use primary service when HA enabled in SQL reconciler

### DIFF
--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -107,7 +107,7 @@ func NewClientWithMariaDB(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,
 		WithUsername("root"),
 		WithPassword(password),
 		WitHost(func() string {
-			if mariadb.Replication().Enabled {
+			if mariadb.IsHAEnabled() {
 				return statefulset.ServiceFQDNWithService(
 					mariadb.ObjectMeta,
 					mariadb.PrimaryServiceKey().Name,


### PR DESCRIPTION
At the moment we are using the primary service only when replication is enabled, it should apply to galera as well.