### PR TITLE
fix two errors in the `webhook-certificate.yaml` helm template in the context of `secretTemplate` setting

### DIFF
--- a/deploy/charts/mariadb-operator/templates/webhook-certificate.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-certificate.yaml
@@ -37,6 +37,7 @@ spec:
   renewBefore: {{ . | quote }}
   {{- end }}
   secretName: {{ include "mariadb-operator.fullname" . }}-webhook-cert
+  {{- if or (.Values.webhook.cert.secretLabels) (.Values.webhook.cert.secretAnnotations) }}
   secretTemplate:
     {{- with .Values.webhook.cert.secretLabels }}
     labels:
@@ -46,4 +47,5 @@ spec:
     annotations:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+  {{- end }}
 {{ end }}

--- a/deploy/charts/mariadb-operator/templates/webhook-certificate.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-certificate.yaml
@@ -44,6 +44,6 @@ spec:
     {{- end }}
     {{- with .Values.webhook.cert.secretAnnotations }}
     annotations:
-      {{- toYaml . | nindent 4 }}
+      {{- toYaml . | nindent 6 }}
     {{- end }}
 {{ end }}


### PR DESCRIPTION
If the `cert-manager` is activated and the two options `secretLabels` and `secretAnnotations` are not set, a deployment error occurs (see also in #699).

At the same time, the indentation of `secretAnnotations` is incorrect, so that a deployment error also occurs here (see also in #700).

Closes #699 
Closes #700 