### PR TITLE
Support for providing path to a non-default CA trust chain in helm chart

### DIFF
--- a/deploy/charts/mariadb-operator/templates/_helpers.tpl
+++ b/deploy/charts/mariadb-operator/templates/_helpers.tpl
@@ -71,6 +71,34 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Webhook CA path to use cert-controller issued certificates
+*/}}
+{{- define "mariadb-operator-webhook.certControllerCAPath" -}}
+{{ .Values.webhook.cert.ca.path | default "/tmp/k8s-webhook-server/certificate-authority" }}
+{{- end }}
+
+{{/*
+Webhook CA full path to use cert-controller issued certificates
+*/}}
+{{- define "mariadb-operator-webhook.certControllerFullCAPath" -}}
+{{- printf "%s/%s" (include "mariadb-operator-webhook.certControllerCAPath" .) (.Values.webhook.cert.ca.key | default "tls.crt") }}
+{{- end }}
+
+{{/*
+Webhook CA path to use cert-manager issued certificates
+*/}}
+{{- define "mariadb-operator-webhook.certManagerCAPath" -}}
+{{ .Values.webhook.cert.ca.path | default .Values.webhook.cert.path }}
+{{- end }}
+
+{{/*
+Webhook CA full path to use cert-manager issued certificates
+*/}}
+{{- define "mariadb-operator-webhook.certManagerFullCAPath" -}}
+{{- printf "%s/%s" (include "mariadb-operator-webhook.certManagerCAPath" .) (.Values.webhook.cert.ca.key | default "ca.crt") }}
+{{- end }}
+
+{{/*
 Cert-controller common labels
 */}}
 {{- define "mariadb-operator-cert-controller.labels" -}}

--- a/deploy/charts/mariadb-operator/templates/webhook-deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-deployment.yaml
@@ -51,9 +51,9 @@ spec:
           args:
             - webhook
             {{- if .Values.webhook.cert.certManager.enabled }}
-            - --ca-cert-path={{ .Values.webhook.cert.path }}/ca.crt
+            - --ca-cert-path={{ include "mariadb-operator-webhook.certManagerFullCAPath" . }}
             {{- else }}
-            - --ca-cert-path={{ .Values.webhook.cert.caPath }}/tls.crt
+            - --ca-cert-path={{ include "mariadb-operator-webhook.certControllerFullCAPath" . }}
             {{- end }}
             - --cert-dir={{ .Values.webhook.cert.path }}
             - --dns-name={{ $fullName }}-webhook.{{ .Release.Namespace }}.svc
@@ -76,7 +76,7 @@ spec:
               name: health
           volumeMounts:
             {{- if not .Values.webhook.cert.certManager.enabled }}
-            - mountPath: {{ .Values.webhook.cert.caPath }}
+            - mountPath: {{ include "mariadb-operator-webhook.certControllerCAPath" . }}
               name: ca
               readOnly: true
             {{- end }}

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -113,9 +113,12 @@ webhook:
     secretAnnotations: {}
     # -- Labels to be added to webhook TLS secret.
     secretLabels: {}
-    # -- Path where the CA certificate will be mounted.
-    caPath: /tmp/k8s-webhook-server/certificate-authority
-    # -- Path where the certificate will be mounted.
+    ca:
+      # -- Path that contains the full CA trust chain.
+      path: ""
+      # -- File under 'ca.path' that contains the full CA trust chain.
+      key: ""
+    # -- Path where the certificate will be mounted. 'tls.crt' and 'tls.key' certificates files should be under this path.
     path: /tmp/k8s-webhook-server/serving-certs
   # -- Port to be used by the webhook server
   port: 9443


### PR DESCRIPTION
Closes https://github.com/mariadb-operator/mariadb-operator/issues/614