### PR TITLE
validation rule added for an odd mariadb.spec.replicas value

### DIFF
--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -428,6 +428,10 @@ type MariaDBSpec struct {
 	// +kubebuilder:default=1
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
 	Replicas int32 `json:"replicas,omitempty"`
+	// disables the validation check for an odd number of replicas.
+	// +kubebuilder:default=false
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	ReplicasAllowEvenNumber bool `json:"replicasAllowEvenNumber,omitempty"`
 	// Port where the instances will be listening for connections.
 	// +optional
 	// +kubebuilder:default=3306
@@ -524,6 +528,7 @@ type MariaDB struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	// +kubebuilder:validation:XValidation:rule="self.replicas %2 == 1 || self.replicasAllowEvenNumber", message="An odd number of MariaDB instances (mariadb.spec.replicas) is required to avoid split brain situations. Use 'mariadb.spec.replicasAllowEvenNumber: true' to disable this validation."
 	Spec   MariaDBSpec   `json:"spec"`
 	Status MariaDBStatus `json:"status,omitempty"`
 }

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -21331,6 +21331,10 @@ spec:
                 description: Replicas indicates the number of desired instances.
                 format: int32
                 type: integer
+              replicasAllowEvenNumber:
+                default: false
+                description: disables the validation check for an odd number of replicas.
+                type: boolean
               replication:
                 description: Replication configures high availability via replication.
                   This feature is still in alpha, use Galera if you are looking for
@@ -25055,6 +25059,11 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-validations:
+            - message: 'An odd number of MariaDB instances (mariadb.spec.replicas)
+                is required to avoid split brain situations. Use ''mariadb.spec.replicasAllowEvenNumber:
+                true'' to disable this validation.'
+              rule: self.replicas %2 == 1 || self.replicasAllowEvenNumber
           status:
             description: MariaDBStatus defines the observed state of MariaDB
             properties:


### PR DESCRIPTION
- [CEL](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#validation-rules) based validation rule used
- to lower the risk of split brain situations for a Galera cluster
- `ReplicasAllowEvenNumber` option added to disable the validation
- ~~manifest example extended~~
- I have used these steps to generate the `k8s.mariadb.com_mariadbs.yaml` file
```shell
make gen
```
This is the message returned by kubectl if the then the validation fails (for instance if replicas: 2 has been defined):
`Error: UPGRADE FAILED: failed to create resource: MariaDB.k8s.mariadb.com "mariadb" is invalid: spec: Invalid value: "object": An odd number of MariaDB instances (mariadb.spec.replicas) is required to avoid split brain situations. Use 'mariadb.spec.replicasAllowEvenNumber: true' to disable this validation.`