### PR TITLE
Using short FQDN in CHANGE MASTER statement to be compatible with MariaDB 10.5

### DIFF
--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -146,7 +146,8 @@ func (r *ReplicationConfig) changeMaster(ctx context.Context, mariadb *mariadbv1
 
 	changeMasterOpts := &sqlClient.ChangeMasterOpts{
 		Connection: connectionName,
-		Host: statefulset.PodFQDNWithService(
+		// MariaDB 10.5 has a limitation of 60 characters in this host.
+		Host: statefulset.PodShortFQDNWithService(
 			mariadb.ObjectMeta,
 			primaryPodIndex,
 			mariadb.InternalServiceKey().Name,

--- a/pkg/statefulset/statefulset.go
+++ b/pkg/statefulset/statefulset.go
@@ -33,6 +33,10 @@ func PodFQDNWithService(meta metav1.ObjectMeta, podIndex int, service string) st
 	return fmt.Sprintf("%s.%s", PodName(meta, podIndex), ServiceFQDNWithService(meta, service))
 }
 
+func PodShortFQDNWithService(meta metav1.ObjectMeta, podIndex int, service string) string {
+	return fmt.Sprintf("%s.%s", PodName(meta, podIndex), service)
+}
+
 func PodIndex(podName string) (*int, error) {
 	parts := strings.Split(podName, "-")
 	if len(parts) == 0 {


### PR DESCRIPTION
Related to https://github.com/mariadb-operator/mariadb-operator/issues/707