### PR TITLE
Support for `MaxConcurrentReconciles`. Set `MariaDB` and `MaxScale` concurrent reconciles to 10 by default

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -41,20 +41,29 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 )
 
 var (
-	scheme            = runtime.NewScheme()
-	setupLog          = ctrl.Log.WithName("setup")
-	metricsAddr       string
-	healthAddr        string
-	logLevel          string
-	logTimeEncoder    string
-	logDev            bool
-	logMaxScale       bool
-	logSql            bool
-	leaderElect       bool
+	scheme      = runtime.NewScheme()
+	setupLog    = ctrl.Log.WithName("setup")
+	metricsAddr string
+	healthAddr  string
+
+	leaderElect bool
+
+	logLevel       string
+	logTimeEncoder string
+	logDev         bool
+	logMaxScale    bool
+	logSql         bool
+
+	maxConcurrentReconciles         int
+	mariadbMaxConcurrentReconciles  int
+	maxscaleMaxConcurrentReconciles int
+
 	requeueConnection time.Duration
 	requeueSql        time.Duration
 	requeueSqlJob     time.Duration
@@ -70,6 +79,9 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	rootCmd.PersistentFlags().StringVar(&healthAddr, "health-addr", ":8081", "The address the probe endpoint binds to.")
+
+	rootCmd.PersistentFlags().BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager.")
+
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level to use, one of: "+
 		"debug, info, warn, error, dpanic, panic, fatal.")
 	rootCmd.PersistentFlags().StringVar(&logTimeEncoder, "log-time-encoder", "epoch", "Log time encoder to use, one of: "+
@@ -77,7 +89,14 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&logDev, "log-dev", false, "Enable development logs.")
 	rootCmd.Flags().BoolVar(&logMaxScale, "log-maxscale", false, "Enable MaxScale API request logs.")
 	rootCmd.Flags().BoolVar(&logSql, "log-sql", false, "Enable SQL resource logs.")
-	rootCmd.PersistentFlags().BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager.")
+
+	rootCmd.Flags().IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1,
+		"Global maximum number of concurrent reconciles per resource.")
+	rootCmd.Flags().IntVar(&mariadbMaxConcurrentReconciles, "mariadb-max-concurrent-reconciles", 10,
+		"Maximum number of concurrent reconciles per MariaDB.")
+	rootCmd.Flags().IntVar(&maxscaleMaxConcurrentReconciles, "maxscale-max-concurrent-reconciles", 10,
+		"Maximum number of concurrent reconciles per MaxScale.")
+
 	rootCmd.Flags().DurationVar(&requeueConnection, "requeue-connection", 30*time.Second, "The interval at which Connections are requeued.")
 	rootCmd.Flags().DurationVar(&requeueSql, "requeue-sql", 30*time.Second, "The interval at which SQL objects are requeued.")
 	rootCmd.Flags().DurationVar(&requeueSqlJob, "requeue-sqljob", 5*time.Second, "The interval at which SqlJobs are requeued.")
@@ -122,6 +141,9 @@ var rootCmd = &cobra.Command{
 			HealthProbeBindAddress: healthAddr,
 			LeaderElection:         leaderElect,
 			LeaderElectionID:       "mariadb-operator.mariadb.com",
+			Controller: config.Controller{
+				MaxConcurrentReconciles: maxConcurrentReconciles,
+			},
 		}
 		if env.WatchNamespace != "" {
 			namespaces, err := env.WatchNamespaces()
@@ -261,7 +283,7 @@ var rootCmd = &cobra.Command{
 			MaxScaleReconciler:    mxsReconciler,
 			ReplicationReconciler: replicationReconciler,
 			GaleraReconciler:      galeraReconciler,
-		}).SetupWithManager(ctx, mgr); err != nil {
+		}).SetupWithManager(ctx, mgr, ctrlcontroller.Options{MaxConcurrentReconciles: mariadbMaxConcurrentReconciles}); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "MariaDB")
 			os.Exit(1)
 		}
@@ -288,7 +310,7 @@ var rootCmd = &cobra.Command{
 
 			RequeueInterval: requeueMaxScale,
 			LogMaxScale:     logMaxScale,
-		}).SetupWithManager(ctx, mgr); err != nil {
+		}).SetupWithManager(ctx, mgr, ctrlcontroller.Options{MaxConcurrentReconciles: maxscaleMaxConcurrentReconciles}); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "MaxScale")
 			os.Exit(1)
 		}

