### PR TITLE
Run integration tests in parallel

### DIFF
--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -85,6 +85,15 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// Controllers only run in process 1 to avoid conflicts reconciling
+	if GinkgoParallelProcess() != 1 {
+		return
+	}
+
 	env, err := environment.GetOperatorEnv(testCtx)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -98,10 +107,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 	DeferCleanup(testEnv.Stop)
-
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
 
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,

--- a/make/dev.mk
+++ b/make/dev.mk
@@ -33,7 +33,7 @@ ENV_ENT ?= \
 	TEST_ENTERPRISE=true \
 	KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)
 
-TEST_ARGS ?= --coverprofile=cover.out --timeout 30m
+TEST_ARGS ?= --coverprofile=cover.out --timeout 30m -p
 TEST ?= $(ENV) $(GINKGO) $(TEST_ARGS)
 TEST_ENT ?= $(ENV_ENT) $(GINKGO) $(TEST_ARGS)
 


### PR DESCRIPTION
`MaxConcurrentReconciles` have been bumped to 10 for `MariaDB` and `MaxScale` in https://github.com/mariadb-operator/mariadb-operator/pull/833. Since we have more worker reconcilers, it is reasonable to increase test workers as well to speed up integration tests.