### PR TITLE
Add replication role labels

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -56,6 +56,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - ""

--- a/deploy/charts/mariadb-operator/templates/rbac-namespace.yaml
+++ b/deploy/charts/mariadb-operator/templates/rbac-namespace.yaml
@@ -78,6 +78,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/deploy/charts/mariadb-operator/templates/rbac.yaml
+++ b/deploy/charts/mariadb-operator/templates/rbac.yaml
@@ -95,6 +95,7 @@ rules:
   - get
   - list
   - watch
+  - patch
 - apiGroups:
   - ""
   resources:

--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -349,6 +349,10 @@ func (r *MariaDBReconciler) reconcileStatefulSet(ctx context.Context, mariadb *m
 }
 
 func (r *MariaDBReconciler) reconcilePodLabels(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB) (ctrl.Result, error) {
+	if mariadb.Status.CurrentPrimaryPodIndex == nil {
+		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+	}
+
 	podList := corev1.PodList{}
 	listOpts := &client.ListOptions{
 		LabelSelector: klabels.SelectorFromSet(
@@ -373,7 +377,7 @@ func (r *MariaDBReconciler) reconcilePodLabels(ctx context.Context, mariadb *mar
 			return ctrl.Result{}, fmt.Errorf("error getting Pod '%s' index: %v", pod.Name, err)
 		}
 
-		if mariadb.Status.CurrentPrimaryPodIndex != nil && *podIndex == *mariadb.Status.CurrentPrimaryPodIndex {
+		if *podIndex == *mariadb.Status.CurrentPrimaryPodIndex {
 			role = "primary"
 		}
 

--- a/internal/controller/mariadb_controller_replication_test.go
+++ b/internal/controller/mariadb_controller_replication_test.go
@@ -155,6 +155,20 @@ var _ = Describe("MariaDB replication", Ordered, func() {
 		By("Expecting to create a secondary Service")
 		Expect(k8sClient.Get(testCtx, mdb.SecondaryServiceKey(), &svc)).To(Succeed())
 
+		By("Expecting role label to be set to primary")
+		Eventually(func() bool {
+			currentPrimary := *mdb.Status.CurrentPrimary
+			primaryPodKey := types.NamespacedName{
+				Name:      currentPrimary,
+				Namespace: mdb.Namespace,
+			}
+			var primaryPod corev1.Pod
+			if err := k8sClient.Get(testCtx, primaryPodKey, &primaryPod); err != nil {
+				return apierrors.IsNotFound(err)
+			}
+			return primaryPod.Labels["k8s.mariadb.com/role"] == "primary"
+		}, testTimeout, testInterval).Should(BeTrue())
+
 		By("Expecting Connection to be ready eventually")
 		Eventually(func() bool {
 			var conn mariadbv1alpha1.Connection

--- a/pkg/builder/labels/labels.go
+++ b/pkg/builder/labels/labels.go
@@ -11,6 +11,7 @@ const (
 	instanceLabel      = "app.kubernetes.io/instance"
 	statefulSetPodName = "statefulset.kubernetes.io/pod-name"
 	volumeRole         = "pvc.k8s.mariadb.com/role"
+	podRole            = "k8s.mariadb.com/role"
 	appMariaDb         = "mariadb"
 	appExporter        = "exporter"
 	appMaxScale        = "maxscale"
@@ -65,6 +66,11 @@ func (b *LabelsBuilder) WithMaxScaleSelectorLabels(mxs *mariadbv1alpha1.MaxScale
 
 func (b *LabelsBuilder) WithPVCRole(role string) *LabelsBuilder {
 	b.labels[volumeRole] = role
+	return b
+}
+
+func (b *LabelsBuilder) WithPodRole(role string) *LabelsBuilder {
+	b.labels[podRole] = role
 	return b
 }
 


### PR DESCRIPTION
This PR closes #823.

The assumption made here is that we only want this to be available when replication is enabled, since on galera it's all primary and standalone is not a cluster. We could perhaps tag it as such, i.e `k8s.mariadb.com/role=galera` or `k8s.mariadb.com/role=standalone`, but I think there is little to no value having it.