### PR TITLE
Updating node address even if MariaDB request fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-VERSION ?= 0.0.26
+VERSION ?= 0.0.27
 
 IMG_NAME ?= ghcr.io/mariadb-operator/mariadb-operator
 IMG ?= $(IMG_NAME):v$(VERSION)
@@ -27,10 +27,10 @@ RELATED_IMAGE_MARIADB_ENT ?= us-central1-docker.pkg.dev/mariadb-es-docker-regist
 RELATED_IMAGE_MAXSCALE ?= mariadb/maxscale:23.08
 RELATED_IMAGE_EXPORTER ?= prom/mysqld-exporter:v0.15.1
 
-MARIADB_GALERA_INIT_IMAGE ?= $(IMG_NAME):v0.0.26
-MARIADB_GALERA_ENT_INIT_IMAGE ?= $(IMG_ENT_NAME):v0.0.26
-MARIADB_GALERA_AGENT_IMAGE ?= $(IMG_NAME):v0.0.26
-MARIADB_GALERA_ENT_AGENT_IMAGE ?= $(IMG_ENT_NAME):v0.0.26
+MARIADB_GALERA_INIT_IMAGE ?= $(IMG_NAME):v0.0.27
+MARIADB_GALERA_ENT_INIT_IMAGE ?= $(IMG_ENT_NAME):v0.0.27
+MARIADB_GALERA_AGENT_IMAGE ?= $(IMG_NAME):v0.0.27
+MARIADB_GALERA_ENT_AGENT_IMAGE ?= $(IMG_ENT_NAME):v0.0.27
 MARIADB_GALERA_LIB_PATH ?= /usr/lib/galera/libgalera_smm.so
 MARIADB_GALERA_ENT_LIB_PATH ?= /usr/lib/galera/libgalera_enterprise_smm.so
 

--- a/deploy/charts/mariadb-operator/templates/configmap.yaml
+++ b/deploy/charts/mariadb-operator/templates/configmap.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 data:
-  MARIADB_GALERA_AGENT_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.26
-  MARIADB_GALERA_INIT_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.26
+  MARIADB_GALERA_AGENT_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
+  MARIADB_GALERA_INIT_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
   MARIADB_GALERA_LIB_PATH: /usr/lib/galera/libgalera_smm.so
-  MARIADB_OPERATOR_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.26
+  MARIADB_OPERATOR_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
   RELATED_IMAGE_EXPORTER: prom/mysqld-exporter:v0.15.1
   RELATED_IMAGE_MARIADB: mariadb:11.2.2
   RELATED_IMAGE_MAXSCALE: mariadb/maxscale:23.08

--- a/pkg/galera/filemanager/filemanager.go
+++ b/pkg/galera/filemanager/filemanager.go
@@ -45,6 +45,10 @@ func (f *FileManager) WriteConfigFile(name string, bytes []byte) error {
 	return os.WriteFile(filepath.Join(f.configDir, name), bytes, writeFileMode)
 }
 
+func (f *FileManager) ReadConfigFile(name string) ([]byte, error) {
+	return os.ReadFile(filepath.Join(f.configDir, name))
+}
+
 func (f *FileManager) DeleteConfigFile(name string) error {
 	return os.Remove(filepath.Join(f.configDir, name))
 }


### PR DESCRIPTION
This PR enables the Galera initContainer to update the `wsrep_node_address` with the `Pod` IP even if the `MariaDB` request fails.