--- a/cmd/enterprise/main.go
+++ b/cmd/enterprise/main.go
@@ -41,29 +41,39 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var (
-	scheme            = runtime.NewScheme()
-	setupLog          = ctrl.Log.WithName("setup")
-	metricsAddr       string
-	healthAddr        string
-	logLevel          string
-	logTimeEncoder    string
-	logDev            bool
-	logMaxScale       bool
-	logSql            bool
-	leaderElect       bool
+	scheme      = runtime.NewScheme()
+	setupLog    = ctrl.Log.WithName("setup")
+	metricsAddr string
+	healthAddr  string
+
+	leaderElect bool
+
+	logLevel       string
+	logTimeEncoder string
+	logDev         bool
+	logMaxScale    bool
+	logSql         bool
+
+	maxConcurrentReconciles         int
+	mariadbMaxConcurrentReconciles  int
+	maxscaleMaxConcurrentReconciles int
+
 	requeueConnection time.Duration
 	requeueSql        time.Duration
 	requeueSqlJob     time.Duration
 	requeueMaxScale   time.Duration
-	webhookEnabled    bool
-	webhookPort       int
-	webhookCertDir    string
+
+	webhookEnabled bool
+	webhookPort    int
+	webhookCertDir string
 
 	featureMaxScaleSuspend bool
 )
@@ -75,6 +85,9 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	rootCmd.PersistentFlags().StringVar(&healthAddr, "health-addr", ":8081", "The address the probe endpoint binds to.")
+
+	rootCmd.PersistentFlags().BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager.")
+
 	rootCmd.PersistentFlags().StringVar(&logLevel, "log-level", "info", "Log level to use, one of: "+
 		"debug, info, warn, error, dpanic, panic, fatal.")
 	rootCmd.PersistentFlags().StringVar(&logTimeEncoder, "log-time-encoder", "epoch", "Log time encoder to use, one of: "+
@@ -82,17 +95,26 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&logDev, "log-dev", false, "Enable development logs.")
 	rootCmd.Flags().BoolVar(&logSql, "log-sql", false, "Enable SQL resource logs.")
 	rootCmd.Flags().BoolVar(&logMaxScale, "log-maxscale", false, "Enable MaxScale API request logs.")
-	rootCmd.PersistentFlags().BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager.")
+
+	rootCmd.Flags().IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1,
+		"Global maximum number of concurrent reconciles per resource.")
+	rootCmd.Flags().IntVar(&mariadbMaxConcurrentReconciles, "mariadb-max-concurrent-reconciles", 10,
+		"Maximum number of concurrent reconciles per MariaDB.")
+	rootCmd.Flags().IntVar(&maxscaleMaxConcurrentReconciles, "maxscale-max-concurrent-reconciles", 10,
+		"Maximum number of concurrent reconciles per MaxScale.")
+
 	rootCmd.Flags().DurationVar(&requeueConnection, "requeue-connection", 30*time.Second, "The interval at which Connections are requeued.")
 	rootCmd.Flags().DurationVar(&requeueSql, "requeue-sql", 30*time.Second, "The interval at which SQL objects are requeued.")
 	rootCmd.Flags().DurationVar(&requeueSqlJob, "requeue-sqljob", 5*time.Second, "The interval at which SqlJobs are requeued.")
 	rootCmd.Flags().DurationVar(&requeueMaxScale, "requeue-maxscale", 10*time.Second, "The interval at which MaxScales are requeued.")
+
 	rootCmd.Flags().BoolVar(&webhookEnabled, "webhook", true, "Enable the webhook server.")
 	rootCmd.Flags().IntVar(&webhookPort, "webhook-port", 9443, "Port to be used by the webhook server."+
 		"This only applies if the webhook server is enabled.")
 	rootCmd.Flags().StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs",
 		"Directory containing the TLS certificate for the webhook server. 'tls.crt' and 'tls.key' must be present in this directory."+
 			"This only applies if the webhook server is enabled.")
+
 	rootCmd.Flags().BoolVar(&featureMaxScaleSuspend, "feature-maxscale-suspend", false, "Feature flag to enable MaxScale resource suspension.")
 }
 
