### PR TITLE
user facing RBAC ClusterRoles with aggregation by default

### DIFF
--- a/deploy/charts/mariadb-operator/templates/rbac-user.yaml
+++ b/deploy/charts/mariadb-operator/templates/rbac-user.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.rbac.enabled -}}
+{{ $fullName := include "mariadb-operator.fullname" . }}
+# the mariadb-view ClusterRole allows viewing all k8s.mariadb.com resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $fullName }}-view
+  {{- if .Values.rbac.aggregation.enabled }}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  {{- end }}
+rules:
+- apiGroups: ["k8s.mariadb.com"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+---
+# the mariadb-edit ClusterRole allows editing k8s.mariadb.com resources
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $fullName }}-edit
+  {{- if .Values.rbac.aggregation.enabled }}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+  {{- end }}
+rules:
+- apiGroups: ["k8s.mariadb.com"]
+  resources: ["*"]
+  verbs: ["create", "update", "patch", "delete"]
+{{- end }}

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -51,6 +51,11 @@ rbac:
   # -- Specifies whether RBAC resources should be created
   enabled: true
 
+  aggregation:
+
+    # -- Specifies whether the cluster roles aggrate to view and edit predefinied roles
+    enabled: true
+
 # -- Extra arguments to be passed to the controller entrypoint
 extrArgs: []
 


### PR DESCRIPTION
Close #747 

Some notes for the reviewer:
* Based on the existing objects I used the `{{ $fullName }}` template function, not a literal string like `mariadb-view` from the example in the original PR
* I didn't see anything related to tests for the helm chart, checked the tree and the ci / makefile. If there are some tests please mention it so I can add on for this feature
* I have not found a good place to add some documentation. Starting a whole new .md file for this mini feature felt a bit overblown. I can write a sentence about this if you can tell me where to put it