### PR TITLE
Allow to get `Pod` logs to mariadb-operator `ServiceAccount`

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -66,6 +66,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/deploy/charts/mariadb-operator/templates/rbac.yaml
+++ b/deploy/charts/mariadb-operator/templates/rbac.yaml
@@ -104,6 +104,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - create

--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -94,6 +94,7 @@ type patcherMariaDB func(*mariadbv1alpha1.MariaDBStatus) error
 //+kubebuilder:rbac:groups="",resources=endpoints,verbs=create;patch;get;list;watch
 //+kubebuilder:rbac:groups="",resources=endpoints/restricted,verbs=create;patch;get;list;watch
 //+kubebuilder:rbac:groups="",resources=pods,verbs=get;delete
+//+kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 //+kubebuilder:rbac:groups="",resources=persistentvolumeclaims,verbs=list
 //+kubebuilder:rbac:groups="",resources=events,verbs=list;watch;create;patch
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=list;watch;create;patch


### PR DESCRIPTION
Related to https://github.com/mariadb-operator/mariadb-operator/issues/672#issuecomment-2239225235