### PR TITLE
Disable bootstrap config in `Pods` during recovery

### DIFF
--- a/pkg/controller/galera/recovery.go
+++ b/pkg/controller/galera/recovery.go
@@ -479,7 +479,6 @@ func (r *GaleraReconciler) patchStatefulSetReplicas(ctx context.Context, key typ
 
 	return wait.PollWithMariaDB(ctx, key, r.Client, logger, func(ctx context.Context) error {
 		var sts appsv1.StatefulSet
-
 		if err := r.Get(ctx, key, &sts); err != nil {
 			return fmt.Errorf("error getting StatefulSet: %v", err)
 		}
@@ -507,22 +506,18 @@ func (r *GaleraReconciler) ensurePodRunning(ctx context.Context, mariadbKey, pod
 	if err := r.Delete(ctx, &pod); err != nil {
 		return fmt.Errorf("error deleting Pod '%s': %v", podKey.Name, err)
 	}
-
 	return r.pollUntilPodRunning(ctx, mariadbKey, podKey, logger)
 }
 
 func (r *GaleraReconciler) ensureJob(ctx context.Context, recoveryJob *batchv1.Job) error {
-	key := ctrlclient.ObjectKeyFromObject(recoveryJob)
-
 	var job batchv1.Job
-	if err := r.Get(ctx, key, &job); err != nil {
+	if err := r.Get(ctx, ctrlclient.ObjectKeyFromObject(recoveryJob), &job); err != nil {
 		if apierrors.IsNotFound(err) {
 			return r.Create(ctx, recoveryJob)
 		}
 		return err
 	}
-
-	return r.Delete(ctx, recoveryJob, &client.DeleteOptions{PropagationPolicy: ptr.To(metav1.DeletePropagationBackground)})
+	return nil
 }
 
 func (r *GaleraReconciler) pollUntilPodRunning(ctx context.Context, mariadbKey, podKey types.NamespacedName, logger logr.Logger) error {

--- a/pkg/controller/galera/recovery.go
+++ b/pkg/controller/galera/recovery.go
@@ -477,15 +477,8 @@ func (r *GaleraReconciler) disableBootstrapInPod(ctx context.Context, mariadbKey
 	if err := r.ensurePodRunning(ctx, mariadbKey, podKey, logger); err != nil {
 		return fmt.Errorf("error ensuring Pod '%s' is running: %v", podKey.Name, err)
 	}
-
-	isEnabled, err := client.Galera.IsBootstrapEnabled(ctx)
-	if err != nil {
-		return fmt.Errorf("error checking bootstrap in Pod '%s': %v", podKey.Name, err)
-	}
-	if isEnabled {
-		if err := client.Galera.DisableBootstrap(ctx); err != nil {
-			return fmt.Errorf("error disabling bootstrap in Pod '%s': %v", podKey.Name, err)
-		}
+	if err := client.Galera.DisableBootstrap(ctx); err != nil && !galeraerrors.IsNotFound(err) {
+		return fmt.Errorf("error disabling bootstrap in Pod '%s': %v", podKey.Name, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This PR removes the bootstrap configuration from `Pods` that are not supposed to be bootstrapping the new cluster, avoiding errors like:
```bash
 [ERROR] WSREP: It may not be safe to bootstrap the cluster from this node. It was not the last one to leave the cluster and may not contain all the updates.
```

It could be possible that on previous bootstrap attempts, a different `Pod` was chosen to bootstrap, and therefore it may still have the bootstrap configuration.