### PR TITLE
multiple webhook validations migrated CRD validation checks using the CEL syntax

### DIFF
--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -530,6 +530,7 @@ type MariaDB struct {
 
 	// +kubebuilder:validation:XValidation:rule="self.replicas %2 == 1 || self.replicasAllowEvenNumber", message="An odd number of MariaDB instances (mariadb.spec.replicas) is required to avoid split brain situations. Use 'mariadb.spec.replicasAllowEvenNumber: true' to disable this validation."
 	// +kubebuilder:validation:XValidation:rule="self.galera.enabled && self.replication.enabled", message="You may only enable one HA method at a time, either 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled'"
+	// +kubebuilder:validation:XValidation:rule="self.replicas > 1 && (self.galera.enabled || self.replication.enabled)", message="Multiple replicas (mariadb.spec.replicas) can only be specified when 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled' are true"
 	Spec   MariaDBSpec   `json:"spec"`
 	Status MariaDBStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -529,6 +529,7 @@ type MariaDB struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:validation:XValidation:rule="self.replicas %2 == 1 || self.replicasAllowEvenNumber", message="An odd number of MariaDB instances (mariadb.spec.replicas) is required to avoid split brain situations. Use 'mariadb.spec.replicasAllowEvenNumber: true' to disable this validation."
+	// +kubebuilder:validation:XValidation:rule="self.galera.enabled && self.replication.enabled", message="You may only enable one HA method at a time, either 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled'"
 	Spec   MariaDBSpec   `json:"spec"`
 	Status MariaDBStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -528,12 +528,12 @@ type MariaDB struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	// +kubebuilder:validation:XValidation:rule="self.replicas %2 == 1 || self.replicasAllowEvenNumber", message="An odd number of MariaDB instances (mariadb.spec.replicas) is required to avoid split brain situations. Use 'mariadb.spec.replicasAllowEvenNumber: true' to disable this validation."
-	// +kubebuilder:validation:XValidation:rule="self.galera.enabled && self.replication.enabled", message="You may only enable one HA method at a time, either 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled'"
-	// +kubebuilder:validation:XValidation:rule="self.replicas > 1 && (self.galera.enabled || self.replication.enabled)", message="Multiple replicas (mariadb.spec.replicas) can only be specified when 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled' are true"
-	// +kubebuilder:validation:XValidation:rule="self.replicas <= 1 && (!self.galera.enabled && !self.replication.enabled)", message="If 'mariadb.spec.replicas' is set to 1 or less than 'mariadb.spec.galera.enabled' and 'mariadb.spec.replication.enabled' have to be false to disable HA"
-	// +kubebuilder:validation:XValidation:rule="(self.galera.replicaThreads > 0 && self.galera.enabled) || !self.galera.enabled", message="If 'mariadb.spec.galera.enabled' is true than 'mariadb.spec.galera.replicaThreads' must be at least 1"
-	// +kubebuilder:validation:XValidation:rule="type(self.rootPasswordSecretKeyRef) != map || (type(self.rootPasswordSecretKeyRef) == map && !self.rootEmptyPassword)", message="'mariadb.spec.rootEmptyPassword' must be disabled when 'mariadb.spec.rootPasswordSecretKeyRef' is specified"
+	// +kubebuilder:validation:XValidation:rule="self.replicas %2 == 1 || self.?replicasAllowEvenNumber.orValue(false) == true", message="An odd number of MariaDB instances (mariadb.spec.replicas) is required to avoid split brain situations. Use 'mariadb.spec.replicasAllowEvenNumber: true' to disable this validation."
+	// +kubebuilder:validation:XValidation:rule="self.?galera.enabled.orValue(false) == false || self.?replication.enabled.orValue(false) == false", message="You may only enable one HA method at a time, either 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled'"
+	// +kubebuilder:validation:XValidation:rule="self.replicas <= 1 || (self.replicas > 1 && (self.?galera.enabled.orValue(false) == true || self.?replication.enabled.orValue(false) == true))", message="Multiple replicas (mariadb.spec.replicas) can only be specified when 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled' are true"
+	// +kubebuilder:validation:XValidation:rule="self.replicas > 1 || (self.replicas <= 1 && (self.?galera.enabled.orValue(false) == false || self.?replication.enabled.orValue(false) == false))", message="If 'mariadb.spec.replicas' is set to 1 or less than 'mariadb.spec.galera.enabled' and 'mariadb.spec.replication.enabled' have to be false to disable HA"
+	// +kubebuilder:validation:XValidation:rule="self.?galera.enabled.orValue(false) == false || (self.?galera.enabled.orValue(false) == true && self.?galera.replicaThreads.orValue(0) > 0)", message="If 'mariadb.spec.galera.enabled' is true than 'mariadb.spec.galera.replicaThreads' must be at least 1"
+	// +kubebuilder:validation:XValidation:rule="type(self.rootPasswordSecretKeyRef) != map || (type(self.rootPasswordSecretKeyRef) == map && self.?rootEmptyPassword.orValue(false) == false)", message="'mariadb.spec.rootEmptyPassword' must be disabled when 'mariadb.spec.rootPasswordSecretKeyRef' is specified"
 	Spec   MariaDBSpec   `json:"spec"`
 	Status MariaDBStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -531,6 +531,7 @@ type MariaDB struct {
 	// +kubebuilder:validation:XValidation:rule="self.replicas %2 == 1 || self.replicasAllowEvenNumber", message="An odd number of MariaDB instances (mariadb.spec.replicas) is required to avoid split brain situations. Use 'mariadb.spec.replicasAllowEvenNumber: true' to disable this validation."
 	// +kubebuilder:validation:XValidation:rule="self.galera.enabled && self.replication.enabled", message="You may only enable one HA method at a time, either 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled'"
 	// +kubebuilder:validation:XValidation:rule="self.replicas > 1 && (self.galera.enabled || self.replication.enabled)", message="Multiple replicas (mariadb.spec.replicas) can only be specified when 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled' are true"
+	// +kubebuilder:validation:XValidation:rule="self.replicas <= 1 && (!self.galera.enabled && !self.replication.enabled)", message="If 'mariadb.spec.replicas' is set to 1 or less than 'mariadb.spec.galera.enabled' and 'mariadb.spec.replication.enabled' have to be false to disable HA"
 	Spec   MariaDBSpec   `json:"spec"`
 	Status MariaDBStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -533,6 +533,7 @@ type MariaDB struct {
 	// +kubebuilder:validation:XValidation:rule="self.replicas > 1 && (self.galera.enabled || self.replication.enabled)", message="Multiple replicas (mariadb.spec.replicas) can only be specified when 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled' are true"
 	// +kubebuilder:validation:XValidation:rule="self.replicas <= 1 && (!self.galera.enabled && !self.replication.enabled)", message="If 'mariadb.spec.replicas' is set to 1 or less than 'mariadb.spec.galera.enabled' and 'mariadb.spec.replication.enabled' have to be false to disable HA"
 	// +kubebuilder:validation:XValidation:rule="(self.galera.replicaThreads > 0 && self.galera.enabled) || !self.galera.enabled", message="If 'mariadb.spec.galera.enabled' is true than 'mariadb.spec.galera.replicaThreads' must be at least 1"
+	// +kubebuilder:validation:XValidation:rule="type(self.rootPasswordSecretKeyRef) != map || (type(self.rootPasswordSecretKeyRef) == map && !self.rootEmptyPassword)", message="'mariadb.spec.rootEmptyPassword' must be disabled when 'mariadb.spec.rootPasswordSecretKeyRef' is specified"
 	Spec   MariaDBSpec   `json:"spec"`
 	Status MariaDBStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -532,6 +532,7 @@ type MariaDB struct {
 	// +kubebuilder:validation:XValidation:rule="self.galera.enabled && self.replication.enabled", message="You may only enable one HA method at a time, either 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled'"
 	// +kubebuilder:validation:XValidation:rule="self.replicas > 1 && (self.galera.enabled || self.replication.enabled)", message="Multiple replicas (mariadb.spec.replicas) can only be specified when 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled' are true"
 	// +kubebuilder:validation:XValidation:rule="self.replicas <= 1 && (!self.galera.enabled && !self.replication.enabled)", message="If 'mariadb.spec.replicas' is set to 1 or less than 'mariadb.spec.galera.enabled' and 'mariadb.spec.replication.enabled' have to be false to disable HA"
+	// +kubebuilder:validation:XValidation:rule="(self.galera.replicaThreads > 0 && self.galera.enabled) || !self.galera.enabled", message="If 'mariadb.spec.galera.enabled' is true than 'mariadb.spec.galera.replicaThreads' must be at least 1"
 	Spec   MariaDBSpec   `json:"spec"`
 	Status MariaDBStatus `json:"status,omitempty"`
 }

--- a/api/v1alpha1/mariadb_webhook.go
+++ b/api/v1alpha1/mariadb_webhook.go
@@ -250,12 +250,5 @@ func (r *MariaDB) validateUpdateStorage(old *MariaDB) error {
 }
 
 func (r *MariaDB) validateRootPassword() error {
-	if r.IsRootPasswordEmpty() && r.IsRootPasswordDefined() {
-		return field.Invalid(
-			field.NewPath("spec").Child("rootEmptyPassword"),
-			r.Spec.RootEmptyPassword,
-			"'spec.rootEmptyPassword' must be disabled when 'spec.rootPasswordSecretKeyRef' is specified",
-		)
-	}
 	return nil
 }

--- a/api/v1alpha1/mariadb_webhook.go
+++ b/api/v1alpha1/mariadb_webhook.go
@@ -93,13 +93,6 @@ func (r *MariaDB) ValidateDelete() (admission.Warnings, error) {
 }
 
 func (r *MariaDB) validateHA() error {
-	if r.IsHAEnabled() && r.Spec.Replicas <= 1 {
-		return field.Invalid(
-			field.NewPath("spec").Child("replicas"),
-			r.Spec.Replicas,
-			"Multiple replicas must be specified when 'spec.replication' or 'spec.galera' are configured",
-		)
-	}
 	return nil
 }
 

--- a/api/v1alpha1/mariadb_webhook.go
+++ b/api/v1alpha1/mariadb_webhook.go
@@ -93,13 +93,6 @@ func (r *MariaDB) ValidateDelete() (admission.Warnings, error) {
 }
 
 func (r *MariaDB) validateHA() error {
-	if !r.IsHAEnabled() && r.Spec.Replicas > 1 {
-		return field.Invalid(
-			field.NewPath("spec").Child("replicas"),
-			r.Spec.Replicas,
-			"Multiple replicas can only be specified when 'spec.replication' or 'spec.galera' are configured",
-		)
-	}
 	if r.IsHAEnabled() && r.Spec.Replicas <= 1 {
 		return field.Invalid(
 			field.NewPath("spec").Child("replicas"),

--- a/api/v1alpha1/mariadb_webhook.go
+++ b/api/v1alpha1/mariadb_webhook.go
@@ -130,13 +130,6 @@ func (r *MariaDB) validateGalera() error {
 			)
 		}
 	}
-	if galera.ReplicaThreads < 0 {
-		return field.Invalid(
-			field.NewPath("spec").Child("galera").Child("replicaThreads"),
-			galera.ReplicaThreads,
-			"'spec.galera.replicaThreads' must be at least 1",
-		)
-	}
 	_, exists := galera.ProviderOptions[galerakeys.WsrepOptISTRecvAddr]
 	if exists {
 		return field.Invalid(

--- a/api/v1alpha1/mariadb_webhook.go
+++ b/api/v1alpha1/mariadb_webhook.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"errors"
 	"reflect"
 
 	galerakeys "github.com/mariadb-operator/mariadb-operator/pkg/galera/config/keys"
@@ -94,9 +93,6 @@ func (r *MariaDB) ValidateDelete() (admission.Warnings, error) {
 }
 
 func (r *MariaDB) validateHA() error {
-	if r.Replication().Enabled && r.IsGaleraEnabled() {
-		return errors.New("You may only enable one HA method at a time, either 'spec.replication' or 'spec.galera'")
-	}
 	if !r.IsHAEnabled() && r.Spec.Replicas > 1 {
 		return field.Invalid(
 			field.NewPath("spec").Child("replicas"),

--- a/api/v1alpha1/mariadb_webhook_test.go
+++ b/api/v1alpha1/mariadb_webhook_test.go
@@ -478,20 +478,6 @@ var _ = Describe("MariaDB webhook", func() {
 				},
 				false,
 			),
-			Entry(
-				"Valid rootEmptyPassword",
-				&MariaDB{
-					ObjectMeta: meta,
-					Spec: MariaDBSpec{
-						RootPasswordSecretKeyRef: GeneratedSecretKeyRef{},
-						RootEmptyPassword:        ptr.To(true),
-						Storage: Storage{
-							Size: ptr.To(resource.MustParse("100Mi")),
-						},
-					},
-				},
-				false,
-			),
 		)
 
 		It("Should default replication", func() {

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -25071,6 +25071,10 @@ spec:
                 when 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled'
                 are true
               rule: self.replicas > 1 && (self.galera.enabled || self.replication.enabled)
+            - message: If 'mariadb.spec.replicas' is set to 1 or less than 'mariadb.spec.galera.enabled'
+                and 'mariadb.spec.replication.enabled' have to be false to disable
+                HA
+              rule: self.replicas <= 1 && (!self.galera.enabled && !self.replication.enabled)
           status:
             description: MariaDBStatus defines the observed state of MariaDB
             properties:

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -25075,6 +25075,9 @@ spec:
                 and 'mariadb.spec.replication.enabled' have to be false to disable
                 HA
               rule: self.replicas <= 1 && (!self.galera.enabled && !self.replication.enabled)
+            - message: If 'mariadb.spec.galera.enabled' is true than 'mariadb.spec.galera.replicaThreads'
+                must be at least 1
+              rule: (self.galera.replicaThreads > 0 && self.galera.enabled) || !self.galera.enabled
           status:
             description: MariaDBStatus defines the observed state of MariaDB
             properties:

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -25064,6 +25064,9 @@ spec:
                 is required to avoid split brain situations. Use ''mariadb.spec.replicasAllowEvenNumber:
                 true'' to disable this validation.'
               rule: self.replicas %2 == 1 || self.replicasAllowEvenNumber
+            - message: You may only enable one HA method at a time, either 'mariadb.spec.galera.enabled'
+                or 'mariadb.spec.replication.enabled'
+              rule: self.galera.enabled && self.replication.enabled
           status:
             description: MariaDBStatus defines the observed state of MariaDB
             properties:

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -25063,25 +25063,30 @@ spec:
             - message: 'An odd number of MariaDB instances (mariadb.spec.replicas)
                 is required to avoid split brain situations. Use ''mariadb.spec.replicasAllowEvenNumber:
                 true'' to disable this validation.'
-              rule: self.replicas %2 == 1 || self.replicasAllowEvenNumber
+              rule: self.replicas %2 == 1 || self.?replicasAllowEvenNumber.orValue(false)
+                == true
             - message: You may only enable one HA method at a time, either 'mariadb.spec.galera.enabled'
                 or 'mariadb.spec.replication.enabled'
-              rule: self.galera.enabled && self.replication.enabled
+              rule: self.?galera.enabled.orValue(false) == false || self.?replication.enabled.orValue(false)
+                == false
             - message: Multiple replicas (mariadb.spec.replicas) can only be specified
                 when 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled'
                 are true
-              rule: self.replicas > 1 && (self.galera.enabled || self.replication.enabled)
+              rule: self.replicas <= 1 || (self.replicas > 1 && (self.?galera.enabled.orValue(false)
+                == true || self.?replication.enabled.orValue(false) == true))
             - message: If 'mariadb.spec.replicas' is set to 1 or less than 'mariadb.spec.galera.enabled'
                 and 'mariadb.spec.replication.enabled' have to be false to disable
                 HA
-              rule: self.replicas <= 1 && (!self.galera.enabled && !self.replication.enabled)
+              rule: self.replicas > 1 || (self.replicas <= 1 && (self.?galera.enabled.orValue(false)
+                == false || self.?replication.enabled.orValue(false) == false))
             - message: If 'mariadb.spec.galera.enabled' is true than 'mariadb.spec.galera.replicaThreads'
                 must be at least 1
-              rule: (self.galera.replicaThreads > 0 && self.galera.enabled) || !self.galera.enabled
+              rule: self.?galera.enabled.orValue(false) == false || (self.?galera.enabled.orValue(false)
+                == true && self.?galera.replicaThreads.orValue(0) > 0)
             - message: '''mariadb.spec.rootEmptyPassword'' must be disabled when ''mariadb.spec.rootPasswordSecretKeyRef''
                 is specified'
               rule: type(self.rootPasswordSecretKeyRef) != map || (type(self.rootPasswordSecretKeyRef)
-                == map && !self.rootEmptyPassword)
+                == map && self.?rootEmptyPassword.orValue(false) == false)
           status:
             description: MariaDBStatus defines the observed state of MariaDB
             properties:

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -25078,6 +25078,10 @@ spec:
             - message: If 'mariadb.spec.galera.enabled' is true than 'mariadb.spec.galera.replicaThreads'
                 must be at least 1
               rule: (self.galera.replicaThreads > 0 && self.galera.enabled) || !self.galera.enabled
+            - message: '''mariadb.spec.rootEmptyPassword'' must be disabled when ''mariadb.spec.rootPasswordSecretKeyRef''
+                is specified'
+              rule: type(self.rootPasswordSecretKeyRef) != map || (type(self.rootPasswordSecretKeyRef)
+                == map && !self.rootEmptyPassword)
           status:
             description: MariaDBStatus defines the observed state of MariaDB
             properties:

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -25067,6 +25067,10 @@ spec:
             - message: You may only enable one HA method at a time, either 'mariadb.spec.galera.enabled'
                 or 'mariadb.spec.replication.enabled'
               rule: self.galera.enabled && self.replication.enabled
+            - message: Multiple replicas (mariadb.spec.replicas) can only be specified
+                when 'mariadb.spec.galera.enabled' or 'mariadb.spec.replication.enabled'
+                are true
+              rule: self.replicas > 1 && (self.galera.enabled || self.replication.enabled)
           status:
             description: MariaDBStatus defines the observed state of MariaDB
             properties:

--- a/internal/controller/mariadb_controller_galera_test.go
+++ b/internal/controller/mariadb_controller_galera_test.go
@@ -93,6 +93,7 @@ var _ = Describe("MariaDB Galera", Ordered, func() {
 								},
 							},
 						},
+						ReplicaThreads: 1,
 					},
 				},
 				Replicas: 3,


### PR DESCRIPTION
To simplify the webhook code i have migrated several checks into CRD validations using the CEL syntax including support for potentially undefined YAML keys.

## validateHA function
- duplicate HA method check
- replica count check
- replica count check for disabled HA
## validateGalera function
- galera.replicaThreads check
## validateRootPassword function
- mariadb.rootEmptyPassword check

I have kept the empty functions to be able to add other checks that are not possible with the CEL feature set.