### PR TITLE
Support for `timeZone` in `MariaDB`

### DIFF
--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -386,6 +386,10 @@ type MariaDBSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	MyCnfConfigMapKeyRef *corev1.ConfigMapKeySelector `json:"myCnfConfigMapKeyRef,omitempty"`
+	// TimeZone sets the default timezone. If not provided, it defaults to SYSTEM and the timezone data is not loaded.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	TimeZone *string `json:"timeZone,omitempty" webhook:"inmutable"`
 	// BootstrapFrom defines a source to bootstrap from.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1337,6 +1337,11 @@ func (in *MariaDBSpec) DeepCopyInto(out *MariaDBSpec) {
 		*out = new(v1.ConfigMapKeySelector)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.TimeZone != nil {
+		in, out := &in.TimeZone, &out.TimeZone
+		*out = new(string)
+		**out = **in
+	}
 	if in.BootstrapFrom != nil {
 		in, out := &in.BootstrapFrom, &out.BootstrapFrom
 		*out = new(BootstrapFrom)

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -22872,6 +22872,10 @@ spec:
                       It defaults to true.
                     type: boolean
                 type: object
+              timeZone:
+                description: TimeZone sets the default timezone. If not provided,
+                  it defaults to SYSTEM and the timezone data is not loaded.
+                type: string
               tolerations:
                 description: Tolerations to be used in the Pod.
                 items:

--- a/internal/controller/mariadb_controller_metrics.go
+++ b/internal/controller/mariadb_controller_metrics.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"text/template"
 	"time"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
@@ -212,8 +211,4 @@ func (r *MariaDBReconciler) reconcileServiceMonitor(ctx context.Context, mariadb
 		return fmt.Errorf("error building Service Monitor: %v", err)
 	}
 	return r.ServiceMonitorReconciler.Reconcile(ctx, desiredSvcMonitor)
-}
-
-func createTpl(name, t string) *template.Template {
-	return template.Must(template.New(name).Parse(t))
 }

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -401,6 +401,13 @@ func mariadbEnv(mariadb *mariadbv1alpha1.MariaDB) []corev1.EnvVar {
 		})
 	}
 
+	if mariadb.Spec.TimeZone == nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "MYSQL_INITDB_SKIP_TZINFO",
+			Value: "1",
+		})
+	}
+
 	if mariadb.Spec.Env != nil {
 		idx := make(map[string]int, len(env))
 		for i, envVar := range env {


### PR DESCRIPTION
Close https://github.com/mariadb-operator/mariadb-operator/issues/684

Context:
- https://github.com/MariaDB/mariadb-docker/issues/262
- https://mariadb.com/kb/en/mariadb-server-docker-official-image-environment-variables/#mariadb_initdb_skip_tzinfo-mysql_initdb_skip_tzinfo