### PR TITLE
Ability to opt out from `ignoreGlobalPriv` in `Backup`

### DIFF
--- a/api/v1alpha1/backup_types.go
+++ b/api/v1alpha1/backup_types.go
@@ -74,8 +74,8 @@ type BackupSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Databases []string `json:"databases,omitempty"`
-	// IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups. If not provided, it will default to false.
-	// When backing up MariaDB instances with Galera enabled, mysql.global_priv will be ignored anyway, as it is incompatible with Galera.
+	// IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups.
+	// If not provided, it will default to true when the referred MariaDB instance has Galera enabled and otherwise to false.
 	// See: https://github.com/mariadb-operator/mariadb-operator/issues/556
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -135,6 +135,11 @@ func (in *BackupSpec) DeepCopyInto(out *BackupSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.IgnoreGlobalPriv != nil {
+		in, out := &in.IgnoreGlobalPriv, &out.IgnoreGlobalPriv
+		*out = new(bool)
+		**out = **in
+	}
 	if in.InheritMetadata != nil {
 		in, out := &in.InheritMetadata, &out.InheritMetadata
 		*out = new(Metadata)

--- a/bundle/manifests/k8s.mariadb.com_backups.yaml
+++ b/bundle/manifests/k8s.mariadb.com_backups.yaml
@@ -1122,8 +1122,8 @@ spec:
                 type: array
               ignoreGlobalPriv:
                 description: |-
-                  IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups. If not provided, it will default to false.
-                  When backing up MariaDB instances with Galera enabled, mysql.global_priv will be ignored anyway, as it is incompatible with Galera.
+                  IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups.
+                  If not provided, it will default to true when the referred MariaDB instance has Galera enabled and otherwise to false.
                   See: https://github.com/mariadb-operator/mariadb-operator/issues/556
                 type: boolean
               imagePullSecrets:

--- a/bundle/manifests/mariadb-operator-enterprise.clusterserviceversion.yaml
+++ b/bundle/manifests/mariadb-operator-enterprise.clusterserviceversion.yaml
@@ -371,7 +371,7 @@ metadata:
     categories: Database
     certified: "true"
     containerImage: mariadb/mariadb-operator-enterprise@sha256:181c471bae75418cbefd54fb7d65fe5ac8e341136509e203fc148f216308b713
-    createdAt: "2024-04-12T14:02:19Z"
+    createdAt: "2024-04-15T10:05:37Z"
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
@@ -440,7 +440,7 @@ spec:
           - description: EnvFrom represents the references (via ConfigMap and Secrets) to environment variables to be injected in the container.
             displayName: Env From
             path: envFrom
-          - description: 'IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups. If not provided, it will default to false. When backing up MariaDB instances with Galera enabled, mysql.global_priv will be ignored anyway, as it is incompatible with Galera. See: https://github.com/mariadb-operator/mariadb-operator/issues/556'
+          - description: 'IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups. If not provided, it will default to true when the referred MariaDB instance has Galera enabled and otherwise to false. See: https://github.com/mariadb-operator/mariadb-operator/issues/556'
             displayName: Ignore Global Priv
             path: ignoreGlobalPriv
           - description: ImagePullSecrets is the list of pull Secrets to be used to pull the image.

--- a/config/crd/bases/k8s.mariadb.com_backups.yaml
+++ b/config/crd/bases/k8s.mariadb.com_backups.yaml
@@ -1122,8 +1122,8 @@ spec:
                 type: array
               ignoreGlobalPriv:
                 description: |-
-                  IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups. If not provided, it will default to false.
-                  When backing up MariaDB instances with Galera enabled, mysql.global_priv will be ignored anyway, as it is incompatible with Galera.
+                  IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups.
+                  If not provided, it will default to true when the referred MariaDB instance has Galera enabled and otherwise to false.
                   See: https://github.com/mariadb-operator/mariadb-operator/issues/556
                 type: boolean
               imagePullSecrets:

--- a/config/manifests/bases/mariadb-operator-enterprise.clusterserviceversion.yaml
+++ b/config/manifests/bases/mariadb-operator-enterprise.clusterserviceversion.yaml
@@ -314,9 +314,8 @@ spec:
         displayName: Env From
         path: envFrom
       - description: 'IgnoreGlobalPriv indicates to ignore the mysql.global_priv in
-          backups. If not provided, it will default to false. When backing up MariaDB
-          instances with Galera enabled, mysql.global_priv will be ignored anyway,
-          as it is incompatible with Galera. See: https://github.com/mariadb-operator/mariadb-operator/issues/556'
+          backups. If not provided, it will default to true when the referred MariaDB
+          instance has Galera enabled and otherwise to false. See: https://github.com/mariadb-operator/mariadb-operator/issues/556'
         displayName: Ignore Global Priv
         path: ignoreGlobalPriv
       - description: ImagePullSecrets is the list of pull Secrets to be used to pull

--- a/deploy/charts/mariadb-operator/crds/crds.yaml
+++ b/deploy/charts/mariadb-operator/crds/crds.yaml
@@ -1121,8 +1121,8 @@ spec:
                 type: array
               ignoreGlobalPriv:
                 description: |-
-                  IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups. If not provided, it will default to false.
-                  When backing up MariaDB instances with Galera enabled, mysql.global_priv will be ignored anyway, as it is incompatible with Galera.
+                  IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups.
+                  If not provided, it will default to true when the referred MariaDB instance has Galera enabled and otherwise to false.
                   See: https://github.com/mariadb-operator/mariadb-operator/issues/556
                 type: boolean
               imagePullSecrets:

--- a/deploy/crds/crds.yaml
+++ b/deploy/crds/crds.yaml
@@ -1121,8 +1121,8 @@ spec:
                 type: array
               ignoreGlobalPriv:
                 description: |-
-                  IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups. If not provided, it will default to false.
-                  When backing up MariaDB instances with Galera enabled, mysql.global_priv will be ignored anyway, as it is incompatible with Galera.
+                  IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups.
+                  If not provided, it will default to true when the referred MariaDB instance has Galera enabled and otherwise to false.
                   See: https://github.com/mariadb-operator/mariadb-operator/issues/556
                 type: boolean
               imagePullSecrets:

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -106,7 +106,7 @@ _Appears in:_
 | `schedule` _[Schedule](#schedule)_ | Schedule defines when the Backup will be taken. |  |  |
 | `maxRetention` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#duration-v1-meta)_ | MaxRetention defines the retention policy for backups. Old backups will be cleaned up by the Backup Job.<br />It defaults to 30 days. |  |  |
 | `databases` _string array_ | Databases defines the logical databases to be backed up. If not provided, all databases are backed up. |  |  |
-| `ignoreGlobalPriv` _boolean_ | IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups. If not provided, it will default to false.<br />When backing up MariaDB instances with Galera enabled, mysql.global_priv will be ignored anyway, as it is incompatible with Galera.<br />See: https://github.com/mariadb-operator/mariadb-operator/issues/556 |  |  |
+| `ignoreGlobalPriv` _boolean_ | IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups.<br />If not provided, it will default to true when the referred MariaDB instance has Galera enabled and otherwise to false.<br />See: https://github.com/mariadb-operator/mariadb-operator/issues/556 |  |  |
 | `logLevel` _string_ | LogLevel to be used n the Backup Job. It defaults to 'info'. | info |  |
 | `backoffLimit` _integer_ | BackoffLimit defines the maximum number of attempts to successfully take a Backup. |  |  |
 | `restartPolicy` _[RestartPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#restartpolicy-v1-core)_ | RestartPolicy to be added to the Backup Pod. | OnFailure | Enum: [Always OnFailure Never] <br /> |

--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -9,6 +9,7 @@ import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	backuppkg "github.com/mariadb-operator/mariadb-operator/pkg/backup"
 	ds "github.com/mariadb-operator/mariadb-operator/pkg/datastructures"
+	"k8s.io/utils/ptr"
 )
 
 type BackupOpts struct {
@@ -264,7 +265,7 @@ func (b *BackupCommand) mariadbDumpArgs(backup *mariadbv1alpha1.Backup, mariab *
 	// because the livenessProbe fails due to authentication errors.
 	// Users and grants should be created by the entrypoint or the User and Grant CRs.
 	// See: https://github.com/mariadb-operator/mariadb-operator/issues/556
-	if backup.Spec.IgnoreGlobalPriv || mariab.IsGaleraEnabled() {
+	if ptr.Deref(backup.Spec.IgnoreGlobalPriv, false) {
 		args = append(args, "--ignore-table=mysql.global_priv")
 	}
 

--- a/pkg/command/backup_test.go
+++ b/pkg/command/backup_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	"k8s.io/utils/ptr"
 )
 
 func TestMariadbDumpArgs(t *testing.T) {
@@ -65,7 +66,6 @@ func TestMariadbDumpArgs(t *testing.T) {
 				"--routines",
 				"--all-databases",
 				"--skip-add-locks",
-				"--ignore-table=mysql.global_priv",
 			},
 		},
 		{
@@ -73,7 +73,7 @@ func TestMariadbDumpArgs(t *testing.T) {
 			backupCmd: &BackupCommand{},
 			backup: &mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
-					IgnoreGlobalPriv: true,
+					IgnoreGlobalPriv: ptr.To(true),
 				},
 			},
 			mariadb: &mariadbv1alpha1.MariaDB{},
@@ -226,7 +226,7 @@ func TestMariadbDumpArgs(t *testing.T) {
 						"db2",
 						"db3",
 					},
-					IgnoreGlobalPriv: true,
+					IgnoreGlobalPriv: ptr.To(true),
 				},
 			},
 			mariadb: &mariadbv1alpha1.MariaDB{


### PR DESCRIPTION
Related to https://github.com/mariadb-operator/mariadb-operator/issues/556