### PR TITLE
maxscale: set default config based on memory limits

### DIFF
--- a/pkg/maxscale/config/config.go
+++ b/pkg/maxscale/config/config.go
@@ -10,29 +10,34 @@ import (
 )
 
 type tplOpts struct {
-	Threads               string
-	PersistRuntimeChanges bool
-	LoadPersistentConfigs bool
-	AdminHost             string
-	AdminPort             int32
-	AdminGui              bool
-	AdminSecureGui        bool
-	Params                map[string]string
+	Threads                  string
+	QueryClassifierCacheSize string
+	PersistRuntimeChanges    bool
+	LoadPersistentConfigs    bool
+	AdminHost                string
+	AdminPort                int32
+	AdminGui                 bool
+	AdminSecureGui           bool
+	Params                   map[string]string
 }
 
 var existingConfigKeys = map[string]struct{}{
-	"threads":                 {},
-	"persist_runtime_changes": {},
-	"load_persisted_configs":  {},
-	"admin_host":              {},
-	"admin_port":              {},
-	"admin_gui":               {},
-	"admin_secure_gui":        {},
+	"threads":                     {},
+	"query_classifier_cache_size": {},
+	"persist_runtime_changes":     {},
+	"load_persisted_configs":      {},
+	"admin_host":                  {},
+	"admin_port":                  {},
+	"admin_gui":                   {},
+	"admin_secure_gui":            {},
 }
 
 func Config(mxs *mariadbv1alpha1.MaxScale) ([]byte, error) {
 	tpl := createTpl(mxs.ConfigSecretKeyRef().Key, `[maxscale]
 threads={{ .Threads }}
+{{- if .QueryClassifierCacheSize }}
+query_classifier_cache_size={{ .QueryClassifierCacheSize }}
+{{- end }}
 persist_runtime_changes={{ .PersistRuntimeChanges }}
 load_persisted_configs={{ .LoadPersistentConfigs }}
 admin_host={{ .AdminHost }}
@@ -44,14 +49,15 @@ admin_secure_gui={{ .AdminSecureGui }}
 {{ end }}`)
 	buf := new(bytes.Buffer)
 	err := tpl.Execute(buf, tplOpts{
-		Threads:               configValueOrDefault("threads", mxs.Spec.Config.Params, "auto"),
-		PersistRuntimeChanges: true,
-		LoadPersistentConfigs: true,
-		AdminHost:             configValueOrDefault("admin_host", mxs.Spec.Config.Params, "0.0.0.0"),
-		AdminPort:             mxs.Spec.Admin.Port,
-		AdminGui:              ptr.Deref(mxs.Spec.Admin.GuiEnabled, true),
-		AdminSecureGui:        false,
-		Params:                filterExistingConfig(mxs.Spec.Config.Params),
+		Threads:                  configValueOrDefault("threads", mxs.Spec.Config.Params, threads(mxs)),
+		QueryClassifierCacheSize: configValueOrDefault("query_classifier_cache_size", mxs.Spec.Config.Params, queryClassifierCacheSize(mxs)),
+		PersistRuntimeChanges:    true,
+		LoadPersistentConfigs:    true,
+		AdminHost:                configValueOrDefault("admin_host", mxs.Spec.Config.Params, "0.0.0.0"),
+		AdminPort:                mxs.Spec.Admin.Port,
+		AdminGui:                 ptr.Deref(mxs.Spec.Admin.GuiEnabled, true),
+		AdminSecureGui:           false,
+		Params:                   filterExistingConfig(mxs.Spec.Config.Params),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error rendering MaxScale config: %v", err)

--- a/pkg/maxscale/config/config_test.go
+++ b/pkg/maxscale/config/config_test.go
@@ -96,6 +96,31 @@ persistdir=/var/lib/maxscale/maxscale.cnf.d/
 `,
 		},
 		{
+			name: "override query_classifier_cache_size",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{
+					Config: mariadbv1alpha1.MaxScaleConfig{
+						Params: map[string]string{
+							"query_classifier_cache_size": "10MB",
+						},
+					},
+					Admin: mariadbv1alpha1.MaxScaleAdmin{
+						Port: 8989,
+					},
+				},
+			},
+			wantConfig: `[maxscale]
+threads=auto
+query_classifier_cache_size=10MB
+persist_runtime_changes=true
+load_persisted_configs=true
+admin_host=0.0.0.0
+admin_port=8989
+admin_gui=true
+admin_secure_gui=false
+`,
+		},
+		{
 			name: "non overridable params",
 			mxs: &mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{

--- a/pkg/maxscale/config/defaults.go
+++ b/pkg/maxscale/config/defaults.go
@@ -7,6 +7,8 @@ import (
 )
 
 const (
+	// Fraction of container memory limit used to calculate maximum size of query classifier cache.
+	// Value taken from https://mariadb.com/kb/en/mariadb-maxscale-6-mariadb-maxscale-configuration-guide/#query_classifier_cache_size
 	queryClassifierCacheLimitFraction = 0.15
 )
 

--- a/pkg/maxscale/config/defaults.go
+++ b/pkg/maxscale/config/defaults.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"fmt"
+
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+)
+
+const (
+	queryClassifierCacheLimitFraction = 0.15
+)
+
+func threads(mxs *mariadbv1alpha1.MaxScale) string {
+	threads := "auto"
+	if mxs.Spec.Resources == nil || mxs.Spec.Resources.Limits == nil {
+		return threads
+	}
+
+	cpuLimit := mxs.Spec.Resources.Limits.Cpu().Value()
+	if cpuLimit != 0 {
+		threads = fmt.Sprintf("%d", cpuLimit)
+	}
+	return threads
+}
+
+func queryClassifierCacheSize(mxs *mariadbv1alpha1.MaxScale) string {
+	queryClassifierCacheSize := ""
+	if mxs.Spec.Resources == nil || mxs.Spec.Resources.Limits == nil {
+		return queryClassifierCacheSize
+	}
+
+	memLimit := mxs.Spec.Resources.Limits.Memory().Value()
+	if memLimit != 0 {
+		queryClassCacheScaled := int64(float64(memLimit) * queryClassifierCacheLimitFraction)
+		queryClassifierCacheSize = fmt.Sprintf("%d", queryClassCacheScaled)
+	}
+	return queryClassifierCacheSize
+}

--- a/pkg/maxscale/config/defaults_test.go
+++ b/pkg/maxscale/config/defaults_test.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"testing"
+
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestThreads(t *testing.T) {
+	tests := []struct {
+		name       string
+		mxs        *mariadbv1alpha1.MaxScale
+		wantString string
+	}{
+		{
+			name: "cpu limit defined",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{
+					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"cpu": resource.MustParse("1"),
+							},
+						},
+					},
+				},
+			},
+			wantString: "1",
+		},
+		{
+			name: "cpu limit defined round up",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{
+					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"cpu": resource.MustParse("200m"),
+							},
+						},
+					},
+				},
+			},
+			wantString: "1",
+		},
+		{
+			name: "resources not defined",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{},
+			},
+			wantString: "auto",
+		},
+		{
+			name: "only requests defined",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{
+					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
+						Resources: &corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"cpu": resource.MustParse("200m"),
+							},
+						},
+					},
+				},
+			},
+			wantString: "auto",
+		},
+		{
+			name: "other limit defined",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{
+					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"memory": resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+			wantString: "auto",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotString := threads(tt.mxs)
+			if tt.wantString != gotString {
+				t.Errorf("unexpected result:\nexpected:\n%s\ngot:\n%s\n", tt.wantString, gotString)
+			}
+		})
+	}
+}
+
+func TestQueryClassifierCacheSize(t *testing.T) {
+	tests := []struct {
+		name       string
+		mxs        *mariadbv1alpha1.MaxScale
+		wantString string
+	}{
+		{
+			name: "memory limit defined",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{
+					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"memory": resource.MustParse("1G"),
+							},
+						},
+					},
+				},
+			},
+			wantString: "150000000",
+		},
+		{
+			name: "resources not defined",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{},
+			},
+			wantString: "",
+		},
+		{
+			name: "only requests defined",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{
+					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
+						Resources: &corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"memory": resource.MustParse("2Gi"),
+							},
+						},
+					},
+				},
+			},
+			wantString: "",
+		},
+		{
+			name: "other limit defined",
+			mxs: &mariadbv1alpha1.MaxScale{
+				Spec: mariadbv1alpha1.MaxScaleSpec{
+					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
+						Resources: &corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{
+								"cpu": resource.MustParse("100m"),
+							},
+						},
+					},
+				},
+			},
+			wantString: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotString := queryClassifierCacheSize(tt.mxs)
+			if tt.wantString != gotString {
+				t.Errorf("unexpected result:\nexpected:\n%s\ngot:\n%s\n", tt.wantString, gotString)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- set threads to auto if cpu limit is not defined
- set threads to cpu limit rounded up if cpu limit is defined
- do not set query_classifier_cache_size if memory limit is not defined
- set query_classifier_cache_size to 15% of memory limit if memory limit is defined
- till allow to override those options with mxs.spec.config.params

Closes https://github.com/mariadb-operator/mariadb-operator/issues/510