### PR TITLE
Fix `mariadb.sys`. Force user reconciliation

### DIFF
--- a/controller/user_controller.go
+++ b/controller/user_controller.go
@@ -124,8 +124,8 @@ func (wr *wrappedUserReconciler) Reconcile(ctx context.Context, mdbClient *sqlCl
 
 	if !exists {
 		accountName := wr.user.AccountName()
-		// After restoring a backup, mysql.user and mysql.global_priv don't have the account entry, but the CREATE query still succeeds.
 		// This forces the user to be recreated from a clean state.
+		// It helps fixing intermediate states in mysql.global_priv and mysql.user.
 		if err := mdbClient.DropUser(ctx, accountName); err != nil {
 			return fmt.Errorf("error dropping User: %v", err)
 		}

--- a/controller/user_controller.go
+++ b/controller/user_controller.go
@@ -123,7 +123,13 @@ func (wr *wrappedUserReconciler) Reconcile(ctx context.Context, mdbClient *sqlCl
 	}
 
 	if !exists {
-		if err := mdbClient.CreateUser(ctx, wr.user.AccountName(), createUserOpts...); err != nil {
+		accountName := wr.user.AccountName()
+		// After restoring a backup, mysql.user and mysql.global_priv don't have the account entry, but the CREATE query still succeeds.
+		// This forces the user to be recreated from a clean state.
+		if err := mdbClient.DropUser(ctx, accountName); err != nil {
+			return fmt.Errorf("error dropping User: %v", err)
+		}
+		if err := mdbClient.CreateUser(ctx, accountName, createUserOpts...); err != nil {
 			return fmt.Errorf("error creating User: %v", err)
 		}
 	} else if password != "" {


### PR DESCRIPTION
Forcing `mariadb.sys` `User` reconciliation, which is used internally by MariaDB to manage users and its privileges.

Context: when backing up and restoring a Galera cluster `mysql.global_priv` is not backed up by default, since non InnoDB tables are not replicated. See: https://github.com/mariadb-operator/mariadb-operator/issues/580

In some cases, after restoring a backup in a Galera cluster, the initial user doesn't correctly get recreated in spite of the `CREATE USER` statement being successfuly. This PR also fixes this.