### PR TITLE
`PodSecurityContext` compatibility with OpenShift `SecurityContextConstraints`

### DIFF
--- a/api/v1alpha1/maxscale_types.go
+++ b/api/v1alpha1/maxscale_types.go
@@ -736,11 +736,6 @@ func (m *MaxScale) SetDefaults(env *environment.OperatorEnv, mariadb *MariaDB) {
 	}
 
 	m.Spec.PodTemplate.SetDefaults(m.ObjectMeta)
-	if m.Spec.PodTemplate.PodSecurityContext == nil {
-		m.Spec.PodTemplate.PodSecurityContext = &corev1.PodSecurityContext{
-			FSGroup: ptr.To(int64(996)),
-		}
-	}
 }
 
 func (m *MaxScale) getAntiAffinityInstances(mariadb *MariaDB) []string {

--- a/api/v1alpha1/maxscale_types_test.go
+++ b/api/v1alpha1/maxscale_types_test.go
@@ -67,9 +67,6 @@ var _ = Describe("MaxScale types", func() {
 					Spec: MaxScaleSpec{
 						PodTemplate: PodTemplate{
 							ServiceAccountName: &objMeta.Name,
-							PodSecurityContext: &corev1.PodSecurityContext{
-								FSGroup: ptr.To(int64(996)),
-							},
 						},
 						Image: env.RelatedMaxscaleImage,
 						Servers: []MaxScaleServer{
@@ -239,9 +236,6 @@ var _ = Describe("MaxScale types", func() {
 					Spec: MaxScaleSpec{
 						PodTemplate: PodTemplate{
 							ServiceAccountName: &objMeta.Name,
-							PodSecurityContext: &corev1.PodSecurityContext{
-								FSGroup: ptr.To(int64(996)),
-							},
 							Affinity: &AffinityConfig{
 								AntiAffinityEnabled: ptr.To(true),
 								Affinity: corev1.Affinity{

--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -94,7 +94,7 @@ func (b *Builder) BuildBackupJob(key types.NamespacedName, backup *mariadbv1alph
 		return nil, err
 	}
 
-	securityContext, err := b.buildPodSecurityContext(backup.Spec.PodSecurityContext)
+	securityContext, err := b.buildPodSecurityContextWithUserGroup(backup.Spec.PodSecurityContext, mysqlUser, mysqlGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -216,7 +216,7 @@ func (b *Builder) BuildRestoreJob(key types.NamespacedName, restore *mariadbv1al
 		return nil, err
 	}
 
-	securityContext, err := b.buildPodSecurityContext(restore.Spec.PodSecurityContext)
+	securityContext, err := b.buildPodSecurityContextWithUserGroup(restore.Spec.PodSecurityContext, mysqlUser, mysqlGroup)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/builder/batch_container_builder_test.go
+++ b/pkg/builder/batch_container_builder_test.go
@@ -30,7 +30,7 @@ func TestJobContainerSecurityContext(t *testing.T) {
 	}
 
 	securityContext = &corev1.SecurityContext{
-		RunAsUser: ptr.To(int64(999)),
+		RunAsUser: ptr.To(int64(mysqlUser)),
 	}
 	container, err = builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)
 	if err != nil {

--- a/pkg/builder/batch_container_builder_test.go
+++ b/pkg/builder/batch_container_builder_test.go
@@ -30,7 +30,7 @@ func TestJobContainerSecurityContext(t *testing.T) {
 	}
 
 	securityContext = &corev1.SecurityContext{
-		RunAsUser: ptr.To(int64(mysqlUser)),
+		RunAsUser: ptr.To(mysqlUser),
 	}
 	container, err = builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)
 	if err != nil {

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -201,7 +201,7 @@ func (b *Builder) galeraAgentContainer(mariadb *mariadbv1alpha1.MariaDB) (*corev
 	}()
 
 	defaultSc := corev1.SecurityContext{
-		RunAsUser: ptr.To(int64(999)), // mysql user that owns /var/lib/mysql
+		RunAsUser: ptr.To(int64(mysqlUser)),
 	}
 	sc := ptr.Deref(container.SecurityContext, defaultSc)
 

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -486,6 +486,18 @@ func maxscaleVolumeMounts(maxscale *mariadbv1alpha1.MaxScale) []corev1.VolumeMou
 			Name:      ConfigVolume,
 			MountPath: MaxscaleConfigMountPath,
 		},
+		{
+			Name:      RunVolume,
+			MountPath: MaxScaleRunMountPath,
+		},
+		{
+			Name:      LogVolume,
+			MountPath: MaxScaleLogMountPath,
+		},
+		{
+			Name:      CacheVolume,
+			MountPath: MaxScaleCacheMountPath,
+		},
 	}
 	if maxscale.Spec.VolumeMounts != nil {
 		volumeMounts = append(volumeMounts, maxscale.Spec.VolumeMounts...)

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -200,11 +200,9 @@ func (b *Builder) galeraAgentContainer(mariadb *mariadbv1alpha1.MariaDB) (*corev
 		return defaultGaleraAgentProbe(galera)
 	}()
 
-	defaultSc := corev1.SecurityContext{
-		RunAsUser: ptr.To(int64(mysqlUser)),
-	}
-	sc := ptr.Deref(container.SecurityContext, defaultSc)
-
+	sc := ptr.Deref(container.SecurityContext, corev1.SecurityContext{
+		RunAsUser: ptr.To(mysqlUser),
+	})
 	securityContext, err := b.buildContainerSecurityContext(&sc)
 	if err != nil {
 		return nil, err

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -117,15 +117,13 @@ func (b *Builder) maxscaleContainers(mxs *mariadbv1alpha1.MaxScale) ([]corev1.Co
 
 	container.Name = MaxScaleContainerName
 	container.Command = []string{
-		"bash",
-		"-c",
+		"maxscale",
 	}
 	container.Args = []string{
-		"maxscale",
 		"--config",
 		fmt.Sprintf("%s/%s", MaxscaleConfigMountPath, mxs.ConfigSecretKeyRef().Key),
 		"-dU",
-		"$(id -u)",
+		"maxscale",
 		"-l",
 		"stdout",
 	}

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -199,16 +199,6 @@ func (b *Builder) galeraAgentContainer(mariadb *mariadbv1alpha1.MariaDB) (*corev
 		}
 		return defaultGaleraAgentProbe(galera)
 	}()
-
-	sc := ptr.Deref(container.SecurityContext, corev1.SecurityContext{
-		RunAsUser: ptr.To(mysqlUser),
-	})
-	securityContext, err := b.buildContainerSecurityContext(&sc)
-	if err != nil {
-		return nil, err
-	}
-	container.SecurityContext = securityContext
-
 	return container, nil
 }
 

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -117,13 +117,15 @@ func (b *Builder) maxscaleContainers(mxs *mariadbv1alpha1.MaxScale) ([]corev1.Co
 
 	container.Name = MaxScaleContainerName
 	container.Command = []string{
-		"maxscale",
+		"bash",
+		"-c",
 	}
 	container.Args = []string{
+		"maxscale",
 		"--config",
 		fmt.Sprintf("%s/%s", MaxscaleConfigMountPath, mxs.ConfigSecretKeyRef().Key),
 		"-dU",
-		"maxscale",
+		"$(id -u)",
 		"-l",
 		"stdout",
 	}

--- a/pkg/builder/container_builder_test.go
+++ b/pkg/builder/container_builder_test.go
@@ -785,7 +785,7 @@ func TestContainerSecurityContext(t *testing.T) {
 
 	tpl = &mariadbv1alpha1.ContainerTemplate{
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: ptr.To(int64(999)),
+			RunAsUser: ptr.To(int64(mysqlUser)),
 		},
 	}
 	container, err = builder.buildContainer("mariadb:10.6", corev1.PullIfNotPresent, tpl)

--- a/pkg/builder/container_builder_test.go
+++ b/pkg/builder/container_builder_test.go
@@ -785,7 +785,7 @@ func TestContainerSecurityContext(t *testing.T) {
 
 	tpl = &mariadbv1alpha1.ContainerTemplate{
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser: ptr.To(int64(mysqlUser)),
+			RunAsUser: ptr.To(mysqlUser),
 		},
 	}
 	container, err = builder.buildContainer("mariadb:10.6", corev1.PullIfNotPresent, tpl)

--- a/pkg/builder/pod_builder.go
+++ b/pkg/builder/pod_builder.go
@@ -142,10 +142,7 @@ func (b *Builder) mariadbPodTemplate(mariadb *mariadbv1alpha1.MariaDB, opts ...m
 		return nil, err
 	}
 
-	sc := ptr.Deref(mariadb.Spec.PodSecurityContext, corev1.PodSecurityContext{
-		FSGroup: ptr.To(mysqlUser),
-	})
-	securityContext, err := b.buildPodSecurityContext(&sc)
+	securityContext, err := b.buildPodSecurityContextWithUserGroup(mariadb.Spec.PodSecurityContext, mysqlUser, mysqlGroup)
 	if err != nil {
 		return nil, err
 	}
@@ -200,10 +197,7 @@ func (b *Builder) maxscalePodTemplate(mxs *mariadbv1alpha1.MaxScale) (*corev1.Po
 		return nil, err
 	}
 
-	sc := ptr.Deref(mxs.Spec.PodSecurityContext, corev1.PodSecurityContext{
-		FSGroup: ptr.To(maxscaleUser),
-	})
-	securityContext, err := b.buildPodSecurityContext(&sc)
+	securityContext, err := b.buildPodSecurityContextWithUserGroup(mxs.Spec.PodSecurityContext, maxscaleUser, maxscaleGroup)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/builder/pod_builder.go
+++ b/pkg/builder/pod_builder.go
@@ -142,7 +142,10 @@ func (b *Builder) mariadbPodTemplate(mariadb *mariadbv1alpha1.MariaDB, opts ...m
 		return nil, err
 	}
 
-	securityContext, err := b.buildPodSecurityContext(mariadb.Spec.PodSecurityContext)
+	sc := ptr.Deref(mariadb.Spec.PodSecurityContext, corev1.PodSecurityContext{
+		FSGroup: ptr.To(mysqlUser),
+	})
+	securityContext, err := b.buildPodSecurityContext(&sc)
 	if err != nil {
 		return nil, err
 	}
@@ -197,7 +200,10 @@ func (b *Builder) maxscalePodTemplate(mxs *mariadbv1alpha1.MaxScale) (*corev1.Po
 		return nil, err
 	}
 
-	securityContext, err := b.buildPodSecurityContext(mxs.Spec.PodSecurityContext)
+	sc := ptr.Deref(mxs.Spec.PodSecurityContext, corev1.PodSecurityContext{
+		FSGroup: ptr.To(maxscaleUser),
+	})
+	securityContext, err := b.buildPodSecurityContext(&sc)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/builder/pod_builder.go
+++ b/pkg/builder/pod_builder.go
@@ -351,6 +351,24 @@ func maxscaleVolumes(maxscale *mariadbv1alpha1.MaxScale) []corev1.Volume {
 				},
 			},
 		},
+		{
+			Name: RunVolume,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: LogVolume,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
+		{
+			Name: CacheVolume,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		},
 	}
 	if maxscale.Spec.Volumes != nil {
 		volumes = append(volumes, maxscale.Spec.Volumes...)

--- a/pkg/builder/pod_builder_test.go
+++ b/pkg/builder/pod_builder_test.go
@@ -538,8 +538,57 @@ func TestMariadbPodBuilder(t *testing.T) {
 	if podTpl.Spec.Affinity == nil {
 		t.Error("expected affinity to have been set")
 	}
+
 	if reflect.ValueOf(podTpl.Spec.Containers[0].Resources).IsZero() {
 		t.Error("expected resources to have been set")
+	}
+
+	if podTpl.Spec.SecurityContext == nil {
+		t.Error("expected podSecurityContext to have been set")
+	}
+	sc := ptr.Deref(podTpl.Spec.SecurityContext, corev1.PodSecurityContext{})
+	runAsUser := ptr.Deref(sc.RunAsUser, 0)
+	if runAsUser != mysqlUser {
+		t.Errorf("expected to run as mysql user, got user: %d", runAsUser)
+	}
+	runAsGroup := ptr.Deref(sc.RunAsGroup, 0)
+	if runAsGroup != mysqlGroup {
+		t.Errorf("expected to run as mysql group, got group: %d", runAsGroup)
+	}
+	fsGroup := ptr.Deref(sc.FSGroup, 0)
+	if fsGroup != mysqlGroup {
+		t.Errorf("expected to run as mysql fsGroup, got fsGroup: %d", fsGroup)
+	}
+}
+
+func TestMaxscalePodBuilder(t *testing.T) {
+	builder := newTestBuilder(t)
+	mxs := &mariadbv1alpha1.MaxScale{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-maxscale-builder",
+		},
+	}
+
+	podTpl, err := builder.maxscalePodTemplate(mxs)
+	if err != nil {
+		t.Fatalf("unexpected error building MaxScale Pod template: %v", err)
+	}
+
+	if podTpl.Spec.SecurityContext == nil {
+		t.Error("expected podSecurityContext to have been set")
+	}
+	sc := ptr.Deref(podTpl.Spec.SecurityContext, corev1.PodSecurityContext{})
+	runAsUser := ptr.Deref(sc.RunAsUser, 0)
+	if runAsUser != maxscaleUser {
+		t.Errorf("expected to run as maxscale user, got user: %d", runAsUser)
+	}
+	runAsGroup := ptr.Deref(sc.RunAsGroup, 0)
+	if runAsGroup != maxscaleGroup {
+		t.Errorf("expected to run as maxscale group, got group: %d", runAsGroup)
+	}
+	fsGroup := ptr.Deref(sc.FSGroup, 0)
+	if fsGroup != maxscaleGroup {
+		t.Errorf("expected to run as maxscale fsGroup, got fsGroup: %d", fsGroup)
 	}
 }
 

--- a/pkg/builder/securitycontext_builder.go
+++ b/pkg/builder/securitycontext_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 func (b *Builder) buildContainerSecurityContext(securityContext *corev1.SecurityContext) (*corev1.SecurityContext, error) {
@@ -32,4 +33,28 @@ func (b *Builder) buildPodSecurityContext(podSecurityContext *corev1.PodSecurity
 		return nil, nil
 	}
 	return podSecurityContext, nil
+}
+
+func (b *Builder) buildPodSecurityContextWithUserGroup(podSecurityContext *corev1.PodSecurityContext,
+	user, group int64) (*corev1.PodSecurityContext, error) {
+	sccExists, err := b.discovery.SecurityContextConstrainstsExist()
+	if err != nil {
+		return nil, fmt.Errorf("error discovering SecurityContextConstraints: %v", err)
+	}
+	// Delegate SecurityContext assigment to OpenShift.
+	// A SecurityContext is created based on SecurityContextConstraints.
+	// See: https://redhat-connect.gitbook.io/certified-operator-guide/troubleshooting-and-resources/sccs
+	if sccExists {
+		return nil, nil
+	}
+	if podSecurityContext != nil {
+		return podSecurityContext, nil
+	}
+
+	return &corev1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		RunAsUser:    &user,
+		RunAsGroup:   &group,
+		FSGroup:      &group,
+	}, nil
 }

--- a/pkg/builder/securitycontext_builder_test.go
+++ b/pkg/builder/securitycontext_builder_test.go
@@ -13,7 +13,7 @@ func TestBuildContainerSecurityContext(t *testing.T) {
 	builder := newTestBuilder(t)
 
 	sc, err := builder.buildContainerSecurityContext(&corev1.SecurityContext{
-		RunAsUser: ptr.To(int64(mysqlUser)),
+		RunAsUser: ptr.To(mysqlUser),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error building SecurityContext: %v", err)
@@ -37,7 +37,7 @@ func TestBuildContainerSecurityContext(t *testing.T) {
 	builder = newTestBuilder(t, WithDiscovery(discovery))
 
 	sc, err = builder.buildContainerSecurityContext(&corev1.SecurityContext{
-		RunAsUser: ptr.To(int64(mysqlUser)),
+		RunAsUser: ptr.To(mysqlUser),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error building SecurityContext: %v", err)
@@ -51,7 +51,7 @@ func TestBuildPodSecurityContext(t *testing.T) {
 	builder := newTestBuilder(t)
 
 	sc, err := builder.buildPodSecurityContext(&corev1.PodSecurityContext{
-		RunAsUser: ptr.To(int64(mysqlUser)),
+		RunAsUser: ptr.To(mysqlUser),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
@@ -75,7 +75,7 @@ func TestBuildPodSecurityContext(t *testing.T) {
 	builder = newTestBuilder(t, WithDiscovery(discovery))
 
 	sc, err = builder.buildPodSecurityContext(&corev1.PodSecurityContext{
-		RunAsUser: ptr.To(int64(mysqlUser)),
+		RunAsUser: ptr.To(mysqlUser),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error building PodSecurityContext: %v", err)

--- a/pkg/builder/securitycontext_builder_test.go
+++ b/pkg/builder/securitycontext_builder_test.go
@@ -13,7 +13,7 @@ func TestBuildContainerSecurityContext(t *testing.T) {
 	builder := newTestBuilder(t)
 
 	sc, err := builder.buildContainerSecurityContext(&corev1.SecurityContext{
-		RunAsUser: ptr.To(int64(999)),
+		RunAsUser: ptr.To(int64(mysqlUser)),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error building SecurityContext: %v", err)
@@ -37,7 +37,7 @@ func TestBuildContainerSecurityContext(t *testing.T) {
 	builder = newTestBuilder(t, WithDiscovery(discovery))
 
 	sc, err = builder.buildContainerSecurityContext(&corev1.SecurityContext{
-		RunAsUser: ptr.To(int64(999)),
+		RunAsUser: ptr.To(int64(mysqlUser)),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error building SecurityContext: %v", err)
@@ -51,7 +51,7 @@ func TestBuildPodSecurityContext(t *testing.T) {
 	builder := newTestBuilder(t)
 
 	sc, err := builder.buildPodSecurityContext(&corev1.PodSecurityContext{
-		RunAsUser: ptr.To(int64(999)),
+		RunAsUser: ptr.To(int64(mysqlUser)),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
@@ -75,7 +75,7 @@ func TestBuildPodSecurityContext(t *testing.T) {
 	builder = newTestBuilder(t, WithDiscovery(discovery))
 
 	sc, err = builder.buildPodSecurityContext(&corev1.PodSecurityContext{
-		RunAsUser: ptr.To(int64(999)),
+		RunAsUser: ptr.To(int64(mysqlUser)),
 	})
 	if err != nil {
 		t.Fatalf("unexpected error building PodSecurityContext: %v", err)

--- a/pkg/builder/securitycontext_builder_test.go
+++ b/pkg/builder/securitycontext_builder_test.go
@@ -84,3 +84,61 @@ func TestBuildPodSecurityContext(t *testing.T) {
 		t.Error("PodSecurityContext must be nil")
 	}
 }
+
+func TestBuildPodSecurityContextWithUserGroup(t *testing.T) {
+	builder := newTestBuilder(t)
+
+	sc, err := builder.buildPodSecurityContextWithUserGroup(&corev1.PodSecurityContext{
+		RunAsUser: ptr.To(mysqlUser),
+	}, mysqlUser, mysqlGroup)
+	if err != nil {
+		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
+	}
+	if sc == nil {
+		t.Error("PodSecurityContext must be non nil")
+	}
+
+	sc, err = builder.buildPodSecurityContextWithUserGroup(nil, mysqlUser, mysqlGroup)
+	if err != nil {
+		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
+	}
+	if sc == nil {
+		t.Fatal("PodSecurityContext must be non nil")
+	}
+	runAsUser := ptr.Deref(sc.RunAsUser, 0)
+	if runAsUser != mysqlUser {
+		t.Errorf("expected to run as mysql user, got user: %d", runAsUser)
+	}
+	runAsGroup := ptr.Deref(sc.RunAsGroup, 0)
+	if runAsGroup != mysqlGroup {
+		t.Errorf("expected to run as mysql group, got group: %d", runAsGroup)
+	}
+	fsGroup := ptr.Deref(sc.FSGroup, 0)
+	if fsGroup != mysqlGroup {
+		t.Errorf("expected to run as mysql fsGroup, got fsGroup: %d", fsGroup)
+	}
+
+	resource := &metav1.APIResourceList{
+		GroupVersion: "security.openshift.io/v1",
+		APIResources: []metav1.APIResource{
+			{
+				Name: "securitycontextconstraints",
+			},
+		},
+	}
+	discovery, err := discovery.NewFakeDiscovery(resource)
+	if err != nil {
+		t.Fatalf("unexpected error getting discovery: %v", err)
+	}
+	builder = newTestBuilder(t, WithDiscovery(discovery))
+
+	sc, err = builder.buildPodSecurityContextWithUserGroup(&corev1.PodSecurityContext{
+		RunAsUser: ptr.To(mysqlUser),
+	}, mysqlUser, mysqlGroup)
+	if err != nil {
+		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
+	}
+	if sc != nil {
+		t.Error("PodSecurityContext must be nil")
+	}
+}

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -47,7 +47,8 @@ const (
 	ServiceAccountVolume    = "serviceaccount"
 	ServiceAccountMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 
-	mysqlUser = 999 // mysql user that owns /var/lib/mysql
+	mysqlUser    = int64(999) // mysql user that owns /var/lib/mysql
+	maxscaleUser = int64(999) // maxscale user that owns /var/lib/maxscale
 )
 
 func (b *Builder) BuildMariadbStatefulSet(mariadb *mariadbv1alpha1.MariaDB, key types.NamespacedName) (*appsv1.StatefulSet, error) {

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -49,8 +49,8 @@ const (
 
 	mysqlUser     = int64(999)
 	mysqlGroup    = int64(999)
-	maxscaleUser  = int64(999)
-	maxscaleGroup = int64(999)
+	maxscaleUser  = int64(998)
+	maxscaleGroup = int64(996)
 )
 
 func (b *Builder) BuildMariadbStatefulSet(mariadb *mariadbv1alpha1.MariaDB, key types.NamespacedName) (*appsv1.StatefulSet, error) {

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -47,8 +47,10 @@ const (
 	ServiceAccountVolume    = "serviceaccount"
 	ServiceAccountMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
 
-	mysqlUser    = int64(999) // mysql user that owns /var/lib/mysql
-	maxscaleUser = int64(999) // maxscale user that owns /var/lib/maxscale
+	mysqlUser     = int64(999)
+	mysqlGroup    = int64(999)
+	maxscaleUser  = int64(999)
+	maxscaleGroup = int64(999)
 )
 
 func (b *Builder) BuildMariadbStatefulSet(mariadb *mariadbv1alpha1.MariaDB, key types.NamespacedName) (*appsv1.StatefulSet, error) {

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -46,6 +46,8 @@ const (
 
 	ServiceAccountVolume    = "serviceaccount"
 	ServiceAccountMountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+
+	mysqlUser = 999 // mysql user that owns /var/lib/mysql
 )
 
 func (b *Builder) BuildMariadbStatefulSet(mariadb *mariadbv1alpha1.MariaDB, key types.NamespacedName) (*appsv1.StatefulSet, error) {

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -27,6 +27,15 @@ const (
 	MaxscaleConfigMountPath = "/etc/config"
 	ConfigVolumeRole        = "config"
 
+	RunVolume            = "run"
+	MaxScaleRunMountPath = "/var/run/maxscale"
+
+	LogVolume            = "log"
+	MaxScaleLogMountPath = "/var/log/maxscale"
+
+	CacheVolume            = "cache"
+	MaxScaleCacheMountPath = "/var/cache/maxscale"
+
 	InitVolume        = "init"
 	InitConfigPath    = "/init"
 	InitLibKey        = "lib.sh"


### PR DESCRIPTION
Related to https://github.com/mariadb-operator/mariadb-operator/issues/457