### PR TITLE
Change default timezone settings

### DIFF
--- a/controller/mariadb_controller.go
+++ b/controller/mariadb_controller.go
@@ -265,6 +265,7 @@ func (r *MariaDBReconciler) reconcileConfigMap(ctx context.Context, mariadb *mar
 		Data: map[string]string{
 			defaultConfigMapKeyRef.Key: `[mariadb]
 skip-name-resolve
+default_time_zone = 'UTC'
 `,
 		},
 	}

--- a/controller/mariadb_controller_test.go
+++ b/controller/mariadb_controller_test.go
@@ -89,6 +89,7 @@ var _ = Describe("MariaDB", func() {
 			g.Expect(cm.ObjectMeta.Labels).To(HaveKeyWithValue("k8s.mariadb.com/test", "test"))
 			g.Expect(cm.ObjectMeta.Annotations).NotTo(BeNil())
 			g.Expect(cm.ObjectMeta.Annotations).To(HaveKeyWithValue("k8s.mariadb.com/test", "test"))
+			g.Expect(cm.Data).To(HaveKeyWithValue("0-default.cnf", "[mariadb]\nskip-name-resolve\ndefault_time_zone = 'UTC'\n"))
 			return true
 		}, testTimeout, testInterval).Should(BeTrue())
 

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -354,10 +354,6 @@ func mariadbEnv(mariadb *mariadbv1alpha1.MariaDB) []corev1.EnvVar {
 			Value: "%",
 		},
 		{
-			Name:  "MYSQL_INITDB_SKIP_TZINFO",
-			Value: "1",
-		},
-		{
 			Name:  "CLUSTER_NAME",
 			Value: clusterName,
 		},

--- a/pkg/builder/container_builder_test.go
+++ b/pkg/builder/container_builder_test.go
@@ -981,10 +981,6 @@ func TestMariadbEnv(t *testing.T) {
 								Value: "1.2.3.4",
 							},
 							{
-								Name:  "MYSQL_INITDB_SKIP_TZINFO",
-								Value: "0",
-							},
-							{
 								Name:  "CLUSTER_NAME",
 								Value: "foo.bar",
 							},
@@ -1020,10 +1016,6 @@ func TestMariadbEnv(t *testing.T) {
 				{
 					Name:  "MARIADB_ROOT_HOST",
 					Value: "1.2.3.4",
-				},
-				{
-					Name:  "MYSQL_INITDB_SKIP_TZINFO",
-					Value: "0",
 				},
 				{
 					Name:  "CLUSTER_NAME",
@@ -1105,10 +1097,6 @@ func defaultEnv(overrides []corev1.EnvVar) []corev1.EnvVar {
 		{
 			Name:  "MARIADB_ROOT_HOST",
 			Value: "%",
-		},
-		{
-			Name:  "MYSQL_INITDB_SKIP_TZINFO",
-			Value: "1",
 		},
 		defaults[clusterName.Name],
 		{


### PR DESCRIPTION
Addressing the discussion from #684, this PR introduces the following changes:
* `MYSQL_INITDB_SKIP_TZINFO` stops being passed by default.
* a `default_time_zone = 'UTC'` directive is added to the default `/etc/mysql/conf.d/0-default.cnf` file (through the respective `ConfigMap`).

Before:

```bash
mysql@mariadb-0:/$ mariadb -u root -p$MARIADB_ROOT_PASSWORD -e 'SELECT @@global.time_zone, @@session.time_zone, NOW();'
+--------------------+---------------------+---------------------+
| @@global.time_zone | @@session.time_zone | NOW()               |
+--------------------+---------------------+---------------------+
| SYSTEM             | SYSTEM              | 2024-07-05 13:15:23 |
+--------------------+---------------------+---------------------+
mysql@mariadb-0:/$ date
Fri Jul  5 13:15:26 UTC 2024
```

After:

```bash
mysql@mariadb-0:/$ mariadb -u root -p$MARIADB_ROOT_PASSWORD -e 'SELECT @@global.time_zone, @@session.time_zone, NOW();'
+--------------------+---------------------+---------------------+
| @@global.time_zone | @@session.time_zone | NOW()               |
+--------------------+---------------------+---------------------+
| UTC                | UTC                 | 2024-07-05 13:19:01 |
+--------------------+---------------------+---------------------+
mysql@mariadb-0:/$ date
Fri Jul  5 13:19:01 UTC 2024
```