### PR TITLE
Stop polling when `MariaDB` not found

### DIFF
--- a/pkg/controller/galera/recovery.go
+++ b/pkg/controller/galera/recovery.go
@@ -196,15 +196,17 @@ func (r *GaleraReconciler) restartPods(ctx context.Context, mariadb *mariadbv1al
 			logger.Info("Restarting Pod", "pod", key.Name)
 		}
 
+		mariadbKey := ctrlclient.ObjectKeyFromObject(mariadb)
+
 		syncTimeout := ptr.Deref(recovery.PodSyncTimeout, metav1.Duration{Duration: 5 * time.Minute}).Duration
 		syncCtx, syncCancel := context.WithTimeout(ctx, syncTimeout)
 		defer syncCancel()
 
-		if err := wait.PollUntilSucessWithTimeout(syncCtx, logger, func(ctx context.Context) error {
-			if err := r.pollUntilPodDeleted(ctx, key, logger); err != nil {
+		if err := wait.PollWithMariaDB(syncCtx, mariadbKey, r.Client, logger, func(ctx context.Context) error {
+			if err := r.pollUntilPodDeleted(ctx, mariadbKey, key, logger); err != nil {
 				return fmt.Errorf("error deleting Pod '%s': %v", key.Name, err)
 			}
-			if err := r.pollUntilPodSynced(ctx, key, sqlClientSet, logger); err != nil {
+			if err := r.pollUntilPodSynced(ctx, mariadbKey, key, sqlClientSet, logger); err != nil {
 				return fmt.Errorf("error waiting for Pod '%s' to be synced: %v", key.Name, err)
 			}
 			return nil
@@ -263,14 +265,15 @@ func (r *GaleraReconciler) getGaleraState(ctx context.Context, mariadb *mariadbv
 
 			galera := ptr.Deref(mariadb.Spec.Galera, mariadbv1alpha1.Galera{})
 			recovery := ptr.Deref(galera.Recovery, mariadbv1alpha1.GaleraRecovery{})
+			mariadbKey := ctrlclient.ObjectKeyFromObject(mariadb)
 			stateLogger := logger.WithValues("pod", pod.Name)
 
 			recoveryTimeout := ptr.Deref(recovery.PodRecoveryTimeout, metav1.Duration{Duration: 5 * time.Minute}).Duration
 			recoveryCtx, cancelRecovery := context.WithTimeout(ctx, recoveryTimeout)
 			defer cancelRecovery()
 
-			err = wait.PollUntilSucessWithTimeout(recoveryCtx, stateLogger, func(ctx context.Context) error {
-				if err := r.ensurePodRunning(ctx, ctrlclient.ObjectKeyFromObject(&pod), logger); err != nil {
+			err = wait.PollWithMariaDB(recoveryCtx, mariadbKey, r.Client, stateLogger, func(ctx context.Context) error {
+				if err := r.ensurePodRunning(ctx, mariadbKey, ctrlclient.ObjectKeyFromObject(&pod), logger); err != nil {
 					return err
 				}
 				galeraState, err := client.Galera.GetState(ctx)
@@ -349,37 +352,38 @@ func (r *GaleraReconciler) recoverGaleraState(ctx context.Context, mariadb *mari
 			recoveryCtx, cancelRecovery := context.WithTimeout(ctx, recoveryTimeout)
 			defer cancelRecovery()
 
-			if err = wait.PollUntilSucessWithTimeout(recoveryCtx, recoveryLogger, func(ctx context.Context) error {
-				var job batchv1.Job
-				if err := r.Get(ctx, recoveryJobKey, &job); err != nil {
-					return fmt.Errorf("error getting recovery Job for Pod '%s': %v", pod.Name, err)
-				}
+			if err = wait.PollWithMariaDB(recoveryCtx, ctrlclient.ObjectKeyFromObject(mariadb), r.Client, recoveryLogger,
+				func(ctx context.Context) error {
+					var job batchv1.Job
+					if err := r.Get(ctx, recoveryJobKey, &job); err != nil {
+						return fmt.Errorf("error getting recovery Job for Pod '%s': %v", pod.Name, err)
+					}
 
-				if !jobpkg.IsJobComplete(&job) {
-					return fmt.Errorf("recovery Job '%s' not complete", job.Name)
-				}
+					if !jobpkg.IsJobComplete(&job) {
+						return fmt.Errorf("recovery Job '%s' not complete", job.Name)
+					}
 
-				logs, err := r.getJobLogs(ctx, recoveryJobKey)
-				if err != nil {
-					return fmt.Errorf("error getting logs from recovery Job '%s': %v", job.Name, err)
-				}
+					logs, err := r.getJobLogs(ctx, recoveryJobKey)
+					if err != nil {
+						return fmt.Errorf("error getting logs from recovery Job '%s': %v", job.Name, err)
+					}
 
-				var bootstrap galerarecovery.Bootstrap
-				if err := bootstrap.Unmarshal([]byte(logs)); err != nil {
-					return fmt.Errorf("error unmarshaling recovery logs from Job '%s': %v", job.Name, err)
-				}
+					var bootstrap galerarecovery.Bootstrap
+					if err := bootstrap.Unmarshal([]byte(logs)); err != nil {
+						return fmt.Errorf("error unmarshaling recovery logs from Job '%s': %v", job.Name, err)
+					}
 
-				recoveryLogger.Info(
-					"Recovered Galera state",
-					"sequence", bootstrap.Seqno,
-					"uuid", bootstrap.UUID,
-				)
-				r.recorder.Eventf(mariadb, corev1.EventTypeNormal, mariadbv1alpha1.ReasonGaleraPodRecovered,
-					"Recovered Galera sequence in Pod '%s'", pod.Name)
-				rs.setRecovered(pod.Name, &bootstrap)
+					recoveryLogger.Info(
+						"Recovered Galera state",
+						"sequence", bootstrap.Seqno,
+						"uuid", bootstrap.UUID,
+					)
+					r.recorder.Eventf(mariadb, corev1.EventTypeNormal, mariadbv1alpha1.ReasonGaleraPodRecovered,
+						"Recovered Galera sequence in Pod '%s'", pod.Name)
+					rs.setRecovered(pod.Name, &bootstrap)
 
-				return nil
-			}); err != nil {
+					return nil
+				}); err != nil {
 				return fmt.Errorf("error performing recovery in Pod '%s': %v", pod.Name, err)
 			}
 			return nil
@@ -407,12 +411,13 @@ func (r *GaleraReconciler) bootstrap(ctx context.Context, src *bootstrapSource, 
 	bootstrapCtx, cancelBootstrap := context.WithTimeout(ctx, 3*time.Minute)
 	defer cancelBootstrap()
 
+	mariadbKey := ctrlclient.ObjectKeyFromObject(mdb)
 	podKey := types.NamespacedName{
 		Name:      src.pod,
 		Namespace: mdb.Namespace,
 	}
-	if err = wait.PollUntilSucessWithTimeout(bootstrapCtx, logger, func(ctx context.Context) error {
-		if err := r.ensurePodRunning(ctx, podKey, logger); err != nil {
+	if err = wait.PollWithMariaDB(bootstrapCtx, mariadbKey, r.Client, logger, func(ctx context.Context) error {
+		if err := r.ensurePodRunning(ctx, mariadbKey, podKey, logger); err != nil {
 			return err
 		}
 		return client.Galera.EnableBootstrap(ctx, src.bootstrap)
@@ -424,7 +429,7 @@ func (r *GaleraReconciler) bootstrap(ctx context.Context, src *bootstrapSource, 
 	return nil
 }
 
-func (r *GaleraReconciler) ensurePodRunning(ctx context.Context, podKey types.NamespacedName, logger logr.Logger) error {
+func (r *GaleraReconciler) ensurePodRunning(ctx context.Context, mariadbKey, podKey types.NamespacedName, logger logr.Logger) error {
 	var pod corev1.Pod
 	if err := r.Get(ctx, podKey, &pod); err != nil {
 		return fmt.Errorf("error getting Pod '%s': %v", podKey.Name, err)
@@ -436,7 +441,7 @@ func (r *GaleraReconciler) ensurePodRunning(ctx context.Context, podKey types.Na
 	if err := r.Delete(ctx, &pod); err != nil {
 		return fmt.Errorf("error deleting Pod '%s': %v", podKey.Name, err)
 	}
-	return r.pollUntilPodRunning(ctx, podKey, logger)
+	return r.pollUntilPodRunning(ctx, mariadbKey, podKey, logger)
 }
 
 func (r *GaleraReconciler) ensureJob(ctx context.Context, recoveryJob *batchv1.Job) error {
@@ -453,8 +458,8 @@ func (r *GaleraReconciler) ensureJob(ctx context.Context, recoveryJob *batchv1.J
 	return r.Delete(ctx, recoveryJob, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationBackground)})
 }
 
-func (r *GaleraReconciler) pollUntilPodRunning(ctx context.Context, podKey types.NamespacedName, logger logr.Logger) error {
-	return wait.PollUntilSucessWithTimeout(ctx, logger, func(ctx context.Context) error {
+func (r *GaleraReconciler) pollUntilPodRunning(ctx context.Context, mariadbKey, podKey types.NamespacedName, logger logr.Logger) error {
+	return wait.PollWithMariaDB(ctx, mariadbKey, r.Client, logger, func(ctx context.Context) error {
 		var pod corev1.Pod
 		if err := r.Get(ctx, podKey, &pod); err != nil {
 			return fmt.Errorf("error getting Pod '%s': %v", podKey.Name, err)
@@ -466,8 +471,8 @@ func (r *GaleraReconciler) pollUntilPodRunning(ctx context.Context, podKey types
 	})
 }
 
-func (r *GaleraReconciler) pollUntilPodDeleted(ctx context.Context, podKey types.NamespacedName, logger logr.Logger) error {
-	return wait.PollUntilSucessWithTimeout(ctx, logger, func(ctx context.Context) error {
+func (r *GaleraReconciler) pollUntilPodDeleted(ctx context.Context, mariadbKey, podKey types.NamespacedName, logger logr.Logger) error {
+	return wait.PollWithMariaDB(ctx, mariadbKey, r.Client, logger, func(ctx context.Context) error {
 		var pod corev1.Pod
 		if err := r.Get(ctx, podKey, &pod); err != nil {
 			return fmt.Errorf("error getting Pod '%s': %v", podKey.Name, err)
@@ -479,9 +484,9 @@ func (r *GaleraReconciler) pollUntilPodDeleted(ctx context.Context, podKey types
 	})
 }
 
-func (r *GaleraReconciler) pollUntilPodSynced(ctx context.Context, podKey types.NamespacedName, sqlClientSet *sqlclientset.ClientSet,
-	logger logr.Logger) error {
-	return wait.PollUntilSucessWithTimeout(ctx, logger, func(ctx context.Context) error {
+func (r *GaleraReconciler) pollUntilPodSynced(ctx context.Context, mariadbKey, podKey types.NamespacedName,
+	sqlClientSet *sqlclientset.ClientSet, logger logr.Logger) error {
+	return wait.PollWithMariaDB(ctx, mariadbKey, r.Client, logger, func(ctx context.Context) error {
 		var pod corev1.Pod
 		if err := r.Get(ctx, podKey, &pod); err != nil {
 			return fmt.Errorf("error getting Pod '%s': %v", podKey.Name, err)

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -5,18 +5,38 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
 	kwait "k8s.io/apimachinery/pkg/util/wait"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func PollUntilSucessWithTimeout(ctx context.Context, logger logr.Logger, fn func(ctx context.Context) error) error {
-	if err := kwait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
+func PollUntilSucessOrContextCancel(ctx context.Context, logger logr.Logger, fn func(ctx context.Context) error) error {
+	return kwait.PollUntilContextCancel(ctx, 1*time.Second, true, func(ctx context.Context) (bool, error) {
 		if err := fn(ctx); err != nil {
 			logger.V(1).Info("Error polling", "err", err)
 			return false, nil
 		}
 		return true, nil
-	}); err != nil {
-		return err
+	})
+}
+
+func PollWithMariaDB(ctx context.Context, mariadbKey types.NamespacedName, client ctrlclient.Client, logger logr.Logger,
+	fn func(ctx context.Context) error) error {
+	return PollUntilSucessOrContextCancel(ctx, logger, func(ctx context.Context) error {
+		if shouldPoll(ctx, mariadbKey, client, logger) {
+			return fn(ctx)
+		}
+		return nil
+	})
+}
+
+func shouldPoll(ctx context.Context, mariadbKey types.NamespacedName, client ctrlclient.Client, logger logr.Logger) bool {
+	var mdb mariadbv1alpha1.MariaDB
+	if err := client.Get(ctx, mariadbKey, &mdb); err != nil {
+		logger.V(1).Info("Error getting MariaDB", "err", err)
+		return !apierrors.IsNotFound(err)
 	}
-	return nil
+	return true
 }


### PR DESCRIPTION
If the `MariaDB` resource gets deleted while polling, the operator keeps polling until reaching a timeout and therefore blocking any other reconciliation.

This PR fixes this issue by cancelling polling whenever `MariaDB` gets deleted.