### PR TITLE
Galera IPv6 support

### DIFF
--- a/api/v1alpha1/mariadb_galera_types.go
+++ b/api/v1alpha1/mariadb_galera_types.go
@@ -348,6 +348,11 @@ type GaleraSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ReplicaThreads int `json:"replicaThreads,omitempty"`
+	// ProviderOptions is map of Galera configuration parameters.
+	// More info: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_provider_options.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	ProviderOptions map[string]string `json:"providerOptions,omitempty"`
 	// GaleraAgent is a sidecar agent that co-operates with mariadb-operator.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1alpha1/mariadb_webhook.go
+++ b/api/v1alpha1/mariadb_webhook.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 
+	"github.com/mariadb-operator/mariadb-operator/pkg/galera/options"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -152,6 +153,14 @@ func (r *MariaDB) validateGalera() error {
 			field.NewPath("spec").Child("galera").Child("replicaThreads"),
 			galera.ReplicaThreads,
 			"'spec.galera.replicaThreads' must be at least 1",
+		)
+	}
+	_, exists := galera.ProviderOptions[options.WSREPOptISTRecvAddr]
+	if exists {
+		return field.Invalid(
+			field.NewPath("spec").Child("galera").Child("ProviderOptions"),
+			galera.ProviderOptions,
+			"'spec.galera.ProviderOptions' can not contain: ist.recv_addr",
 		)
 	}
 	if galera.Recovery != nil {

--- a/api/v1alpha1/mariadb_webhook_test.go
+++ b/api/v1alpha1/mariadb_webhook_test.go
@@ -247,6 +247,28 @@ var _ = Describe("MariaDB webhook", func() {
 				true,
 			),
 			Entry(
+				"Invalid provider options",
+				&MariaDB{
+					ObjectMeta: meta,
+					Spec: MariaDBSpec{
+						Galera: &Galera{
+							Enabled: true,
+							GaleraSpec: GaleraSpec{
+								SST: SSTMariaBackup,
+								ProviderOptions: map[string]string{
+									"ist.recv_addr": "1.2.3.4:4568",
+								},
+							},
+						},
+						Replicas: 3,
+						Storage: Storage{
+							Size: ptr.To(resource.MustParse("100Mi")),
+						},
+					},
+				},
+				true,
+			),
+			Entry(
 				"Invalid replication primary pod index",
 				&MariaDB{
 					ObjectMeta: meta,

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -823,6 +823,13 @@ func (in *GaleraSpec) DeepCopyInto(out *GaleraSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.ProviderOptions != nil {
+		in, out := &in.ProviderOptions, &out.ProviderOptions
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Agent.DeepCopyInto(&out.Agent)
 	if in.Recovery != nil {
 		in, out := &in.Recovery, &out.Recovery

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -5568,6 +5568,12 @@ spec:
                           switchover.
                         type: integer
                     type: object
+                  providerOptions:
+                    additionalProperties:
+                      type: string
+                    description: 'ProviderOptions is map of Galera configuration parameters.
+                      More info: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_provider_options.'
+                    type: object
                   recovery:
                     description: 'GaleraRecovery is the recovery process performed
                       by the operator whenever the Galera cluster is not healthy.

--- a/deploy/charts/mariadb-operator/crds/crds.yaml
+++ b/deploy/charts/mariadb-operator/crds/crds.yaml
@@ -13415,6 +13415,12 @@ spec:
                           switchover.
                         type: integer
                     type: object
+                  providerOptions:
+                    additionalProperties:
+                      type: string
+                    description: 'ProviderOptions is map of Galera configuration parameters.
+                      More info: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_provider_options.'
+                    type: object
                   recovery:
                     description: 'GaleraRecovery is the recovery process performed
                       by the operator whenever the Galera cluster is not healthy.

--- a/deploy/charts/mariadb-operator/templates/configmap.yaml
+++ b/deploy/charts/mariadb-operator/templates/configmap.yaml
@@ -3,7 +3,7 @@ data:
   MARIADB_GALERA_AGENT_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
   MARIADB_GALERA_INIT_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
   MARIADB_GALERA_LIB_PATH: /usr/lib/galera/libgalera_smm.so
-  MARIADB_OPERATOR_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
+  MARIADB_OPERATOR_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27b
   RELATED_IMAGE_EXPORTER: prom/mysqld-exporter:v0.15.1
   RELATED_IMAGE_MARIADB: mariadb:10.11.7
   RELATED_IMAGE_MAXSCALE: mariadb/maxscale:23.08

--- a/deploy/charts/mariadb-operator/templates/configmap.yaml
+++ b/deploy/charts/mariadb-operator/templates/configmap.yaml
@@ -3,7 +3,7 @@ data:
   MARIADB_GALERA_AGENT_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
   MARIADB_GALERA_INIT_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
   MARIADB_GALERA_LIB_PATH: /usr/lib/galera/libgalera_smm.so
-  MARIADB_OPERATOR_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27b
+  MARIADB_OPERATOR_IMAGE: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
   RELATED_IMAGE_EXPORTER: prom/mysqld-exporter:v0.15.1
   RELATED_IMAGE_MARIADB: mariadb:10.11.7
   RELATED_IMAGE_MAXSCALE: mariadb/maxscale:23.08

--- a/deploy/crds/crds.yaml
+++ b/deploy/crds/crds.yaml
@@ -13415,6 +13415,12 @@ spec:
                           switchover.
                         type: integer
                     type: object
+                  providerOptions:
+                    additionalProperties:
+                      type: string
+                    description: 'ProviderOptions is map of Galera configuration parameters.
+                      More info: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_provider_options.'
+                    type: object
                   recovery:
                     description: 'GaleraRecovery is the recovery process performed
                       by the operator whenever the Galera cluster is not healthy.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -382,6 +382,7 @@ _Appears in:_
 | `availableWhenDonor` _boolean_ | AvailableWhenDonor indicates whether a donor node should be responding to queries. It defaults to false. |
 | `galeraLibPath` _string_ | GaleraLibPath is a path inside the MariaDB image to the wsrep provider plugin. It is defaulted if not provided. More info: https://galeracluster.com/library/documentation/mysql-wsrep-options.html#wsrep-provider. |
 | `replicaThreads` _integer_ | ReplicaThreads is the number of replica threads used to apply Galera write sets in parallel. More info: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_slave_threads. |
+| `providerOptions` _object (keys:string, values:string)_ | ProviderOptions is map of Galera configuration parameters. More info: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_provider_options. |
 | `agent` _[GaleraAgent](#galeraagent)_ | GaleraAgent is a sidecar agent that co-operates with mariadb-operator. |
 | `recovery` _[GaleraRecovery](#galerarecovery)_ | GaleraRecovery is the recovery process performed by the operator whenever the Galera cluster is not healthy. More info: https://galeracluster.com/library/documentation/crash-recovery.html. |
 | `initContainer` _[Container](#container)_ | InitContainer is an init container that co-operates with mariadb-operator. |
@@ -486,6 +487,7 @@ _Appears in:_
 | `availableWhenDonor` _boolean_ | AvailableWhenDonor indicates whether a donor node should be responding to queries. It defaults to false. |
 | `galeraLibPath` _string_ | GaleraLibPath is a path inside the MariaDB image to the wsrep provider plugin. It is defaulted if not provided. More info: https://galeracluster.com/library/documentation/mysql-wsrep-options.html#wsrep-provider. |
 | `replicaThreads` _integer_ | ReplicaThreads is the number of replica threads used to apply Galera write sets in parallel. More info: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_slave_threads. |
+| `providerOptions` _object (keys:string, values:string)_ | ProviderOptions is map of Galera configuration parameters. More info: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_provider_options. |
 | `agent` _[GaleraAgent](#galeraagent)_ | GaleraAgent is a sidecar agent that co-operates with mariadb-operator. |
 | `recovery` _[GaleraRecovery](#galerarecovery)_ | GaleraRecovery is the recovery process performed by the operator whenever the Galera cluster is not healthy. More info: https://galeracluster.com/library/documentation/crash-recovery.html. |
 | `initContainer` _[Container](#container)_ | InitContainer is an init container that co-operates with mariadb-operator. |

--- a/examples/manifests/mariadb_galera_full.yaml
+++ b/examples/manifests/mariadb_galera_full.yaml
@@ -50,6 +50,8 @@ spec:
     availableWhenDonor: false
     galeraLibPath: /usr/lib/galera/libgalera_smm.so
     replicaThreads: 1
+    providerOptions:
+      fc.limit: '64'
     agent:
       image: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
       port: 5555

--- a/examples/manifests/mariadb_galera_full.yaml
+++ b/examples/manifests/mariadb_galera_full.yaml
@@ -31,7 +31,7 @@ spec:
   # provision a MaxScale instance and set 'spec.maxScaleRef' automatically.
   maxScale:
     enabled: true
-    
+
     kubernetesService:
       type: LoadBalancer
       annotations:
@@ -51,7 +51,7 @@ spec:
     galeraLibPath: /usr/lib/galera/libgalera_smm.so
     replicaThreads: 1
     providerOptions:
-      fc.limit: '64'
+      gcs.fc_limit: '64'
     agent:
       image: ghcr.io/mariadb-operator/mariadb-operator:v0.0.27
       port: 5555

--- a/pkg/galera/config/config.go
+++ b/pkg/galera/config/config.go
@@ -13,6 +13,7 @@ import (
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/pkg/environment"
+	options "github.com/mariadb-operator/mariadb-operator/pkg/galera/options"
 	"github.com/mariadb-operator/mariadb-operator/pkg/galera/recovery"
 	"github.com/mariadb-operator/mariadb-operator/pkg/statefulset"
 	"k8s.io/utils/ptr"
@@ -88,8 +89,8 @@ wsrep_sst_auth="root:{{ .RootPassword }}"
 		return nil, fmt.Errorf("error wrapping address: %v", err)
 	}
 	providerOpts := map[string]string{
-		"gmcast.listen_addr": fmt.Sprintf("tcp://%s:4567", gcommListenAddress),
-		"ist.recv_addr":      fmt.Sprintf("%s:4568", wrappedPodIP),
+		options.WSREPOptGmcastListAddr: fmt.Sprintf("tcp://%s:4567", gcommListenAddress),
+		options.WSREPOptISTRecvAddr:    fmt.Sprintf("%s:4568", wrappedPodIP),
 	}
 	maps.Copy(providerOpts, galera.ProviderOptions)
 	providerOptsSemColSeparated := c.mapToSemColSeparated(providerOpts)

--- a/pkg/galera/config/config_test.go
+++ b/pkg/galera/config/config_test.go
@@ -209,7 +209,7 @@ wsrep_sst_auth="root:mariadb"
 			wantErr: false,
 		},
 		{
-			name: "Additional WSREP privider options",
+			name: "Additional WSREP provider options",
 			mariadb: &mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
@@ -223,8 +223,8 @@ wsrep_sst_auth="root:mariadb"
 							GaleraLibPath:  "/usr/lib/galera/libgalera_enterprise_smm.so",
 							ReplicaThreads: 1,
 							ProviderOptions: map[string]string{
-								"gcache.size": "1G",
-								"fc.limit":    "128",
+								"gcache.size":  "1G",
+								"gcs.fc_limit": "128",
 							},
 						},
 					},
@@ -254,7 +254,7 @@ wsrep_slave_threads=1
 wsrep_node_address="2001:db8::a1"
 wsrep_node_name="mariadb-galera-1"
 wsrep_sst_method="mariabackup"
-wsrep_provider_options = "fc.limit=128; gcache.size=1G; gmcast.listen_addr=tcp://[::]:4567; ist.recv_addr=[2001:db8::a1]:4568"
+wsrep_provider_options = "gcache.size=1G; gcs.fc_limit=128; gmcast.listen_addr=tcp://[::]:4567; ist.recv_addr=[2001:db8::a1]:4568"
 wsrep_sst_receive_address = "[2001:db8::a1]:4444"
 wsrep_sst_auth="root:mariadb"
 `,

--- a/pkg/galera/options/options.go
+++ b/pkg/galera/options/options.go
@@ -1,0 +1,6 @@
+package options
+
+var (
+	WSREPOptISTRecvAddr    = "ist.recv_addr"
+	WSREPOptGmcastListAddr = "gmcast.listen_addr"
+)


### PR DESCRIPTION
- automatically set WSREP options required for IPv6
- add new field (`spec.galera.providerOptions`) to allow providing custom `wsrep_provider_options` that will be merged with options provided by operator

Closes #458 