### PR TITLE
Cleanup previous SST in init container

### DIFF
--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -37,8 +37,8 @@ var (
 )
 
 const (
-	sstInProgressFile = "sst_in_progress"
 	wsrepSSTPidFile   = "wsrep_sst.pid"
+	sstInProgressFile = "sst_in_progress"
 )
 
 func init() {
@@ -219,12 +219,12 @@ func cleanupPreviousSST(fm *filemanager.FileManager) error {
 	for _, file := range []string{wsrepSSTPidFile, sstInProgressFile} {
 		exists, err := fm.StateFileExists(file)
 		if err != nil {
-			return fmt.Errorf("error checking if %s exists: %v", file, err)
+			return fmt.Errorf("error checking if %s file exists: %v", file, err)
 		}
 		if exists {
 			logger.Info("Deleting pending SST file", "file", file)
 			if err := fm.DeleteStateFile(file); err != nil && !errors.Is(err, fs.ErrNotExist) {
-				return err
+				return fmt.Errorf("error deleting %s file: %v", file, err)
 			}
 		}
 	}

--- a/pkg/galera/filemanager/filemanager.go
+++ b/pkg/galera/filemanager/filemanager.go
@@ -1,6 +1,7 @@
 package filemanager
 
 import (
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -39,6 +40,16 @@ func (f *FileManager) ReadStateFile(name string) ([]byte, error) {
 
 func (f *FileManager) DeleteStateFile(name string) error {
 	return os.Remove(filepath.Join(f.stateDir, name))
+}
+
+func (f *FileManager) StateFileExists(name string) (bool, error) {
+	if _, err := os.Stat(filepath.Join(f.stateDir, name)); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
 }
 
 func (f *FileManager) WriteConfigFile(name string, bytes []byte) error {

--- a/pkg/galera/filemanager/filemanager.go
+++ b/pkg/galera/filemanager/filemanager.go
@@ -66,7 +66,7 @@ func (f *FileManager) DeleteConfigFile(name string) error {
 
 func (f *FileManager) ConfigFileExists(name string) (bool, error) {
 	if _, err := os.Stat(filepath.Join(f.configDir, name)); err != nil {
-		if os.IsNotExist(err) {
+		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
 		}
 		return false, err


### PR DESCRIPTION
Close https://github.com/mariadb-operator/mariadb-operator/issues/425

We've been reported with Galera clusters being unable to recover due to pending SST errors:
```bash
WSREP_SST: [INFO] Stale sst_in_progress file: /var/lib/mysql/sst_in_progress (20240301 10:25:49.732)
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:49.822)
2024-03-01 10:25:50 0 [Note] WSREP: (11659a97-92de, 'tcp://0.0.0.0:4567') turning message relay requesting off
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:50.840)
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:51.858)
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:52.874)
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:53.890)
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:54.909)
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:55.927)
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:56.943)
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:57.962)
WSREP_SST: [INFO] previous SST is not completed, waiting for it to exit (20240301 10:25:58.980)
WSREP_SST: [ERROR] previous SST script still running. (20240301 10:25:58.987)
2024-03-01 10:25:58 0 [ERROR] WSREP: Failed to read 'ready <addr>' from: wsrep_sst_mariabackup --role 'joiner'
```

This happens when the MariaDB container restarts in the middle of an SST. When the new container comes up, it sees that `/var/lib/mysql/wsrep_sst.pid` exists, and therefore fails instead of making a new SST. Altough marked as pending, this previous SST will never complete, as the previous container handling it no longer exists.

To solve this, we have decided to clean up `/var/lib/mysql/wsrep_sst.pid` and `/var/lib/mysql/sst_in_progress` in the init container, to ensure that the SST succeeds and the node is able to join the cluster in this situations.

In order to apply this fix, make sure to bump the `initContainer` image once released:

```diff
apiVersion: k8s.mariadb.com/v1alpha1
kind: MariaDB
metadata:
  name: mariadb
spec:
  galera:
    initContainer:
-      image: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:v0.0.30
+      image: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:v0.0.31
```