### PR TITLE
Decouple Galera cluster recovery from control plane where possible

### DIFF
--- a/controller/mariadb_controller_status.go
+++ b/controller/mariadb_controller_status.go
@@ -35,7 +35,7 @@ func (r *MariaDBReconciler) reconcileStatus(ctx context.Context, mdb *mariadbv1a
 		log.FromContext(ctx).V(1).Info("error getting MaxScale primary Pod", "err", mxsErr)
 	}
 	var initJob *batchv1.Job
-	if mdb.IsGaleraEnabled() {
+	if mdb.IsGaleraEnabled() && !mdb.HasGaleraConfiguredCondition() {
 		var err error
 		initJob, err = r.getInitJob(ctx, mdb)
 		if err != nil {

--- a/pkg/controller/galera/recovery.go
+++ b/pkg/controller/galera/recovery.go
@@ -448,7 +448,7 @@ func (r *GaleraReconciler) pollUntilPodSynced(ctx context.Context, podKey types.
 		}
 		sqlClient, err := sqlClientSet.ClientForIndex(ctx, *podIndex, sql.WithTimeout(5*time.Second))
 		if err != nil {
-			return fmt.Errorf("errpr getting SQL client: %v", err)
+			return fmt.Errorf("error getting SQL client: %v", err)
 		}
 
 		synced, err := galeraclient.IsPodSynced(ctx, sqlClient)


### PR DESCRIPTION
Kubenetes requests should not determine whether MariaDB is healthy or not. For example: control-plane down should not trigger a cluster recovery.