@@ -132,6 +154,9 @@ var rootCmd = &cobra.Command{
 			HealthProbeBindAddress: healthAddr,
 			LeaderElection:         leaderElect,
 			LeaderElectionID:       "mariadb-operator-enterprise.k8s.mariadb.com",
+			Controller: config.Controller{
+				MaxConcurrentReconciles: maxConcurrentReconciles,
+			},
 		}
 		if webhookEnabled {
 			setupLog.Info("Enabling webhook")
@@ -279,7 +304,7 @@ var rootCmd = &cobra.Command{
 			MaxScaleReconciler:    mxsReconciler,
 			ReplicationReconciler: replicationReconciler,
 			GaleraReconciler:      galeraReconciler,
-		}).SetupWithManager(ctx, mgr); err != nil {
+		}).SetupWithManager(ctx, mgr, ctrlcontroller.Options{MaxConcurrentReconciles: mariadbMaxConcurrentReconciles}); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "MariaDB")
 			os.Exit(1)
 		}
@@ -306,7 +331,7 @@ var rootCmd = &cobra.Command{
 
 			RequeueInterval: requeueMaxScale,
 			LogMaxScale:     logMaxScale,
-		}).SetupWithManager(ctx, mgr); err != nil {
+		}).SetupWithManager(ctx, mgr, ctrlcontroller.Options{MaxConcurrentReconciles: maxscaleMaxConcurrentReconciles}); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "MaxScale")
 			os.Exit(1)
 		}

--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -47,6 +47,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -914,7 +915,7 @@ func (r *MariaDBReconciler) patch(ctx context.Context, mariadb *mariadbv1alpha1.
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MariaDBReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *MariaDBReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opts controller.Options) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&mariadbv1alpha1.MariaDB{}).
 		Owns(&mariadbv1alpha1.MaxScale{}).
@@ -932,7 +933,8 @@ func (r *MariaDBReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&rbacv1.Role{}).
 		Owns(&rbacv1.RoleBinding{}).
-		Owns(&rbacv1.ClusterRoleBinding{})
+		Owns(&rbacv1.ClusterRoleBinding{}).
+		WithOptions(opts)
 
 	watcherIndexer := watch.NewWatcherIndexer(mgr, builder, r.Client)
 	if err := watcherIndexer.Watch(

--- a/internal/controller/maxscale_controller.go
+++ b/internal/controller/maxscale_controller.go
@@ -41,6 +41,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlbuilder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -1367,7 +1368,7 @@ func (r *MaxScaleReconciler) requeueResult(ctx context.Context, mxs *mariadbv1al
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *MaxScaleReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *MaxScaleReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opts controller.Options) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&mariadbv1alpha1.MaxScale{}).
 		Owns(&mariadbv1alpha1.User{}).
@@ -1377,7 +1378,8 @@ func (r *MaxScaleReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Mana
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&appsv1.StatefulSet{}).
-		Owns(&appsv1.Deployment{})
+		Owns(&appsv1.Deployment{}).
+		WithOptions(opts)
 
 	watcherIndexer := watch.NewWatcherIndexer(mgr, builder, r.Client)
 	if err := watcherIndexer.Watch(

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -39,6 +39,8 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	log "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -103,6 +105,9 @@ var _ = BeforeSuite(func() {
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
+		Controller: config.Controller{
+			MaxConcurrentReconciles: 1,
+		},
 	})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -215,7 +220,7 @@ var _ = BeforeSuite(func() {
 		MaxScaleReconciler:    mxsReconciler,
 		ReplicationReconciler: replicationReconciler,
 		GaleraReconciler:      galeraReconciler,
-	}).SetupWithManager(testCtx, k8sManager)
+	}).SetupWithManager(testCtx, k8sManager, ctrlcontroller.Options{MaxConcurrentReconciles: 10})
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&MaxScaleReconciler{
@@ -241,7 +246,7 @@ var _ = BeforeSuite(func() {
 
 		RequeueInterval: 5 * time.Second,
 		LogMaxScale:     false,
-	}).SetupWithManager(testCtx, k8sManager)
+	}).SetupWithManager(testCtx, k8sManager, ctrlcontroller.Options{MaxConcurrentReconciles: 10})
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&BackupReconciler{


### PR DESCRIPTION
The following controller flags have been introduced, they can be specified via [extraArgs](https://github.com/mariadb-operator/mariadb-operator/blob/6c224f6345faa28f7341120510fee8605a5ee14b/deploy/charts/mariadb-operator/values.yaml#L60):
- `max-concurrent-reconciles`: Global maximum number of concurrent reconciles per resource. Defaults to 1.
- `mariadb-max-concurrent-reconciles`:  Maximum number of concurrent reconciles per `MariaDB`. Defaults to 10.
- `maxscale-max-concurrent-reconciles`: Maximum number of concurrent reconciles per `MaxScale`. Defaults to 10.