### PR TITLE
Ensure `syncMaxConnections` is initialized before derefing the pointer

### DIFF
--- a/controller/maxscale_controller.go
+++ b/controller/maxscale_controller.go
@@ -615,7 +615,8 @@ func (r *MaxScaleReconciler) reconcileAuth(ctx context.Context, req *requestMaxS
 			grants: monitorGrantOpts(monitorKey, mxs),
 		},
 	}
-	if mxs.Spec.Config.Sync != nil && mxs.Spec.Auth.SyncUsername != nil && mxs.Spec.Auth.SyncPasswordSecretKeyRef != nil {
+	if mxs.Spec.Config.Sync != nil && mxs.Spec.Auth.SyncUsername != nil && mxs.Spec.Auth.SyncPasswordSecretKeyRef != nil &&
+		mxs.Spec.Auth.SyncMaxConnections != nil {
 		syncKey := types.NamespacedName{
 			Name:      *mxs.Spec.Auth.SyncUsername,
 			Namespace: mxs.Namespace,


### PR DESCRIPTION
Closes https://github.com/mariadb-operator/mariadb-operator/issues/491