### PR TITLE
Remove probes from container builder

### DIFF
--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -301,12 +301,6 @@ func (b *Builder) buildContainerWithTemplate(image string, pullPolicy corev1.Pul
 		VolumeMounts:    kadapter.ToKubernetesSlice(tpl.VolumeMounts),
 		SecurityContext: sc,
 	}
-	if tpl.LivenessProbe != nil {
-		container.LivenessProbe = ptr.To(tpl.LivenessProbe.ToKubernetesType())
-	}
-	if tpl.ReadinessProbe != nil {
-		container.ReadinessProbe = ptr.To(tpl.ReadinessProbe.ToKubernetesType())
-	}
 	if mariadbOpts.resources != nil {
 		container.Resources = *mariadbOpts.resources
 	} else if tpl.Resources != nil && mariadbOpts.includeMariadbResources {


### PR DESCRIPTION
Regression introduced in https://github.com/mariadb-operator/mariadb-operator/pull/869. In this line to be more specific:
https://github.com/mariadb-operator/mariadb-operator/blob/10d67752d01441a424028feaa122db1a7a093093/pkg/builder/container_builder.go#L304

Removed probes from `buildContainerWithTemplate`, they are set already by the function invoking `buildContainerWithTemplate`.