### PR TITLE
Allow custom labels on certmanager secret template

### DIFF
--- a/deploy/charts/mariadb-operator/README.md
+++ b/deploy/charts/mariadb-operator/README.md
@@ -96,6 +96,7 @@ helm uninstall mariadb-operator
 | webhook.cert.certManager.renewBefore | string | `""` | Renew before duration to be used in the Certificate resource. |
 | webhook.cert.path | string | `"/tmp/k8s-webhook-server/serving-certs"` | Path where the certificate will be mounted. |
 | webhook.cert.secretAnnotations | object | `{}` | Annotatioms to be added to webhook TLS secret. |
+| webhook.cert.secretLabels | object | `{}` | Labels to be added to webhook TLS secret. |
 | webhook.extrArgs | list | `[]` | Extra arguments to be passed to the webhook entrypoint |
 | webhook.extraVolumeMounts | list | `[]` | Extra volumes to mount to webhook container |
 | webhook.extraVolumes | list | `[]` | Extra volumes to pass to webhook Pod |

--- a/deploy/charts/mariadb-operator/templates/webhook-certificate.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-certificate.yaml
@@ -38,8 +38,10 @@ spec:
   {{- end }}
   secretName: {{ include "mariadb-operator.fullname" . }}-webhook-cert
   secretTemplate:
+    {{- with .Values.webhook.cert.secretLabels }}
     labels:
-      {{- include "mariadb-operator-webhook.labels" . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
     {{- with .Values.webhook.cert.secretAnnotations }}
     annotations:
       {{- toYaml . | nindent 4 }}

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -111,6 +111,8 @@ webhook:
       renewBefore: ""
     # -- Annotatioms to be added to webhook TLS secret.
     secretAnnotations: {}
+    # -- Labels to be added to webhook TLS secret.
+    secretLabels: {}
     # -- Path where the CA certificate will be mounted.
     caPath: /tmp/k8s-webhook-server/certificate-authority
     # -- Path where the certificate will be mounted.


### PR DESCRIPTION
Previously chart generated labels, including helm release metadata was added to the webhook certificate secretTemplate metadata, this causes gitops tools like argo cd to constantly delete the cert-manager managed secret and making the webhook unusable.

Related to https://github.com/mariadb-operator/mariadb-operator/issues/285