### PR TITLE
Fix reconciliation of SqlJob history limit updates

### DIFF
--- a/internal/controller/sqljob_controller.go
+++ b/internal/controller/sqljob_controller.go
@@ -235,6 +235,8 @@ func (r *SqlJobReconciler) reconcileCronJob(ctx context.Context, sqlJob *mariadb
 	}
 
 	patch := client.MergeFrom(existingCronJob.DeepCopy())
+	existingCronJob.Spec.FailedJobsHistoryLimit = desiredCronJob.Spec.FailedJobsHistoryLimit
+	existingCronJob.Spec.SuccessfulJobsHistoryLimit = desiredCronJob.Spec.SuccessfulJobsHistoryLimit
 	existingCronJob.Spec.Schedule = desiredCronJob.Spec.Schedule
 	existingCronJob.Spec.Suspend = desiredCronJob.Spec.Suspend
 	existingCronJob.Spec.JobTemplate.Spec.BackoffLimit = desiredCronJob.Spec.JobTemplate.Spec.BackoffLimit


### PR DESCRIPTION
While looking into #383, I found out that in #721 I failed to notice that for `SqlJob` resources, the `CronJob` reconciliation is handled in the `SqlJobReconciler` and not the `BatchReconciler`.

Because of this, once the initial history limits for an `SqlJob` are established, they cannot be subsequently updated. This is really inconvenient, and I am sorry about this!

This PR provides a fix and additional tests that cover the regression.