### PR TITLE
Fix reconcile always refresh service nodeport number

### DIFF
--- a/pkg/controller/service/controller.go
+++ b/pkg/controller/service/controller.go
@@ -78,7 +78,7 @@ func updateServicePorts(existingSvc, desiredSvc *corev1.Service) {
 		}
 	}
 
-	if desiredSvc.Spec.Type != corev1.ServiceTypeNodePort {
+	if desiredSvc.Spec.Type != corev1.ServiceTypeNodePort && desiredSvc.Spec.Type != corev1.ServiceTypeLoadBalancer {
 		for i := range existingSvc.Spec.Ports {
 			existingSvc.Spec.Ports[i].NodePort = 0
 		}

--- a/pkg/controller/service/controller_test.go
+++ b/pkg/controller/service/controller_test.go
@@ -187,4 +187,58 @@ func Test_updateServicePorts(t *testing.T) {
 			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
 		}
 	})
+
+	t.Run("Desired service has LoadBalancer type and existing port has non-zero NodePort", func(t *testing.T) {
+		existingSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+						NodePort: 30000,
+					},
+					{
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+						NodePort: 30001,
+					},
+				},
+			},
+		}
+
+		desiredSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeLoadBalancer,
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		expectedSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+						NodePort: 30000,
+					},
+					{
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+						NodePort: 30001,
+					},
+				},
+			},
+		}
+
+		updateServicePorts(existingSvc, desiredSvc)
+
+		if !reflect.DeepEqual(existingSvc, expectedSvc) {
+			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
+		}
+	})
 }

--- a/pkg/controller/service/controller_test.go
+++ b/pkg/controller/service/controller_test.go
@@ -1,0 +1,190 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func Test_updateServicePorts(t *testing.T) {
+	t.Run("Nil services", func(t *testing.T) {
+		updateServicePorts(nil, nil)
+	})
+
+	t.Run("Existing service has no ports", func(t *testing.T) {
+		existingSvc := &corev1.Service{}
+		desiredSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		expectedSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		updateServicePorts(existingSvc, desiredSvc)
+
+		if !reflect.DeepEqual(existingSvc, expectedSvc) {
+			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
+		}
+	})
+
+	t.Run("Existing service has ports with overlapping ports", func(t *testing.T) {
+		existingSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		desiredSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					},
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		expectedSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					},
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		updateServicePorts(existingSvc, desiredSvc)
+
+		if !reflect.DeepEqual(existingSvc, expectedSvc) {
+			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
+		}
+	})
+
+	t.Run("Desired service has NodePort type and existing port has non-zero NodePort", func(t *testing.T) {
+		existingSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+						NodePort: 30000,
+					},
+				},
+			},
+		}
+
+		desiredSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeNodePort,
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		expectedSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+						NodePort: 30000,
+					},
+				},
+			},
+		}
+
+		updateServicePorts(existingSvc, desiredSvc)
+
+		if !reflect.DeepEqual(existingSvc, expectedSvc) {
+			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
+		}
+	})
+
+	t.Run("Desired service has ClusterIP type and existing port has non-zero NodePort", func(t *testing.T) {
+		existingSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+						NodePort: 30000,
+					},
+					{
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+						NodePort: 30001,
+					},
+				},
+			},
+		}
+
+		desiredSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		expectedSvc := &corev1.Service{
+			Spec: corev1.ServiceSpec{
+				Ports: []corev1.ServicePort{
+					{
+						Port:     3306,
+						Protocol: corev1.ProtocolTCP,
+					},
+					{
+						Port:     80,
+						Protocol: corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		updateServicePorts(existingSvc, desiredSvc)
+
+		if !reflect.DeepEqual(existingSvc, expectedSvc) {
+			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
+		}
+	})
+}


### PR DESCRIPTION
Closes #541 
This PR aims to fix the k8s controller refreshing of the service NodePort. The NodePort was being refreshed constantly, causing instability and disruption in the service availability.