### PR TITLE
Default `MaxScale` fsGroup

### DIFF
--- a/api/v1alpha1/maxscale_types.go
+++ b/api/v1alpha1/maxscale_types.go
@@ -675,6 +675,12 @@ func (m *MaxScale) SetDefaults(env *environment.OperatorEnv) {
 	m.Spec.Config.SetDefaults(m)
 	m.Spec.Auth.SetDefaults(m)
 	m.Spec.PodTemplate.SetDefaults(m.ObjectMeta)
+
+	if m.Spec.PodTemplate.PodSecurityContext == nil {
+		m.Spec.PodTemplate.PodSecurityContext = &corev1.PodSecurityContext{
+			FSGroup: ptr.To(int64(996)),
+		}
+	}
 }
 
 // IsReady indicates whether the Maxscale instance is ready.

--- a/api/v1alpha1/maxscale_types_test.go
+++ b/api/v1alpha1/maxscale_types_test.go
@@ -59,6 +59,9 @@ var _ = Describe("MaxScale types", func() {
 					Spec: MaxScaleSpec{
 						PodTemplate: PodTemplate{
 							ServiceAccountName: &objMeta.Name,
+							PodSecurityContext: &corev1.PodSecurityContext{
+								FSGroup: ptr.To(int64(996)),
+							},
 						},
 						Image: env.RelatedMaxscaleImage,
 						Servers: []MaxScaleServer{
@@ -201,6 +204,9 @@ var _ = Describe("MaxScale types", func() {
 					Spec: MaxScaleSpec{
 						PodTemplate: PodTemplate{
 							ServiceAccountName: &objMeta.Name,
+							PodSecurityContext: &corev1.PodSecurityContext{
+								FSGroup: ptr.To(int64(996)),
+							},
 						},
 						Image:           env.RelatedMaxscaleImage,
 						Replicas:        3,

--- a/pkg/builder/statefulset_container_builder.go
+++ b/pkg/builder/statefulset_container_builder.go
@@ -177,21 +177,7 @@ func mariadbInitContainers(mariadb *mariadbv1alpha1.MariaDB, opts ...mariadbOpt)
 }
 
 func maxscaleInitContainers(mxs *mariadbv1alpha1.MaxScale) []corev1.Container {
-	initContainers := []corev1.Container{
-		{
-			Name:  "init-chown",
-			Image: mxs.Spec.Image,
-			Command: []string{
-				"/bin/sh",
-				"-c",
-				"chown -R 998:996 /var/lib/maxscale",
-			},
-			VolumeMounts: maxscaleVolumeMounts(mxs),
-			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: ptr.To(int64(0)),
-			},
-		},
-	}
+	var initContainers []corev1.Container
 	if mxs.Spec.InitContainers != nil {
 		for index, container := range mxs.Spec.InitContainers {
 			initContainer := buildContainer(container.Image, container.ImagePullPolicy, &container.ContainerTemplate)


### PR DESCRIPTION
Close https://github.com/mariadb-operator/mariadb-operator/issues/381

Remove `MaxScale` defaullt initContainer to perform chown and rely on `CSIDriver` and kubelet to setup permissions via `fsGroup`. See https://github.com/mariadb-operator/mariadb-operator/issues/381#issuecomment-1974828673.