### PR TITLE
Fix cluster size context error in galera recovery

### DIFF
--- a/controller/statefulset_galera_controller.go
+++ b/controller/statefulset_galera_controller.go
@@ -123,17 +123,19 @@ func (r *StatefulSetGaleraReconciler) isHealthy(ctx context.Context, stsObjMeta 
 		return false, nil
 	}
 
-	clientCtx, cancelClient := context.WithTimeout(ctx, 5*time.Second)
-	defer cancelClient()
-
 	clientSet := sqlClientSet.NewClientSet(mdb, r.RefResolver)
 	defer clientSet.Close()
+
+	clientCtx, cancelClient := context.WithTimeout(ctx, 5*time.Second)
+	defer cancelClient()
 	client, err := r.readyClient(clientCtx, mdb, clientSet)
 	if err != nil {
 		return false, fmt.Errorf("error getting ready client: %v", err)
 	}
 
-	size, err := client.GaleraClusterSize(clientCtx)
+	clusterSizeCtx, clusterSizeCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer clusterSizeCancel()
+	size, err := client.GaleraClusterSize(clusterSizeCtx)
 	if err != nil {
 		return false, fmt.Errorf("error getting Galera cluster size: %v", err)
 	}

--- a/controller/statefulset_galera_controller.go
+++ b/controller/statefulset_galera_controller.go
@@ -69,8 +69,7 @@ func (r *StatefulSetGaleraReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	healthy, err := r.pollUntilHealthyWithTimeout(healthyCtx, sts.ObjectMeta, logger)
 	if err != nil {
-		logger.V(1).Info("Error polling MariaDB health", "err", err)
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, fmt.Errorf("error polling MariaDB health: %v", err)
 	}
 	if healthy {
 		return r.monitorResult(mariadb), nil


### PR DESCRIPTION
Galera cluster size request was silently failing, as it was logged in debug level:
```json
{"level":"debug","ts":1713891190.8048348,"logger":"galera.health","msg":"Error polling MariaDB health","controller":"statefulset","controllerGroup":"apps","controllerKind":"StatefulSet","StatefulSet":{"name":"mariadb-galera","namespace":"default"},"namespace":"default","name":"mariadb-galera","reconcileID":"07507b47-459b-42e5-8f8d-1322f4fa007d","err":"error polling health: error getting Galera cluster size: context deadline exceeded"}
```
The issue was resolved by:
- Having a dedicated context for each request.
- Return an error to the controller so it gets logged.