### PR TITLE
Add Glasskube to Adopters list

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -5,5 +5,6 @@ This list is sorted in chronological order, based on the submission date.
 | Organization | Contact | Date | Description of Use |
 | ------------ | ------- | ---- | ------------------ |
 | [Ænix](https://aenix.io) | @kvaps | 2024-02-13 | Ænix provides consulting services for cloud providers and uses mariadb-operator in free PaaS platform [Cozystack](https://cozystack.io) to run managed MariaDB databases. |
+| [Glasskube](https://glasskube.dev/) | @pmig | 2024-02-13 | Glasskube provides managed services with the help of the mariadb-operator and is the creator of [`glasskube`](https://github.com/glasskube/glasskube/) 🧊 The missing Package Manager for Kubernetes 📦 |
 
 Feel free open a PR and add your company or project to the list!


### PR DESCRIPTION
Glasskube first introduced the `mariadb-operator` back in November 2022 (https://github.com/glasskube/operator/issues/20) for supporting Matomo via our apps operator and happily using (and migrating between versions) ever since.