### PR TITLE
Allow scaling to 0 to stop workloads

### DIFF
--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -34,6 +34,7 @@ const (
 	ConditionReasonUpdating            string = "Updating"
 	ConditionReasonUpdated             string = "Updated"
 	ConditionReasonSuspended           string = "Suspended"
+	ConditionReasonStopped             string = "Stopped"
 
 	ConditionReasonMaxScaleNotReady string = "MaxScaleNotReady"
 	ConditionReasonMaxScaleReady    string = "MaxScaleReady"

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -429,9 +429,9 @@ type MariaDBSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	MaxScale *MariaDBMaxScaleSpec `json:"maxScale,omitempty"`
 	// Replicas indicates the number of desired instances.
-	// +kubebuilder:default=1
+	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:podCount"}
-	Replicas int32 `json:"replicas,omitempty"`
+	Replicas int32 `json:"replicas"`
 	// disables the validation check for an odd number of replicas.
 	// +kubebuilder:default=false
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
@@ -701,6 +701,11 @@ func (m *MariaDB) IsUpdating() bool {
 		return false
 	}
 	return condition.Status == metav1.ConditionFalse && condition.Reason == ConditionReasonUpdating
+}
+
+// IsStopped whether a MariaDB is stopped.
+func (m *MariaDB) IsStopped() bool {
+	return m.Spec.Replicas == 0
 }
 
 // IsSuspended whether a MariaDB is suspended.

--- a/api/v1alpha1/mariadb_webhook.go
+++ b/api/v1alpha1/mariadb_webhook.go
@@ -104,7 +104,7 @@ func (r *MariaDB) validateHA() error {
 			"Multiple replicas can only be specified when 'spec.replication' or 'spec.galera' are configured",
 		)
 	}
-	if r.IsHAEnabled() && r.Spec.Replicas <= 1 {
+	if r.IsHAEnabled() && r.Spec.Replicas <= 1 && !r.IsStopped() {
 		return field.Invalid(
 			field.NewPath("spec").Child("replicas"),
 			r.Spec.Replicas,
@@ -127,7 +127,7 @@ func (r *MariaDB) validateMaxScale() error {
 
 func (r *MariaDB) validateGalera() error {
 	galera := ptr.Deref(r.Spec.Galera, Galera{})
-	if !galera.Enabled {
+	if !galera.Enabled || r.IsStopped() {
 		return nil
 	}
 	if galera.Primary.PodIndex != nil {

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -21334,7 +21334,6 @@ spec:
                     type: integer
                 type: object
               replicas:
-                default: 1
                 description: Replicas indicates the number of desired instances.
                 format: int32
                 type: integer

--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -575,7 +575,7 @@ func (r *MariaDBReconciler) reconcileInternalService(ctx context.Context, mariad
 }
 
 func (r *MariaDBReconciler) reconcilePrimaryService(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB) (ctrl.Result, error) {
-	if mariadb.Status.CurrentPrimaryPodIndex == nil {
+	if mariadb.Status.CurrentPrimaryPodIndex == nil && !mariadb.IsStopped() {
 		log.FromContext(ctx).V(1).Info("'status.currentPrimaryPodIndex' must be set")
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
@@ -638,7 +638,7 @@ func (r *MariaDBReconciler) reconcileSecondaryService(ctx context.Context, maria
 }
 
 func (r *MariaDBReconciler) reconcileSQL(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB) (ctrl.Result, error) {
-	if !mariadb.IsReady() {
+	if !mariadb.IsReady() && !mariadb.IsStopped() {
 		log.FromContext(ctx).V(1).Info("MariaDB not ready. Requeuing SQL resources")
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
@@ -793,7 +793,7 @@ func (r *MariaDBReconciler) setSpecDefaults(ctx context.Context, mariadb *mariad
 }
 
 func (r *MariaDBReconciler) reconcileSuspend(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB) (ctrl.Result, error) {
-	if mariadb.IsSuspended() {
+	if mariadb.IsSuspended() && !mariadb.IsStopped() {
 		log.FromContext(ctx).V(1).Info("MariaDB is suspended. Skipping...")
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
@@ -804,7 +804,7 @@ func (r *MariaDBReconciler) reconcileConnection(ctx context.Context, mariadb *ma
 	if !mariadb.IsInitialUserEnabled() {
 		return ctrl.Result{}, nil
 	}
-	if !mariadb.IsReady() {
+	if !mariadb.IsReady() && !mariadb.IsStopped() {
 		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 	if mariadb.IsHAEnabled() {

--- a/internal/controller/mariadb_controller_status.go
+++ b/internal/controller/mariadb_controller_status.go
@@ -31,6 +31,13 @@ func (r *MariaDBReconciler) reconcileStatus(ctx context.Context, mdb *mariadbv1a
 		})
 	}
 
+	if mdb.IsStopped() {
+		return ctrl.Result{}, r.patchStatus(ctx, mdb, func(status *mariadbv1alpha1.MariaDBStatus) error {
+			condition.SetReadyStopped(status)
+			return nil
+		})
+	}
+
 	var sts appsv1.StatefulSet
 	if err := r.Get(ctx, client.ObjectKeyFromObject(mdb), &sts); err != nil {
 		log.FromContext(ctx).V(1).Info("error getting StatefulSet", "err", err)

--- a/internal/controller/mariadb_controller_update.go
+++ b/internal/controller/mariadb_controller_update.go
@@ -23,7 +23,7 @@ import (
 )
 
 func shouldReconcileUpdates(mdb *mariadbv1alpha1.MariaDB) bool {
-	if mdb.IsRestoringBackup() || mdb.IsResizingStorage() || mdb.IsSwitchingPrimary() || mdb.HasGaleraNotReadyCondition() {
+	if mdb.IsRestoringBackup() || mdb.IsResizingStorage() || mdb.IsSwitchingPrimary() || mdb.HasGaleraNotReadyCondition() || mdb.IsStopped() {
 		return false
 	}
 	if mdb.Spec.UpdateStrategy.Type != mariadbv1alpha1.ReplicasFirstPrimaryLast {

--- a/pkg/condition/ready.go
+++ b/pkg/condition/ready.go
@@ -216,3 +216,12 @@ func SetReadySuspended(c Conditioner) {
 		Message: "Suspended",
 	})
 }
+
+func SetReadyStopped(c Conditioner) {
+	c.SetCondition(metav1.Condition{
+		Type:    mariadbv1alpha1.ConditionTypeReady,
+		Status:  metav1.ConditionFalse,
+		Reason:  mariadbv1alpha1.ConditionReasonStopped,
+		Message: "Stopped",
+	})
+}


### PR DESCRIPTION
Close https://github.com/mariadb-operator/mariadb-operator/issues/642
Close https://github.com/mariadb-operator/mariadb-operator/issues/638

Allows scaling to 0 to stop workloads. Works both ways, by scaling mariadb resource (`kubectl scale mdb`) and statefulset (`kubectl scale sts`) - changes are reflected to the related resource.