### PR TITLE
`Skip` mariadb.sys resource cleanup

### DIFF
--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -753,6 +753,7 @@ func (r *MariaDBReconciler) reconcileUsers(ctx context.Context, mariadb *mariadb
 		Name:                 "mariadb.sys",
 		Host:                 "localhost",
 		PasswordSecretKeyRef: nil,
+		CleanupPolicy:        ptr.To(mariadbv1alpha1.CleanupPolicySkip),
 	}
 	grantOpts := auth.GrantOpts{
 		Key: sysGrantKey,
@@ -769,10 +770,11 @@ func (r *MariaDBReconciler) reconcileUsers(ctx context.Context, mariadb *mariadb
 				"UPDATE",
 				"DELETE",
 			},
-			Database: "mysql",
-			Table:    "global_priv",
-			Username: "mariadb.sys",
-			Host:     "localhost",
+			Database:      "mysql",
+			Table:         "global_priv",
+			Username:      "mariadb.sys",
+			Host:          "localhost",
+			CleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
 		},
 	}
 

--- a/pkg/builder/sql_builder.go
+++ b/pkg/builder/sql_builder.go
@@ -17,6 +17,7 @@ type UserOpts struct {
 	PasswordHashSecretKeyRef *mariadbv1alpha1.SecretKeySelector
 	PasswordPlugin           *mariadbv1alpha1.PasswordPlugin
 	MaxUserConnections       int32
+	CleanupPolicy            *mariadbv1alpha1.CleanupPolicy
 	Metadata                 *mariadbv1alpha1.Metadata
 	MariaDBRef               mariadbv1alpha1.MariaDBRef
 }
@@ -42,6 +43,9 @@ func (b *Builder) BuildUser(key types.NamespacedName, owner metav1.Object, opts 
 	if opts.MaxUserConnections > 0 {
 		user.Spec.MaxUserConnections = opts.MaxUserConnections
 	}
+	if opts.CleanupPolicy != nil {
+		user.Spec.CleanupPolicy = opts.CleanupPolicy
+	}
 	if err := controllerutil.SetControllerReference(owner, user, b.scheme); err != nil {
 		return nil, fmt.Errorf("error setting controller reference to User: %v", err)
 	}
@@ -49,14 +53,15 @@ func (b *Builder) BuildUser(key types.NamespacedName, owner metav1.Object, opts 
 }
 
 type GrantOpts struct {
-	Privileges  []string
-	Database    string
-	Table       string
-	Username    string
-	Host        string
-	GrantOption bool
-	Metadata    *mariadbv1alpha1.Metadata
-	MariaDBRef  mariadbv1alpha1.MariaDBRef
+	Privileges    []string
+	Database      string
+	Table         string
+	Username      string
+	Host          string
+	GrantOption   bool
+	CleanupPolicy *mariadbv1alpha1.CleanupPolicy
+	Metadata      *mariadbv1alpha1.Metadata
+	MariaDBRef    mariadbv1alpha1.MariaDBRef
 }
 
 func (b *Builder) BuildGrant(key types.NamespacedName, owner metav1.Object, opts GrantOpts) (*mariadbv1alpha1.Grant, error) {
@@ -77,6 +82,9 @@ func (b *Builder) BuildGrant(key types.NamespacedName, owner metav1.Object, opts
 	}
 	if opts.Host != "" {
 		grant.Spec.Host = &opts.Host
+	}
+	if opts.CleanupPolicy != nil {
+		grant.Spec.CleanupPolicy = opts.CleanupPolicy
 	}
 	if err := controllerutil.SetControllerReference(owner, grant, b.scheme); err != nil {
 		return nil, fmt.Errorf("error setting controller reference to Grant: %v", err)

--- a/pkg/builder/sql_builder_test.go
+++ b/pkg/builder/sql_builder_test.go
@@ -1,10 +1,12 @@
 package builder
 
 import (
+	"reflect"
 	"testing"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 func TestUserMeta(t *testing.T) {
@@ -49,11 +51,47 @@ func TestUserMeta(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configMap, err := builder.BuildUser(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
+			user, err := builder.BuildUser(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
 			if err != nil {
 				t.Fatalf("unexpected error building User: %v", err)
 			}
-			assertObjectMeta(t, &configMap.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
+			assertObjectMeta(t, &user.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
+		})
+	}
+}
+
+func TestUserCleanupPolicy(t *testing.T) {
+	builder := newDefaultTestBuilder(t)
+	key := types.NamespacedName{
+		Name: "user",
+	}
+	tests := []struct {
+		name              string
+		opts              UserOpts
+		wantCleanupPolicy *mariadbv1alpha1.CleanupPolicy
+	}{
+		{
+			name:              "no cleanupPolicy",
+			opts:              UserOpts{},
+			wantCleanupPolicy: nil,
+		},
+		{
+			name: "cleanupPolicy",
+			opts: UserOpts{
+				CleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
+			},
+			wantCleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user, err := builder.BuildUser(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
+			if err != nil {
+				t.Fatalf("unexpected error building User: %v", err)
+			}
+			if !reflect.DeepEqual(user.Spec.CleanupPolicy, tt.wantCleanupPolicy) {
+				t.Errorf("unexpected cleanupPolicy: got: %v, want: %v", user.Spec.CleanupPolicy, tt.wantCleanupPolicy)
+			}
 		})
 	}
 }
@@ -100,11 +138,47 @@ func TestGrantMeta(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			configMap, err := builder.BuildGrant(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
+			grant, err := builder.BuildGrant(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
 			if err != nil {
 				t.Fatalf("unexpected error building Grant: %v", err)
 			}
-			assertObjectMeta(t, &configMap.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
+			assertObjectMeta(t, &grant.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
+		})
+	}
+}
+
+func TestGrantCleanupPolicy(t *testing.T) {
+	builder := newDefaultTestBuilder(t)
+	key := types.NamespacedName{
+		Name: "grant",
+	}
+	tests := []struct {
+		name              string
+		opts              GrantOpts
+		wantCleanupPolicy *mariadbv1alpha1.CleanupPolicy
+	}{
+		{
+			name:              "no cleanupPolicy",
+			opts:              GrantOpts{},
+			wantCleanupPolicy: nil,
+		},
+		{
+			name: "cleanupPolicy",
+			opts: GrantOpts{
+				CleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
+			},
+			wantCleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			grant, err := builder.BuildGrant(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
+			if err != nil {
+				t.Fatalf("unexpected error building Grant: %v", err)
+			}
+			if !reflect.DeepEqual(grant.Spec.CleanupPolicy, tt.wantCleanupPolicy) {
+				t.Errorf("unexpected cleanupPolicy: got: %v, want: %v", grant.Spec.CleanupPolicy, tt.wantCleanupPolicy)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Deleting `mariadb.sys` `User` and `Grant` resources could have fatal consequences and even lead to unavailability in some cases. Thus, we are setting their `cleanupPolicy` to `Skip`. This way, even if the `User` and `Grant` CRs get deleted, the internal user and grants configured in MariaDB will remain. The CRs will be recreated by the operator later on and will result in a noop reconciliation as the internal state already exists.

Issue reported in community Slack:
- https://mariadb-community.slack.com/archives/C06AWJBAC1H/p1727283275971859