### PR TITLE
fix broken ephemeral storage reconcile

### DIFF
--- a/internal/controller/mariadb_controller_storage.go
+++ b/internal/controller/mariadb_controller_storage.go
@@ -24,7 +24,11 @@ import (
 )
 
 func shouldReconcileStorage(mdb *mariadbv1alpha1.MariaDB) bool {
-	if mdb.IsRestoringBackup() || mdb.IsUpdating() || mdb.IsSwitchingPrimary() || mdb.HasGaleraNotReadyCondition() || mdb.IsEphemeralStorageEnabled() {
+	if mdb.IsRestoringBackup() ||
+		mdb.IsUpdating() ||
+		mdb.IsSwitchingPrimary() ||
+		mdb.HasGaleraNotReadyCondition() ||
+		mdb.IsEphemeralStorageEnabled() {
 		return false
 	}
 	return true

--- a/internal/controller/mariadb_controller_storage.go
+++ b/internal/controller/mariadb_controller_storage.go
@@ -24,7 +24,7 @@ import (
 )
 
 func shouldReconcileStorage(mdb *mariadbv1alpha1.MariaDB) bool {
-	if mdb.IsRestoringBackup() || mdb.IsUpdating() || mdb.IsSwitchingPrimary() || mdb.HasGaleraNotReadyCondition() {
+	if mdb.IsRestoringBackup() || mdb.IsUpdating() || mdb.IsSwitchingPrimary() || mdb.HasGaleraNotReadyCondition() || mdb.IsEphemeralStorageEnabled() {
 		return false
 	}
 	return true
@@ -52,7 +52,6 @@ func (r *MariaDBReconciler) reconcileStorage(ctx context.Context, mariadb *maria
 	if desiredSize == nil {
 		return ctrl.Result{}, errors.New("invalid desired storage size")
 	}
-
 	sizeCmp := desiredSize.Cmp(*existingSize)
 	if sizeCmp == 0 {
 		return ctrl.Result{}, nil


### PR DESCRIPTION
When I create a MariaDB instance with ephemeral storage, I encounter the following error:


```
{"level":"error","ts":1726782770.31271,"msg":"Reconciler error","controller":"mariadb","controllerGroup":"k8s.mariadb.com","controllerKind":"MariaDB","MariaDB":{"name":"slurm-acct-db","namespace":"slurm"},"namespace":"slurm","name":"slurm-acct-db","reconcileID":"403b1d9b-5490-4a46-8008-d9ff0c6089ea","error":"error reconciling Storage: 1 error occurred:\n\t* invalid existing storage size\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:316\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:263\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func2.2\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.19.0/pkg/internal/controller/controller.go:224"}
```

It is necessary to return nil if ephemeral storage is enabled and continue the reconciliation process, otherwise dependent resources will not be created.