### PR TITLE
Unify versioning

### DIFF
--- a/.github/workflows/olm.yml
+++ b/.github/workflows/olm.yml
@@ -98,7 +98,7 @@ jobs:
           context: .
           file: ./Dockerfile.bundle
           tags: |
-            mariadb/mariadb-operator-enterprise-bundle:v${{ needs.args.outputs.VERSION }}
+            mariadb/mariadb-operator-enterprise-bundle:${{ needs.args.outputs.VERSION }}
             mariadb/mariadb-operator-enterprise-bundle:latest
           labels: |
             org.opencontainers.image.title=MariaDB Operator Enterprise bundle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - "v*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 env:
   GORELEASER_VERSION: "v2.2.0"
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       BUILD_DATE: ${{ steps.args.outputs.BUILD_DATE }}
-      TAG: ${{ steps.args.outputs.TAG }}
       VERSION: ${{ steps.args.outputs.VERSION }}
       RELEASE_ARGS: ${{ steps.args.outputs.RELEASE_ARGS }}
     steps:
@@ -29,15 +28,11 @@ jobs:
       - name: Args
         id: args
         run: |
-          function get_version() {
-            echo "$1" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+'
-          }
-          TAG=${GITHUB_REF/refs\/tags\//}
-          VERSION=$(get_version "$TAG")
+          VERSION=${GITHUB_REF/refs\/tags\//}
           MAKE_VERSION=$(get_version $(make version))
 
           if [ "$VERSION" != "$MAKE_VERSION" ]; then
-            echo "Tag('$TAG') with version('$VERSION') and Makefile version('$MAKE_VERSION') don't match!"
+            echo "Version('$VERSION') and Makefile version('$MAKE_VERSION') don't match!"
             exit 1;
           fi
           
@@ -56,7 +51,6 @@ jobs:
           fi
           
           echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
-          echo "TAG=${TAG}" >> $GITHUB_OUTPUT
           echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
           echo "RELEASE_ARGS=${RELEASE_ARGS}" >> $GITHUB_OUTPUT
 
@@ -93,7 +87,7 @@ jobs:
           file: ./Dockerfile
           platforms: linux/arm64,linux/amd64
           tags: |
-            ghcr.io/${{ github.repository_owner }}/mariadb-operator:${{ needs.args.outputs.TAG }}
+            ghcr.io/${{ github.repository_owner }}/mariadb-operator:${{ needs.args.outputs.VERSION }}
             ghcr.io/${{ github.repository_owner }}/mariadb-operator:latest
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}
@@ -139,7 +133,7 @@ jobs:
           file: ./Dockerfile.ent
           platforms: linux/arm64,linux/amd64
           tags: |
-            mariadb/mariadb-operator-enterprise:${{ needs.args.outputs.TAG }}
+            mariadb/mariadb-operator-enterprise:${{ needs.args.outputs.VERSION }}
             mariadb/mariadb-operator-enterprise:latest
           labels: |
             org.opencontainers.image.title=MariaDB Operator Enterprise
@@ -153,7 +147,7 @@ jobs:
       - name: Preflight operator image
         run: make preflight-image-submit
         env:
-          IMG_ENT: mariadb/mariadb-operator-enterprise:${{ needs.args.outputs.TAG }}
+          IMG_ENT: mariadb/mariadb-operator-enterprise:${{ needs.args.outputs.VERSION }}
           REDHAT_API_KEY: "${{ secrets.REDHAT_API_KEY }}"
           REDHAT_PROJECT_ID: "${{ secrets.REDHAT_PROJECT_ID }}"
   
@@ -208,11 +202,8 @@ jobs:
       - name: Bump version
         id: version
         env:
-          HELM_APP_VERSION: ${{ needs.args.outputs.TAG }}
-          HELM_CRDS_VERSION: ${{ needs.args.outputs.VERSION }}
-        run: |
-          echo "CRDS_VERSION=$(make helm-crds-version-bump)" >> $GITHUB_OUTPUT
-          echo "OPERATOR_VERSION=$(make helm-version-bump)" >> $GITHUB_OUTPUT
+          HELM_VERSION: ${{ needs.args.outputs.VERSION }}
+        run: make helm-version-bump
       
       - name: Helm generate
         run: make helm-gen
@@ -220,7 +211,7 @@ jobs:
       - name: Commit changes
         run: |
           git add .
-          git commit -am "Updated mariadb-operator(${{ steps.version.outputs.OPERATOR_VERSION }}) and mariadb-operator-crds(${{ steps.version.outputs.CRDS_VERSION }}) helm chart versions"
+          git commit -am "Bump helm chart versions to ${{ needs.args.outputs.VERSION }}"
           git push
 
   olm:
@@ -270,6 +261,6 @@ jobs:
         run: |
           gh workflow run docs.yml \
             --repo mariadb-operator/mariadb-operator \
-            -f version=${{ needs.args.outputs.TAG }} alias=latest
+            -f version=${{ needs.args.outputs.VERSION }} alias=latest
         env:
           GITHUB_TOKEN: "${{ secrets.GHA_TOKEN }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           fi
           
           RELEASE_ARGS=release
-          RELEASE_HEADER_TMPL=docs/releases/RELEASE_${TAG}_HEADER.md.gotmpl
-          RELEASE_FOOTER_TMPL=docs/releases/RELEASE_${TAG}_FOOTER.md.gotmpl
+          RELEASE_HEADER_TMPL=docs/releases/RELEASE_${VERSION}_HEADER.md.gotmpl
+          RELEASE_FOOTER_TMPL=docs/releases/RELEASE_${VERSION}_FOOTER.md.gotmpl
           if [ -f "${RELEASE_HEADER_TMPL}" ]; then
             RELEASE_ARGS="${RELEASE_ARGS} --release-header-tmpl=${RELEASE_HEADER_TMPL}"
           else

--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,14 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-VERSION ?= 0.0.34-dev
+VERSION ?= 0.34.0-dev
 
 # mariadb-operator
 IMG_NAME ?= docker-registry3.mariadb.com/mariadb-operator/mariadb-operator
-IMG_VERSION ?= v$(VERSION)
-IMG ?= $(IMG_NAME):$(IMG_VERSION)
+IMG ?= $(IMG_NAME):$(VERSION)
 
 IMG_ENT_NAME ?= docker-registry2.mariadb.com/mariadb/mariadb-operator-enterprise
-IMG_ENT_VERSION ?= v$(VERSION)
-IMG_ENT ?= $(IMG_ENT_NAME):$(IMG_ENT_VERSION)
+IMG_ENT ?= $(IMG_ENT_NAME):$(VERSION)
 
 # mariadb
 RELATED_IMAGE_MARIADB_NAME ?= docker-registry1.mariadb.com/library/mariadb

--- a/deploy/charts/mariadb-operator/Chart.yaml
+++ b/deploy/charts/mariadb-operator/Chart.yaml
@@ -5,7 +5,7 @@ home: https://github.com/mariadb-operator/mariadb-operator
 icon: https://mariadb-operator.github.io/mariadb-operator/assets/mariadb_profile.svg
 type: application
 version: 0.33.0
-appVersion: "v0.0.34-dev"
+appVersion: "0.34.0-dev"
 kubeVersion: ">=1.26.0-0"
 maintainers:
   - email: martin.montes@mariadb.com

--- a/make/gen.mk
+++ b/make/gen.mk
@@ -47,8 +47,8 @@ manifests-bundle: manifests-crds manifests-bundle-helm manifests-bundle-helm-min
 
 .PHONY: examples-operator
 examples-operator: ## Update mariadb-operator version in examples
-	@./hack/bump_version_examples.sh examples/manifests $(IMG_NAME) $(IMG_VERSION)
-	@./hack/bump_version_examples.sh config/samples $(IMG_ENT_NAME) $(IMG_ENT_VERSION)
+	@./hack/bump_version_examples.sh examples/manifests $(IMG_NAME) $(VERSION)
+	@./hack/bump_version_examples.sh config/samples $(IMG_ENT_NAME) $(VERSION)
 
 .PHONY: examples-mariadb
 examples-mariadb: ## Update mariadb version in examples

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -60,37 +60,19 @@ ifndef HELM_CRDS_CHART_FILE
 endif
 	@cat $(HELM_CRDS_CHART_FILE) | $(YQ) e ".version"
 
-HELM_APP_VERSION ?=
-HELM_CRDS_VERSION ?=
-
+HELM_VERSION ?=
 .PHONY: helm-version-bump
-helm-version-bump: yq ## Bump mariadb-operator version and return it to stdout.
+helm-version-bump: yq ## Bump helm charts version.
 ifndef HELM_CHART_FILE
 	$(error HELM_CHART_FILE is not set. Please set it before running this target)
 endif
-ifndef HELM_APP_VERSION
-	$(error HELM_APP_VERSION is not set. Please set it before running this target)
-endif
-ifndef HELM_CRDS_VERSION
-	$(error HELM_CRDS_VERSION is not set. Please set it before running this target)
-endif
-	@VERSION=$$($(YQ) e '.version' $(HELM_CHART_FILE)); \
-	MAJOR=$$(echo $$VERSION | cut -d'.' -f1); \
-	MINOR=$$(echo $$VERSION | cut -d'.' -f2); \
-	NEW_MINOR=$$((MINOR + 1)); \
-	NEW_VERSION=$$MAJOR.$$NEW_MINOR.0; \
-	$(YQ) e -i ".version = \"$$NEW_VERSION\"" $(HELM_CHART_FILE); \
-	$(YQ) e -i ".appVersion = \"$(HELM_APP_VERSION)\"" $(HELM_CHART_FILE); \
-	$(YQ) e -i ".dependencies |= map(select(.name == \"mariadb-operator-crds\").version = \"$(HELM_CRDS_VERSION)\" // .)" $(HELM_CHART_FILE); \
-	echo $$NEW_VERSION
-
-.PHONY: helm-crds-version-bump
-helm-crds-version-bump: yq ## Bump mariadb-operator-crds version and return it to stdout.
 ifndef HELM_CRDS_CHART_FILE
 	$(error HELM_CRDS_CHART_FILE is not set. Please set it before running this target)
 endif
-ifndef HELM_CRDS_VERSION
-	$(error HELM_CRDS_VERSION is not set. Please set it before running this target)
+ifndef HELM_VERSION
+	$(error HELM_VERSION is not set. Please set it before running this target)
 endif
-	@$(YQ) e -i ".version = \"$(HELM_CRDS_VERSION)\"" $(HELM_CRDS_CHART_FILE); \
-	echo $(HELM_CRDS_VERSION)
+	@$(YQ) e -i ".version = \"$(HELM_VERSION)\"" $(HELM_CHART_FILE); \
+	$(YQ) e -i ".appVersion = \"$(HELM_VERSION)\"" $(HELM_CHART_FILE); \
+	$(YQ) e -i ".dependencies |= map(select(.name == \"mariadb-operator-crds\").version = \"$(HELM_VERSION)\" // .)" $(HELM_CHART_FILE); \
+	$(YQ) e -i ".version = \"$(HELM_VERSION)\"" $(HELM_CRDS_CHART_FILE)

--- a/make/openshift.mk
+++ b/make/openshift.mk
@@ -17,9 +17,9 @@ ifneq ($(origin CATALOG_BASE_IMG), undefined)
 FROM_INDEX_OPT := --from-index $(CATALOG_BASE_IMG)
 endif
 
-BUNDLE_IMG ?= mariadb/mariadb-operator-enterprise-bundle:v$(VERSION)
+BUNDLE_IMG ?= mariadb/mariadb-operator-enterprise-bundle:$(VERSION)
 BUNDLE_IMGS ?= $(BUNDLE_IMG)
-CATALOG_IMG ?= mariadb/mariadb-operator-enterprise-catalog:v$(VERSION)
+CATALOG_IMG ?= mariadb/mariadb-operator-enterprise-catalog:$(VERSION)
 
 REDHAT_PROJECT_ID ?= ""
 REDHAT_API_KEY ?= ""


### PR DESCRIPTION
Close https://github.com/mariadb-operator/mariadb-operator/issues/891

Some users reported that our versioning is confusing:
- mariadb-operator image: `v0.0.33`
- mariadb-operator-crds helm chart: `v0.0.33`
- mariadb-operator helm chart: `0.33.0`

This PR contains the changes needed for unifying the version to `0.34.0` in the next release and avoid confusion.