### PR TITLE
Removed chmod from backup command

### DIFF
--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -150,11 +150,6 @@ func (b *BackupCommand) MariadbDump(backup *mariadbv1alpha1.Backup,
 			"printf \"${BACKUP_FILE}\" > %s",
 			b.TargetFilePath,
 		),
-		"echo 💾 Setting target file permissions",
-		fmt.Sprintf(
-			"chmod 777 %s",
-			b.TargetFilePath,
-		),
 		fmt.Sprintf(
 			"echo 💾 Taking backup: %s",
 			b.getTargetFilePath(),


### PR DESCRIPTION
Close https://github.com/mariadb-operator/mariadb-operator/issues/813

`chmod 777` is no longer needed in the backup command, as we are providing an `fsGroup`. 
https://github.com/mariadb-operator/mariadb-operator/blob/cca6bd09876829552b143dbf8005178c36b2d2be/pkg/builder/batch_builder.go#L100

The permissions are changed recursively by the CSI drivers with support for this:
- https://kubernetes-csi.github.io/docs/support-fsgroup.html  