### PR TITLE
adds the "revisionHistoryLimit" option to the webhook-certificate.yaml template

### DIFF
--- a/deploy/charts/mariadb-operator/README.md
+++ b/deploy/charts/mariadb-operator/README.md
@@ -95,6 +95,7 @@ helm uninstall mariadb-operator
 | webhook.cert.certManager.enabled | bool | `false` | Whether to use cert-manager to issue and rotate the certificate. If set to false, mariadb-operator's cert-controller will be used instead. |
 | webhook.cert.certManager.issuerRef | object | `{}` | Issuer reference to be used in the Certificate resource. If not provided, a self-signed issuer will be used. |
 | webhook.cert.certManager.renewBefore | string | `""` | Renew before duration to be used in the Certificate resource. |
+| webhook.cert.certManager.revisionHistoryLimit | int | `3` | The maximum number of CertificateRequest revisions that are maintained in the Certificate’s history. |
 | webhook.cert.path | string | `"/tmp/k8s-webhook-server/serving-certs"` | Path where the certificate will be mounted. 'tls.crt' and 'tls.key' certificates files should be under this path. |
 | webhook.cert.secretAnnotations | object | `{}` | Annotatioms to be added to webhook TLS secret. |
 | webhook.cert.secretLabels | object | `{}` | Labels to be added to webhook TLS secret. |

--- a/deploy/charts/mariadb-operator/README.md
+++ b/deploy/charts/mariadb-operator/README.md
@@ -95,7 +95,6 @@ helm uninstall mariadb-operator
 | webhook.cert.certManager.enabled | bool | `false` | Whether to use cert-manager to issue and rotate the certificate. If set to false, mariadb-operator's cert-controller will be used instead. |
 | webhook.cert.certManager.issuerRef | object | `{}` | Issuer reference to be used in the Certificate resource. If not provided, a self-signed issuer will be used. |
 | webhook.cert.certManager.renewBefore | string | `""` | Renew before duration to be used in the Certificate resource. |
-| webhook.cert.certManager.revisionHistoryLimit | int | `3` | The maximum number of CertificateRequest revisions that are maintained in the Certificate’s history. |
 | webhook.cert.path | string | `"/tmp/k8s-webhook-server/serving-certs"` | Path where the certificate will be mounted. 'tls.crt' and 'tls.key' certificates files should be under this path. |
 | webhook.cert.secretAnnotations | object | `{}` | Annotatioms to be added to webhook TLS secret. |
 | webhook.cert.secretLabels | object | `{}` | Labels to be added to webhook TLS secret. |

--- a/deploy/charts/mariadb-operator/templates/webhook-certificate.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-certificate.yaml
@@ -36,6 +36,9 @@ spec:
   {{- with .Values.webhook.cert.certManager.renewBefore }}
   renewBefore: {{ . | quote }}
   {{- end }}
+  {{- with .Values.webhook.cert.certManager.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ . }}
+  {{- end }}
   secretName: {{ include "mariadb-operator.fullname" . }}-webhook-cert
   secretTemplate:
     {{- with .Values.webhook.cert.secretLabels }}

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -105,10 +105,12 @@ webhook:
       enabled: false
       # -- Issuer reference to be used in the Certificate resource. If not provided, a self-signed issuer will be used.
       issuerRef: {}
-       # -- Duration to be used in the Certificate resource,
+      # -- Duration to be used in the Certificate resource,
       duration: ""
-       # -- Renew before duration to be used in the Certificate resource.
+      # -- Renew before duration to be used in the Certificate resource.
       renewBefore: ""
+      # -- The maximum number of CertificateRequest revisions that are maintained in the Certificate’s history.
+      revisionHistoryLimit: 3
     # -- Annotatioms to be added to webhook TLS secret.
     secretAnnotations: {}
     # -- Labels to be added to webhook TLS secret.


### PR DESCRIPTION
Cert-Manager does not normally delete CertificateRequests so that they accumulate.
It would be nice if the template [webhook-certificate.yaml](https://github.com/mariadb-operator/mariadb-operator/blob/main/deploy/charts/mariadb-operator/templates/webhook-certificate.yaml) could be extended so that the [Certificate](https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificateSpec) resource has the optional setting revisionHistoryLimit, so that old CertificateRequests are automatically deleted.

Closes #380