### PR TITLE
Fix metrics selector to avoid clashing with `MariaDB`. Sort out anti-affinity cases where there aren't enough nodes for the exporter `Pod`

### DIFF
--- a/controller/mariadb_controller_test.go
+++ b/controller/mariadb_controller_test.go
@@ -172,7 +172,7 @@ var _ = Describe("MariaDB controller", func() {
 				}
 				g.Expect(svcMonitor.Spec.Selector.MatchLabels).NotTo(BeEmpty())
 				g.Expect(svcMonitor.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/name", "exporter"))
-				g.Expect(svcMonitor.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", testMdbkey.Name))
+				g.Expect(svcMonitor.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", testMariaDb.MetricsKey().Name))
 				g.Expect(svcMonitor.Spec.Endpoints).To(HaveLen(1))
 				return true
 			}).WithTimeout(testTimeout).WithPolling(testInterval).Should(BeTrue())

--- a/pkg/builder/labels/labels.go
+++ b/pkg/builder/labels/labels.go
@@ -62,7 +62,7 @@ func (b *LabelsBuilder) WithMariaDBSelectorLabels(mdb *mariadbv1alpha1.MariaDB) 
 
 func (b *LabelsBuilder) WithMetricsSelectorLabels(mdb *mariadbv1alpha1.MariaDB) *LabelsBuilder {
 	return b.WithApp(appExporter).
-		WithInstance(mdb.Name)
+		WithInstance(mdb.MetricsKey().Name)
 }
 
 func (b *LabelsBuilder) WithMaxScaleSelectorLabels(mxs *mariadbv1alpha1.MaxScale) *LabelsBuilder {


### PR DESCRIPTION
This PR fixes the metrics selector labels to have a different name than `MariaDB`. 

This allows to sort out anti-affinity situations where there aren't enough nodes to place the metrics exporter `Pod`.  Anti affinity needs to be disabled for metrics in such case:

```yaml
apiVersion: k8s.mariadb.com/v1alpha1
kind: MariaDB
metadata:
  name: mariadb-galera
spec:
...
  metrics:
    enabled: true
    exporter:
      affinity:
        enableAntiAffinity: false

  affinity:
    enableAntiAffinity: true
```

Related to:
- https://github.com/mariadb-operator/mariadb-operator/issues/442