### PR TITLE
BREAKING CHANGE: `MaxScale` anti-affinity rules relative to `MariaDB`

### DIFF
--- a/api/v1alpha1/backup_types_test.go
+++ b/api/v1alpha1/backup_types_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Backup types", func() {
 					Spec: BackupSpec{
 						JobPodTemplate: JobPodTemplate{
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 							},
 						},
 					},
@@ -92,7 +92,7 @@ var _ = Describe("Backup types", func() {
 						JobPodTemplate: JobPodTemplate{
 							ServiceAccountName: &objMeta.Name,
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -129,7 +129,7 @@ var _ = Describe("Backup types", func() {
 						JobPodTemplate: JobPodTemplate{
 							ServiceAccountName: ptr.To("backup-test"),
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 							},
 						},
 						MaxRetention:     metav1.Duration{Duration: 10 * 24 * time.Hour},
@@ -151,7 +151,7 @@ var _ = Describe("Backup types", func() {
 						JobPodTemplate: JobPodTemplate{
 							ServiceAccountName: ptr.To("backup-test"),
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/api/v1alpha1/base_types.go
+++ b/api/v1alpha1/base_types.go
@@ -201,7 +201,7 @@ type AffinityConfig struct {
 
 // SetDefaults sets reasonable defaults.
 func (a *AffinityConfig) SetDefaults(antiAffinityInstances ...string) {
-	if ptr.Deref(a.AntiAffinityEnabled, false) && reflect.ValueOf(a.Affinity).IsZero() {
+	if ptr.Deref(a.AntiAffinityEnabled, false) && reflect.ValueOf(a.Affinity).IsZero() && len(antiAffinityInstances) > 0 {
 		a.Affinity = corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/api/v1alpha1/base_types.go
+++ b/api/v1alpha1/base_types.go
@@ -182,7 +182,7 @@ type Job struct {
 // SetDefaults sets reasonable defaults.
 func (j *Job) SetDefaults(mariadbObjMeta metav1.ObjectMeta) {
 	if j.Affinity != nil {
-		j.Affinity.SetDefaults(mariadbObjMeta)
+		j.Affinity.SetDefaults(mariadbObjMeta.Name)
 	}
 }
 
@@ -200,7 +200,7 @@ type AffinityConfig struct {
 }
 
 // SetDefaults sets reasonable defaults.
-func (a *AffinityConfig) SetDefaults(mariadbObjMeta metav1.ObjectMeta) {
+func (a *AffinityConfig) SetDefaults(antiAffinityInstances ...string) {
 	if ptr.Deref(a.AntiAffinityEnabled, false) && reflect.ValueOf(a.Affinity).IsZero() {
 		a.Affinity = corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
@@ -211,9 +211,7 @@ func (a *AffinityConfig) SetDefaults(mariadbObjMeta metav1.ObjectMeta) {
 								{
 									Key:      "app.kubernetes.io/instance",
 									Operator: metav1.LabelSelectorOpIn,
-									Values: []string{
-										mariadbObjMeta.Name,
-									},
+									Values:   antiAffinityInstances,
 								},
 							},
 						},
@@ -283,7 +281,7 @@ func (p *PodTemplate) SetDefaults(objMeta metav1.ObjectMeta) {
 		p.ServiceAccountName = ptr.To(p.ServiceAccountKey(objMeta).Name)
 	}
 	if p.Affinity != nil {
-		p.Affinity.SetDefaults(objMeta)
+		p.Affinity.SetDefaults(objMeta.Name)
 	}
 }
 
@@ -365,7 +363,7 @@ func (p *JobPodTemplate) SetDefaults(objMeta, mariadbObjMeta metav1.ObjectMeta) 
 		p.ServiceAccountName = ptr.To(p.ServiceAccountKey(objMeta).Name)
 	}
 	if p.Affinity != nil {
-		p.Affinity.SetDefaults(mariadbObjMeta)
+		p.Affinity.SetDefaults(mariadbObjMeta.Name)
 	}
 }
 

--- a/api/v1alpha1/base_types.go
+++ b/api/v1alpha1/base_types.go
@@ -192,16 +192,16 @@ type AffinityConfig struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	corev1.Affinity `json:",inline"`
-	// EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+	// AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
 	// Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	EnableAntiAffinity *bool `json:"enableAntiAffinity,omitempty" webhook:"inmutable"`
+	AntiAffinityEnabled *bool `json:"antiAffinityEnabled,omitempty" webhook:"inmutable"`
 }
 
 // SetDefaults sets reasonable defaults.
 func (a *AffinityConfig) SetDefaults(mariadbObjMeta metav1.ObjectMeta) {
-	if ptr.Deref(a.EnableAntiAffinity, false) && reflect.ValueOf(a.Affinity).IsZero() {
+	if ptr.Deref(a.AntiAffinityEnabled, false) && reflect.ValueOf(a.Affinity).IsZero() {
 		a.Affinity = corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/api/v1alpha1/mariadb_galera_types_test.go
+++ b/api/v1alpha1/mariadb_galera_types_test.go
@@ -256,7 +256,7 @@ var _ = Describe("MariaDB Galera types", func() {
 						},
 						InitJob: &Job{
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 							},
 						},
 					},
@@ -305,7 +305,7 @@ var _ = Describe("MariaDB Galera types", func() {
 						},
 						InitJob: &Job{
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -504,7 +504,7 @@ func (m *MariaDB) SetDefaults(env *environment.OperatorEnv) {
 			m.Spec.Metrics.Exporter.Port = 9104
 		}
 		if m.Spec.Metrics.Exporter.Affinity != nil {
-			m.Spec.Metrics.Exporter.Affinity.SetDefaults(m.ObjectMeta)
+			m.Spec.Metrics.Exporter.Affinity.SetDefaults(m.ObjectMeta.Name)
 		}
 		if m.Spec.Metrics.Username == "" {
 			m.Spec.Metrics.Username = m.MetricsKey().Name

--- a/api/v1alpha1/mariadb_types_test.go
+++ b/api/v1alpha1/mariadb_types_test.go
@@ -386,7 +386,7 @@ var _ = Describe("MariaDB types", func() {
 							Exporter: Exporter{
 								PodTemplate: PodTemplate{
 									Affinity: &AffinityConfig{
-										EnableAntiAffinity: ptr.To(true),
+										AntiAffinityEnabled: ptr.To(true),
 									},
 								},
 							},
@@ -415,7 +415,7 @@ var _ = Describe("MariaDB types", func() {
 								Port:  9104,
 								PodTemplate: PodTemplate{
 									Affinity: &AffinityConfig{
-										EnableAntiAffinity: ptr.To(true),
+										AntiAffinityEnabled: ptr.To(true),
 										Affinity: corev1.Affinity{
 											PodAntiAffinity: &corev1.PodAntiAffinity{
 												RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -686,7 +686,7 @@ var _ = Describe("MariaDB types", func() {
 					Spec: MariaDBSpec{
 						PodTemplate: PodTemplate{
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 							},
 						},
 					},
@@ -711,7 +711,7 @@ var _ = Describe("MariaDB types", func() {
 						PodTemplate: PodTemplate{
 							ServiceAccountName: &objMeta.Name,
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -796,7 +796,7 @@ var _ = Describe("MariaDB types", func() {
 						PodTemplate: PodTemplate{
 							ServiceAccountName: ptr.To("mariadb-sa"),
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -889,7 +889,7 @@ var _ = Describe("MariaDB types", func() {
 						PodTemplate: PodTemplate{
 							ServiceAccountName: ptr.To("mariadb-sa"),
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/api/v1alpha1/maxscale_types.go
+++ b/api/v1alpha1/maxscale_types.go
@@ -720,6 +720,9 @@ func (m *MaxScale) SetDefaults(env *environment.OperatorEnv) {
 		if m.Spec.Metrics.Exporter.Port == 0 {
 			m.Spec.Metrics.Exporter.Port = 9105
 		}
+		if m.Spec.Metrics.Exporter.Affinity != nil {
+			m.Spec.Metrics.Exporter.Affinity.SetDefaults(m.ObjectMeta.Name)
+		}
 	}
 
 	m.Spec.PodTemplate.SetDefaults(m.ObjectMeta)

--- a/api/v1alpha1/maxscale_types_test.go
+++ b/api/v1alpha1/maxscale_types_test.go
@@ -200,6 +200,13 @@ var _ = Describe("MaxScale types", func() {
 						},
 						Metrics: &MaxScaleMetrics{
 							Enabled: true,
+							Exporter: Exporter{
+								PodTemplate: PodTemplate{
+									Affinity: &AffinityConfig{
+										AntiAffinityEnabled: ptr.To(true),
+									},
+								},
+							},
 						},
 					},
 				},
@@ -353,6 +360,31 @@ var _ = Describe("MaxScale types", func() {
 							Exporter: Exporter{
 								Image: "mariadb/maxscale-prometheus-exporter-ubi:latest",
 								Port:  9105,
+								PodTemplate: PodTemplate{
+									Affinity: &AffinityConfig{
+										AntiAffinityEnabled: ptr.To(true),
+										Affinity: corev1.Affinity{
+											PodAntiAffinity: &corev1.PodAntiAffinity{
+												RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+													{
+														LabelSelector: &metav1.LabelSelector{
+															MatchExpressions: []metav1.LabelSelectorRequirement{
+																{
+																	Key:      "app.kubernetes.io/instance",
+																	Operator: metav1.LabelSelectorOpIn,
+																	Values: []string{
+																		objMeta.Name,
+																	},
+																},
+															},
+														},
+														TopologyKey: "kubernetes.io/hostname",
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					},

--- a/api/v1alpha1/restore_types_test.go
+++ b/api/v1alpha1/restore_types_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Restore types", func() {
 					Spec: RestoreSpec{
 						JobPodTemplate: JobPodTemplate{
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 							},
 						},
 					},
@@ -63,7 +63,7 @@ var _ = Describe("Restore types", func() {
 						JobPodTemplate: JobPodTemplate{
 							ServiceAccountName: &objMeta.Name,
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -98,7 +98,7 @@ var _ = Describe("Restore types", func() {
 						JobPodTemplate: JobPodTemplate{
 							ServiceAccountName: ptr.To("restore-test"),
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 							},
 						},
 						BackoffLimit: 3,
@@ -113,7 +113,7 @@ var _ = Describe("Restore types", func() {
 						JobPodTemplate: JobPodTemplate{
 							ServiceAccountName: ptr.To("restore-test"),
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/api/v1alpha1/sqljob_types_test.go
+++ b/api/v1alpha1/sqljob_types_test.go
@@ -49,7 +49,7 @@ var _ = Describe("SqlJob types", func() {
 					Spec: SqlJobSpec{
 						JobPodTemplate: JobPodTemplate{
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 							},
 						},
 					},
@@ -63,7 +63,7 @@ var _ = Describe("SqlJob types", func() {
 						JobPodTemplate: JobPodTemplate{
 							ServiceAccountName: &objMeta.Name,
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
@@ -98,7 +98,7 @@ var _ = Describe("SqlJob types", func() {
 						JobPodTemplate: JobPodTemplate{
 							ServiceAccountName: ptr.To("sqljob-test"),
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 							},
 						},
 						BackoffLimit: 3,
@@ -113,7 +113,7 @@ var _ = Describe("SqlJob types", func() {
 						JobPodTemplate: JobPodTemplate{
 							ServiceAccountName: ptr.To("sqljob-test"),
 							Affinity: &AffinityConfig{
-								EnableAntiAffinity: ptr.To(true),
+								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{
 									PodAntiAffinity: &corev1.PodAntiAffinity{
 										RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -41,8 +41,8 @@ import (
 func (in *AffinityConfig) DeepCopyInto(out *AffinityConfig) {
 	*out = *in
 	in.Affinity.DeepCopyInto(&out.Affinity)
-	if in.EnableAntiAffinity != nil {
-		in, out := &in.EnableAntiAffinity, &out.EnableAntiAffinity
+	if in.AntiAffinityEnabled != nil {
+		in, out := &in.AntiAffinityEnabled, &out.AntiAffinityEnabled
 		*out = new(bool)
 		**out = **in
 	}

--- a/bundle/manifests/k8s.mariadb.com_backups.yaml
+++ b/bundle/manifests/k8s.mariadb.com_backups.yaml
@@ -58,9 +58,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:

--- a/bundle/manifests/k8s.mariadb.com_mariadbs.yaml
+++ b/bundle/manifests/k8s.mariadb.com_mariadbs.yaml
@@ -58,9 +58,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -971,12 +971,11 @@ spec:
                       Job used to perform the Restore.
                     properties:
                       affinity:
-                        description: Affinity defines policies to schedule the bootstrap
-                          Pods in Nodes.
+                        description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -5757,15 +5756,983 @@ spec:
                     description: InitJob defines metadata to the passed to the initialization
                       Job.
                     properties:
-                      annotations:
-                        additionalProperties:
-                          type: string
-                        description: Annotations to be added to children resources.
+                      affinity:
+                        description: Affinity to be used in the Pod.
+                        properties:
+                          antiAffinityEnabled:
+                            description: |-
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+                            type: boolean
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules
+                              for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: |-
+                                    An empty preferred scheduling term matches all objects with implicit weight 0
+                                    (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated
+                                        with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    weight:
+                                      description: Weight associated with matching
+                                        the corresponding nodeSelectorTerm, in the
+                                        range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to an update), the system
+                                  may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector
+                                      terms. The terms are ORed.
+                                    items:
+                                      description: |-
+                                        A null or empty node selector term matches no objects. The requirements of
+                                        them are ANDed.
+                                        The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements
+                                            by node's labels.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements
+                                            by node's fields.
+                                          items:
+                                            description: |-
+                                              A node selector requirement is a selector that contains values, a key, and an operator
+                                              that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the
+                                                  selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  Represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  An array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. If the operator is Gt or Lt, the values
+                                                  array must have a single element, which will be interpreted as an integer.
+                                                  This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g.
+                              co-locate this pod in the same node, zone, etc. as some
+                              other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                            Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                            Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules
+                              (e.g. avoid putting this pod in the same node, zone,
+                              etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  The scheduler will prefer to schedule pods to nodes that satisfy
+                                  the anti-affinity expressions specified by this field, but it may choose
+                                  a node that violates one or more of the expressions. The node that is
+                                  most preferred is the one with the greatest sum of weights, i.e.
+                                  for each node that meets all of the scheduling requirements (resource
+                                  request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                  compute a sum by iterating through the elements of this field and adding
+                                  "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                  node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm
+                                    fields are added per-node to find the most preferred
+                                    node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term,
+                                        associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: |-
+                                            A label query over a set of resources, in this case pods.
+                                            If it's null, this PodAffinityTerm matches with no Pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        matchLabelKeys:
+                                          description: |-
+                                            MatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                            Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        mismatchLabelKeys:
+                                          description: |-
+                                            MismatchLabelKeys is a set of pod label keys to select which pods will
+                                            be taken into consideration. The keys are used to lookup values from the
+                                            incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                            to select the group of existing pods which pods will be taken into consideration
+                                            for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                            pod labels will be ignored. The default value is empty.
+                                            The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                            Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                            This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                          items:
+                                            type: string
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        namespaceSelector:
+                                          description: |-
+                                            A label query over the set of namespaces that the term applies to.
+                                            The term is applied to the union of the namespaces selected by this field
+                                            and the ones listed in the namespaces field.
+                                            null selector and null or empty namespaces list means "this pod's namespace".
+                                            An empty selector ({}) matches all namespaces.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: |-
+                                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                                  relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: |-
+                                                      operator represents a key's relationship to a set of values.
+                                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: |-
+                                                      values is an array of string values. If the operator is In or NotIn,
+                                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                      the values array must be empty. This array is replaced during a strategic
+                                                      merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: |-
+                                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        namespaces:
+                                          description: |-
+                                            namespaces specifies a static list of namespace names that the term applies to.
+                                            The term is applied to the union of the namespaces listed in this field
+                                            and the ones selected by namespaceSelector.
+                                            null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: |-
+                                            This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                            the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                            whose value of the label with key topologyKey matches that of any node on which any of the
+                                            selected pods is running.
+                                            Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: |-
+                                        weight associated with matching the corresponding podAffinityTerm,
+                                        in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: |-
+                                  If the anti-affinity requirements specified by this field are not met at
+                                  scheduling time, the pod will not be scheduled onto the node.
+                                  If the anti-affinity requirements specified by this field cease to be met
+                                  at some point during pod execution (e.g. due to a pod label update), the
+                                  system may or may not try to eventually evict the pod from its node.
+                                  When there are multiple elements, the lists of nodes corresponding to each
+                                  podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: |-
+                                    Defines a set of pods (namely those matching the labelSelector
+                                    relative to the given namespace(s)) that this pod should be
+                                    co-located (affinity) or not co-located (anti-affinity) with,
+                                    where co-located is defined as running on a node whose value of
+                                    the label with key <topologyKey> matches that of any node on which
+                                    a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: |-
+                                        A label query over a set of resources, in this case pods.
+                                        If it's null, this PodAffinityTerm matches with no Pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    matchLabelKeys:
+                                      description: |-
+                                        MatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                        Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    mismatchLabelKeys:
+                                      description: |-
+                                        MismatchLabelKeys is a set of pod label keys to select which pods will
+                                        be taken into consideration. The keys are used to lookup values from the
+                                        incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                        to select the group of existing pods which pods will be taken into consideration
+                                        for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                        pod labels will be ignored. The default value is empty.
+                                        The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                        Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                        This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    namespaceSelector:
+                                      description: |-
+                                        A label query over the set of namespaces that the term applies to.
+                                        The term is applied to the union of the namespaces selected by this field
+                                        and the ones listed in the namespaces field.
+                                        null selector and null or empty namespaces list means "this pod's namespace".
+                                        An empty selector ({}) matches all namespaces.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    namespaces:
+                                      description: |-
+                                        namespaces specifies a static list of namespace names that the term applies to.
+                                        The term is applied to the union of the namespaces listed in this field
+                                        and the ones selected by namespaceSelector.
+                                        null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: |-
+                                        This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                        the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                        whose value of the label with key topologyKey matches that of any node on which any of the
+                                        selected pods is running.
+                                        Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
                         type: object
-                      labels:
-                        additionalProperties:
+                      args:
+                        description: Args to be used in the Container.
+                        items:
                           type: string
-                        description: Labels to be added to children resources.
+                        type: array
+                      metadata:
+                        description: Metadata defines additional metadata for the
+                          bootstrap Jobs.
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations to be added to children resources.
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels to be added to children resources.
+                            type: object
+                        type: object
+                      resources:
+                        description: Resouces describes the compute resource requirements.
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
                         type: object
                     type: object
                   primary:
@@ -7410,9 +8377,9 @@ spec:
                           affinity:
                             description: Affinity to be used in the Pod.
                             properties:
-                              enableAntiAffinity:
+                              antiAffinityEnabled:
                                 description: |-
-                                  EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                                  AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                                   Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                                 type: boolean
                               nodeAffinity:
@@ -13029,9 +13996,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:

--- a/bundle/manifests/k8s.mariadb.com_maxscales.yaml
+++ b/bundle/manifests/k8s.mariadb.com_maxscales.yaml
@@ -70,9 +70,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -2696,9 +2696,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:

--- a/bundle/manifests/k8s.mariadb.com_restores.yaml
+++ b/bundle/manifests/k8s.mariadb.com_restores.yaml
@@ -58,9 +58,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:

--- a/bundle/manifests/k8s.mariadb.com_sqljobs.yaml
+++ b/bundle/manifests/k8s.mariadb.com_sqljobs.yaml
@@ -58,9 +58,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:

--- a/bundle/manifests/mariadb-operator-enterprise.clusterserviceversion.yaml
+++ b/bundle/manifests/mariadb-operator-enterprise.clusterserviceversion.yaml
@@ -371,7 +371,7 @@ metadata:
     categories: Database
     certified: "true"
     containerImage: mariadb/mariadb-operator-enterprise@sha256:181c471bae75418cbefd54fb7d65fe5ac8e341136509e203fc148f216308b713
-    createdAt: "2024-04-18T14:35:43Z"
+    createdAt: "2024-04-18T18:03:00Z"
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
@@ -3974,10 +3974,6 @@ spec:
   provider:
     name: MariaDB Corporation
   relatedImages:
-    - image: mariadb/mariadb-operator-enterprise@sha256:181c471bae75418cbefd54fb7d65fe5ac8e341136509e203fc148f216308b713
-      name: mariadb-operator-enterprise
-    - image: mariadb/maxscale-prometheus-exporter-ubi@sha256:9c46ec50a349d4c91a78ad34cc56e3bdad84ac7e8d92af101d98bcc55268142f
-      name: exporter_maxscale
     - image: us-central1-docker.pkg.dev/mariadb-es-docker-registry/enterprise-docker/enterprise-server@sha256:45269c911cdefc16a1c14c092580ed4e3afb85c4c6801283681d9c0ac1f1fad7
       name: mariadb
     - image: mariadb/maxscale@sha256:f2ce262fe7764e16da2b01bdf2fb2fc777bb66f688ec4c8ef37d50de2995ce12
@@ -3986,6 +3982,10 @@ spec:
       name: exporter
     - image: mariadb/maxscale-prometheus-exporter-ubi@sha256:9c46ec50a349d4c91a78ad34cc56e3bdad84ac7e8d92af101d98bcc55268142f
       name: exporter-maxscale
+    - image: mariadb/mariadb-operator-enterprise@sha256:181c471bae75418cbefd54fb7d65fe5ac8e341136509e203fc148f216308b713
+      name: mariadb-operator-enterprise
+    - image: mariadb/maxscale-prometheus-exporter-ubi@sha256:9c46ec50a349d4c91a78ad34cc56e3bdad84ac7e8d92af101d98bcc55268142f
+      name: exporter_maxscale
   version: 0.0.27
   webhookdefinitions:
     - admissionReviewVersions:

--- a/bundle/manifests/mariadb-operator-enterprise.clusterserviceversion.yaml
+++ b/bundle/manifests/mariadb-operator-enterprise.clusterserviceversion.yaml
@@ -371,7 +371,7 @@ metadata:
     categories: Database
     certified: "true"
     containerImage: mariadb/mariadb-operator-enterprise@sha256:181c471bae75418cbefd54fb7d65fe5ac8e341136509e203fc148f216308b713
-    createdAt: "2024-04-16T08:08:28Z"
+    createdAt: "2024-04-18T14:35:43Z"
     features.operators.openshift.io/disconnected: "false"
     features.operators.openshift.io/fips-compliant: "false"
     features.operators.openshift.io/proxy-aware: "false"
@@ -417,9 +417,9 @@ spec:
           - description: Affinity to be used in the Pod.
             displayName: Affinity
             path: affinity
-          - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
-            displayName: Enable Anti Affinity
-            path: affinity.enableAntiAffinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: affinity.antiAffinityEnabled
           - description: Args to be used in the Container.
             displayName: Args
             path: args
@@ -799,9 +799,9 @@ spec:
           - description: Affinity to be used in the Pod.
             displayName: Affinity
             path: affinity
-          - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
-            displayName: Enable Anti Affinity
-            path: affinity.enableAntiAffinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: affinity.antiAffinityEnabled
           - description: Args to be used in the Container.
             displayName: Args
             path: args
@@ -814,12 +814,12 @@ spec:
           - description: RestoreJob defines additional properties for the Job used to perform the Restore.
             displayName: Restore Job
             path: bootstrapFrom.restoreJob
-          - description: Affinity defines policies to schedule the bootstrap Pods in Nodes.
+          - description: Affinity to be used in the Pod.
             displayName: Affinity
             path: bootstrapFrom.restoreJob.affinity
-          - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
-            displayName: Enable Anti Affinity
-            path: bootstrapFrom.restoreJob.affinity.enableAntiAffinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: bootstrapFrom.restoreJob.affinity.antiAffinityEnabled
           - description: Args to be used in the Container.
             displayName: Args
             path: bootstrapFrom.restoreJob.args
@@ -1082,12 +1082,29 @@ spec:
           - description: InitJob defines metadata to the passed to the initialization Job.
             displayName: Init Job
             path: galera.initJob
+          - description: Affinity to be used in the Pod.
+            displayName: Affinity
+            path: galera.initJob.affinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: galera.initJob.affinity.antiAffinityEnabled
+          - description: Args to be used in the Container.
+            displayName: Args
+            path: galera.initJob.args
+          - description: Metadata defines additional metadata for the bootstrap Jobs.
+            displayName: Metadata
+            path: galera.initJob.metadata
           - description: Annotations to be added to children resources.
             displayName: Annotations
-            path: galera.initJob.annotations
+            path: galera.initJob.metadata.annotations
           - description: Labels to be added to children resources.
             displayName: Labels
-            path: galera.initJob.labels
+            path: galera.initJob.metadata.labels
+          - description: Resouces describes the compute resource requirements.
+            displayName: Resources
+            path: galera.initJob.resources
+            x-descriptors:
+              - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
           - description: Primary is the Galera configuration for the primary node.
             displayName: Primary
             path: galera.primary
@@ -1429,9 +1446,9 @@ spec:
           - description: Affinity to be used in the Pod.
             displayName: Affinity
             path: maxScale.metrics.exporter.affinity
-          - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
-            displayName: Enable Anti Affinity
-            path: maxScale.metrics.exporter.affinity.enableAntiAffinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: maxScale.metrics.exporter.affinity.antiAffinityEnabled
           - description: Args to be used in the Container.
             displayName: Args
             path: maxScale.metrics.exporter.args
@@ -1697,9 +1714,9 @@ spec:
           - description: Affinity to be used in the Pod.
             displayName: Affinity
             path: metrics.exporter.affinity
-          - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
-            displayName: Enable Anti Affinity
-            path: metrics.exporter.affinity.enableAntiAffinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: metrics.exporter.affinity.antiAffinityEnabled
           - description: Args to be used in the Container.
             displayName: Args
             path: metrics.exporter.args
@@ -2379,9 +2396,9 @@ spec:
           - description: Affinity to be used in the Pod.
             displayName: Affinity
             path: affinity
-          - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
-            displayName: Enable Anti Affinity
-            path: affinity.enableAntiAffinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: affinity.antiAffinityEnabled
           - description: Args to be used in the Container.
             displayName: Args
             path: args
@@ -2665,9 +2682,9 @@ spec:
           - description: Affinity to be used in the Pod.
             displayName: Affinity
             path: metrics.exporter.affinity
-          - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
-            displayName: Enable Anti Affinity
-            path: metrics.exporter.affinity.enableAntiAffinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: metrics.exporter.affinity.antiAffinityEnabled
           - description: Args to be used in the Container.
             displayName: Args
             path: metrics.exporter.args
@@ -3071,9 +3088,9 @@ spec:
           - description: Affinity to be used in the Pod.
             displayName: Affinity
             path: affinity
-          - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
-            displayName: Enable Anti Affinity
-            path: affinity.enableAntiAffinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: affinity.antiAffinityEnabled
           - description: Args to be used in the Container.
             displayName: Args
             path: args
@@ -3216,9 +3233,9 @@ spec:
           - description: Affinity to be used in the Pod.
             displayName: Affinity
             path: affinity
-          - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
-            displayName: Enable Anti Affinity
-            path: affinity.enableAntiAffinity
+          - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA. Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
+            displayName: Anti Affinity Enabled
+            path: affinity.antiAffinityEnabled
           - description: Args to be used in the Container.
             displayName: Args
             path: args

--- a/config/crd/bases/k8s.mariadb.com_backups.yaml
+++ b/config/crd/bases/k8s.mariadb.com_backups.yaml
@@ -58,9 +58,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -58,9 +58,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -973,9 +973,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -5759,9 +5759,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -8377,9 +8377,9 @@ spec:
                           affinity:
                             description: Affinity to be used in the Pod.
                             properties:
-                              enableAntiAffinity:
+                              antiAffinityEnabled:
                                 description: |-
-                                  EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                                  AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                                   Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                                 type: boolean
                               nodeAffinity:
@@ -13996,9 +13996,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:

--- a/config/crd/bases/k8s.mariadb.com_maxscales.yaml
+++ b/config/crd/bases/k8s.mariadb.com_maxscales.yaml
@@ -70,9 +70,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -2696,9 +2696,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:

--- a/config/crd/bases/k8s.mariadb.com_restores.yaml
+++ b/config/crd/bases/k8s.mariadb.com_restores.yaml
@@ -58,9 +58,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:

--- a/config/crd/bases/k8s.mariadb.com_sqljobs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_sqljobs.yaml
@@ -58,9 +58,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:

--- a/config/manifests/bases/mariadb-operator-enterprise.clusterserviceversion.yaml
+++ b/config/manifests/bases/mariadb-operator-enterprise.clusterserviceversion.yaml
@@ -284,11 +284,11 @@ spec:
       - description: Affinity to be used in the Pod.
         displayName: Affinity
         path: affinity
-      - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
           scheduled in a different Node, enabling HA. Make sure you have at least
           as many Nodes available as the replicas to not end up with unscheduled Pods.
-        displayName: Enable Anti Affinity
-        path: affinity.enableAntiAffinity
+        displayName: Anti Affinity Enabled
+        path: affinity.antiAffinityEnabled
       - description: Args to be used in the Container.
         displayName: Args
         path: args
@@ -700,11 +700,11 @@ spec:
       - description: Affinity to be used in the Pod.
         displayName: Affinity
         path: affinity
-      - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
           scheduled in a different Node, enabling HA. Make sure you have at least
           as many Nodes available as the replicas to not end up with unscheduled Pods.
-        displayName: Enable Anti Affinity
-        path: affinity.enableAntiAffinity
+        displayName: Anti Affinity Enabled
+        path: affinity.antiAffinityEnabled
       - description: Args to be used in the Container.
         displayName: Args
         path: args
@@ -719,14 +719,14 @@ spec:
           perform the Restore.
         displayName: Restore Job
         path: bootstrapFrom.restoreJob
-      - description: Affinity defines policies to schedule the bootstrap Pods in Nodes.
+      - description: Affinity to be used in the Pod.
         displayName: Affinity
         path: bootstrapFrom.restoreJob.affinity
-      - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
           scheduled in a different Node, enabling HA. Make sure you have at least
           as many Nodes available as the replicas to not end up with unscheduled Pods.
-        displayName: Enable Anti Affinity
-        path: bootstrapFrom.restoreJob.affinity.enableAntiAffinity
+        displayName: Anti Affinity Enabled
+        path: bootstrapFrom.restoreJob.affinity.antiAffinityEnabled
       - description: Args to be used in the Container.
         displayName: Args
         path: bootstrapFrom.restoreJob.args
@@ -1027,12 +1027,31 @@ spec:
           Job.
         displayName: Init Job
         path: galera.initJob
+      - description: Affinity to be used in the Pod.
+        displayName: Affinity
+        path: galera.initJob.affinity
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
+          scheduled in a different Node, enabling HA. Make sure you have at least
+          as many Nodes available as the replicas to not end up with unscheduled Pods.
+        displayName: Anti Affinity Enabled
+        path: galera.initJob.affinity.antiAffinityEnabled
+      - description: Args to be used in the Container.
+        displayName: Args
+        path: galera.initJob.args
+      - description: Metadata defines additional metadata for the bootstrap Jobs.
+        displayName: Metadata
+        path: galera.initJob.metadata
       - description: Annotations to be added to children resources.
         displayName: Annotations
-        path: galera.initJob.annotations
+        path: galera.initJob.metadata.annotations
       - description: Labels to be added to children resources.
         displayName: Labels
-        path: galera.initJob.labels
+        path: galera.initJob.metadata.labels
+      - description: Resouces describes the compute resource requirements.
+        displayName: Resources
+        path: galera.initJob.resources
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
       - description: Primary is the Galera configuration for the primary node.
         displayName: Primary
         path: galera.primary
@@ -1448,11 +1467,11 @@ spec:
       - description: Affinity to be used in the Pod.
         displayName: Affinity
         path: maxScale.metrics.exporter.affinity
-      - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
           scheduled in a different Node, enabling HA. Make sure you have at least
           as many Nodes available as the replicas to not end up with unscheduled Pods.
-        displayName: Enable Anti Affinity
-        path: maxScale.metrics.exporter.affinity.enableAntiAffinity
+        displayName: Anti Affinity Enabled
+        path: maxScale.metrics.exporter.affinity.antiAffinityEnabled
       - description: Args to be used in the Container.
         displayName: Args
         path: maxScale.metrics.exporter.args
@@ -1760,11 +1779,11 @@ spec:
       - description: Affinity to be used in the Pod.
         displayName: Affinity
         path: metrics.exporter.affinity
-      - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
           scheduled in a different Node, enabling HA. Make sure you have at least
           as many Nodes available as the replicas to not end up with unscheduled Pods.
-        displayName: Enable Anti Affinity
-        path: metrics.exporter.affinity.enableAntiAffinity
+        displayName: Anti Affinity Enabled
+        path: metrics.exporter.affinity.antiAffinityEnabled
       - description: Args to be used in the Container.
         displayName: Args
         path: metrics.exporter.args
@@ -2511,11 +2530,11 @@ spec:
       - description: Affinity to be used in the Pod.
         displayName: Affinity
         path: affinity
-      - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
           scheduled in a different Node, enabling HA. Make sure you have at least
           as many Nodes available as the replicas to not end up with unscheduled Pods.
-        displayName: Enable Anti Affinity
-        path: affinity.enableAntiAffinity
+        displayName: Anti Affinity Enabled
+        path: affinity.antiAffinityEnabled
       - description: Args to be used in the Container.
         displayName: Args
         path: args
@@ -2853,11 +2872,11 @@ spec:
       - description: Affinity to be used in the Pod.
         displayName: Affinity
         path: metrics.exporter.affinity
-      - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
           scheduled in a different Node, enabling HA. Make sure you have at least
           as many Nodes available as the replicas to not end up with unscheduled Pods.
-        displayName: Enable Anti Affinity
-        path: metrics.exporter.affinity.enableAntiAffinity
+        displayName: Anti Affinity Enabled
+        path: metrics.exporter.affinity.antiAffinityEnabled
       - description: Args to be used in the Container.
         displayName: Args
         path: metrics.exporter.args
@@ -3317,11 +3336,11 @@ spec:
       - description: Affinity to be used in the Pod.
         displayName: Affinity
         path: affinity
-      - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
           scheduled in a different Node, enabling HA. Make sure you have at least
           as many Nodes available as the replicas to not end up with unscheduled Pods.
-        displayName: Enable Anti Affinity
-        path: affinity.enableAntiAffinity
+        displayName: Anti Affinity Enabled
+        path: affinity.antiAffinityEnabled
       - description: Args to be used in the Container.
         displayName: Args
         path: args
@@ -3486,11 +3505,11 @@ spec:
       - description: Affinity to be used in the Pod.
         displayName: Affinity
         path: affinity
-      - description: EnableAntiAffinity configures PodAntiAffinity so each Pod is
+      - description: AntiAffinityEnabled configures PodAntiAffinity so each Pod is
           scheduled in a different Node, enabling HA. Make sure you have at least
           as many Nodes available as the replicas to not end up with unscheduled Pods.
-        displayName: Enable Anti Affinity
-        path: affinity.enableAntiAffinity
+        displayName: Anti Affinity Enabled
+        path: affinity.antiAffinityEnabled
       - description: Args to be used in the Container.
         displayName: Args
         path: args

--- a/controller/maxscale_controller.go
+++ b/controller/maxscale_controller.go
@@ -306,7 +306,7 @@ func (r *MaxScaleReconciler) setSpecDefaults(ctx context.Context, req *requestMa
 		}
 	}
 	if err := r.patch(ctx, req.mxs, func(mxs *mariadbv1alpha1.MaxScale) {
-		mxs.SetDefaults(r.Environment)
+		mxs.SetDefaults(r.Environment, nil)
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error setting defaults: %v", err)
 	}
@@ -353,7 +353,7 @@ func (r *MaxScaleReconciler) setMariadbDefaults(ctx context.Context, req *reques
 		if mxs.Spec.Monitor.Params == nil {
 			mxs.Spec.Monitor.Params = monitorParams
 		}
-		mxs.SetDefaults(r.Environment)
+		mxs.SetDefaults(r.Environment, mdb)
 	})
 }
 

--- a/deploy/charts/mariadb-operator/crds/crds.yaml
+++ b/deploy/charts/mariadb-operator/crds/crds.yaml
@@ -57,9 +57,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -4457,9 +4457,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -5372,9 +5372,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -10158,9 +10158,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -12776,9 +12776,9 @@ spec:
                           affinity:
                             description: Affinity to be used in the Pod.
                             properties:
-                              enableAntiAffinity:
+                              antiAffinityEnabled:
                                 description: |-
-                                  EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                                  AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                                   Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                                 type: boolean
                               nodeAffinity:
@@ -18395,9 +18395,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -28015,9 +28015,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -30641,9 +30641,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -39696,9 +39696,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -43103,9 +43103,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:

--- a/deploy/crds/crds.yaml
+++ b/deploy/crds/crds.yaml
@@ -57,9 +57,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -4457,9 +4457,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -5372,9 +5372,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -10158,9 +10158,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -12776,9 +12776,9 @@ spec:
                           affinity:
                             description: Affinity to be used in the Pod.
                             properties:
-                              enableAntiAffinity:
+                              antiAffinityEnabled:
                                 description: |-
-                                  EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                                  AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                                   Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                                 type: boolean
                               nodeAffinity:
@@ -18395,9 +18395,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -28015,9 +28015,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -30641,9 +30641,9 @@ spec:
                       affinity:
                         description: Affinity to be used in the Pod.
                         properties:
-                          enableAntiAffinity:
+                          antiAffinityEnabled:
                             description: |-
-                              EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                              AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                               Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                             type: boolean
                           nodeAffinity:
@@ -39696,9 +39696,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:
@@ -43103,9 +43103,9 @@ spec:
               affinity:
                 description: Affinity to be used in the Pod.
                 properties:
-                  enableAntiAffinity:
+                  antiAffinityEnabled:
                     description: |-
-                      EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
+                      AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.
                       Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods.
                     type: boolean
                   nodeAffinity:

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -45,7 +45,7 @@ _Appears in:_
 | `nodeAffinity` _[NodeAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#nodeaffinity-v1-core)_ | Describes node affinity scheduling rules for the pod. |  |  |
 | `podAffinity` _[PodAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podaffinity-v1-core)_ | Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)). |  |  |
 | `podAntiAffinity` _[PodAntiAffinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#podantiaffinity-v1-core)_ | Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)). |  |  |
-| `enableAntiAffinity` _boolean_ | EnableAntiAffinity configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.<br />Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods. |  |  |
+| `antiAffinityEnabled` _boolean_ | AntiAffinityEnabled configures PodAntiAffinity so each Pod is scheduled in a different Node, enabling HA.<br />Make sure you have at least as many Nodes available as the replicas to not end up with unscheduled Pods. |  |  |
 
 
 #### Backup

--- a/pkg/builder/pod_builder_test.go
+++ b/pkg/builder/pod_builder_test.go
@@ -514,8 +514,8 @@ func TestMariadbPodBuilder(t *testing.T) {
 	}
 	opts := []mariadbOpt{
 		withAffinity(&mariadbv1alpha1.AffinityConfig{
-			EnableAntiAffinity: ptr.To(true),
-			Affinity:           corev1.Affinity{},
+			AntiAffinityEnabled: ptr.To(true),
+			Affinity:            corev1.Affinity{},
 		}),
 		withResources(&corev1.ResourceRequirements{
 			Requests: corev1.ResourceList{

--- a/pkg/builder/restore_builder_test.go
+++ b/pkg/builder/restore_builder_test.go
@@ -78,8 +78,8 @@ func TestBuildRestore(t *testing.T) {
 			BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
 				RestoreJob: &mariadbv1alpha1.Job{
 					Affinity: &mariadbv1alpha1.AffinityConfig{
-						EnableAntiAffinity: ptr.To(true),
-						Affinity:           corev1.Affinity{},
+						AntiAffinityEnabled: ptr.To(true),
+						Affinity:            corev1.Affinity{},
 					},
 					Resources: &corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{


### PR DESCRIPTION
Closes https://github.com/mariadb-operator/mariadb-operator/issues/565

Related to:
- https://github.com/mariadb-operator/mariadb-operator/pull/566

__BREAKING CHANGES__:
- `affinity.enableAntiAffinity` has been renamed to `affinity.antiAffinityEnabled`. This affects to `MariaDB`, `Backup`, `Restore` and `SqlJob` CRs.