### PR TITLE
Support for `securityContext` in `Exporter`

### DIFF
--- a/api/v1alpha1/base_types.go
+++ b/api/v1alpha1/base_types.go
@@ -770,6 +770,10 @@ type Exporter struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	PodMetadata *Metadata `json:"podMetadata,omitempty"`
+	// SecurityContext holds container-level security attributes.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	SecurityContext *SecurityContext `json:"securityContext,omitempty"`
 	// SecurityContext holds pod-level security attributes and common container settings.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}

--- a/api/v1alpha1/kubernetes_types.go
+++ b/api/v1alpha1/kubernetes_types.go
@@ -452,24 +452,24 @@ func (s SecurityContext) ToKubernetesType() corev1.SecurityContext {
 // Refer to the Kubernetes docs: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#podsecuritycontext-v1-core
 type PodSecurityContext struct {
 	// +optional
-	SELinuxOptions *corev1.SELinuxOptions `json:"seLinuxOptions,omitempty" protobuf:"bytes,1,opt,name=seLinuxOptions"`
+	SELinuxOptions *corev1.SELinuxOptions `json:"seLinuxOptions,omitempty"`
 	// +optional
-	RunAsUser *int64 `json:"runAsUser,omitempty" protobuf:"varint,2,opt,name=runAsUser"`
+	RunAsUser *int64 `json:"runAsUser,omitempty"`
 	// +optional
-	RunAsGroup *int64 `json:"runAsGroup,omitempty" protobuf:"varint,6,opt,name=runAsGroup"`
+	RunAsGroup *int64 `json:"runAsGroup,omitempty"`
 	// +optional
-	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty" protobuf:"varint,3,opt,name=runAsNonRoot"`
+	RunAsNonRoot *bool `json:"runAsNonRoot,omitempty"`
 	// +optional
 	// +listType=atomic
-	SupplementalGroups []int64 `json:"supplementalGroups,omitempty" protobuf:"varint,4,rep,name=supplementalGroups"`
+	SupplementalGroups []int64 `json:"supplementalGroups,omitempty"`
 	// +optional
-	FSGroup *int64 `json:"fsGroup,omitempty" protobuf:"varint,5,opt,name=fsGroup"`
+	FSGroup *int64 `json:"fsGroup,omitempty"`
 	// +optional
-	FSGroupChangePolicy *corev1.PodFSGroupChangePolicy `json:"fsGroupChangePolicy,omitempty" protobuf:"bytes,9,opt,name=fsGroupChangePolicy"`
+	FSGroupChangePolicy *corev1.PodFSGroupChangePolicy `json:"fsGroupChangePolicy,omitempty"`
 	// +optional
-	SeccompProfile *corev1.SeccompProfile `json:"seccompProfile,omitempty" protobuf:"bytes,10,opt,name=seccompProfile"`
+	SeccompProfile *corev1.SeccompProfile `json:"seccompProfile,omitempty"`
 	// +optional
-	AppArmorProfile *corev1.AppArmorProfile `json:"appArmorProfile,omitempty" protobuf:"bytes,11,opt,name=appArmorProfile"`
+	AppArmorProfile *corev1.AppArmorProfile `json:"appArmorProfile,omitempty"`
 }
 
 func (s PodSecurityContext) ToKubernetesType() corev1.PodSecurityContext {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -803,6 +803,11 @@ func (in *Exporter) DeepCopyInto(out *Exporter) {
 		*out = new(Metadata)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SecurityContext != nil {
+		in, out := &in.SecurityContext, &out.SecurityContext
+		*out = new(SecurityContext)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PodSecurityContext != nil {
 		in, out := &in.PodSecurityContext, &out.PodSecurityContext
 		*out = new(PodSecurityContext)

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -2743,6 +2743,46 @@ spec:
                                   quantity) pairs.
                                 type: object
                             type: object
+                          securityContext:
+                            description: SecurityContext holds container-level security
+                              attributes.
+                            properties:
+                              allowPrivilegeEscalation:
+                                type: boolean
+                              capabilities:
+                                description: Adds and removes POSIX capabilities from
+                                  running containers.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              privileged:
+                                type: boolean
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                            type: object
                           tolerations:
                             description: Tolerations to be used in the Pod.
                             items:
@@ -3315,6 +3355,46 @@ spec:
                             description: ResourceList is a set of (resource name,
                               quantity) pairs.
                             type: object
+                        type: object
+                      securityContext:
+                        description: SecurityContext holds container-level security
+                          attributes.
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            description: Adds and removes POSIX capabilities from
+                              running containers.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          privileged:
+                            type: boolean
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
                         type: object
                       tolerations:
                         description: Tolerations to be used in the Pod.

--- a/config/crd/bases/k8s.mariadb.com_maxscales.yaml
+++ b/config/crd/bases/k8s.mariadb.com_maxscales.yaml
@@ -1204,6 +1204,46 @@ spec:
                               quantity) pairs.
                             type: object
                         type: object
+                      securityContext:
+                        description: SecurityContext holds container-level security
+                          attributes.
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            description: Adds and removes POSIX capabilities from
+                              running containers.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          privileged:
+                            type: boolean
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
+                        type: object
                       tolerations:
                         description: Tolerations to be used in the Pod.
                         items:

--- a/deploy/charts/mariadb-operator-crds/templates/crds.yaml
+++ b/deploy/charts/mariadb-operator-crds/templates/crds.yaml
@@ -4258,6 +4258,46 @@ spec:
                                   quantity) pairs.
                                 type: object
                             type: object
+                          securityContext:
+                            description: SecurityContext holds container-level security
+                              attributes.
+                            properties:
+                              allowPrivilegeEscalation:
+                                type: boolean
+                              capabilities:
+                                description: Adds and removes POSIX capabilities from
+                                  running containers.
+                                properties:
+                                  add:
+                                    description: Added capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  drop:
+                                    description: Removed capabilities
+                                    items:
+                                      description: Capability represent POSIX capabilities
+                                        type
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                type: object
+                              privileged:
+                                type: boolean
+                              readOnlyRootFilesystem:
+                                type: boolean
+                              runAsGroup:
+                                format: int64
+                                type: integer
+                              runAsNonRoot:
+                                type: boolean
+                              runAsUser:
+                                format: int64
+                                type: integer
+                            type: object
                           tolerations:
                             description: Tolerations to be used in the Pod.
                             items:
@@ -4830,6 +4870,46 @@ spec:
                             description: ResourceList is a set of (resource name,
                               quantity) pairs.
                             type: object
+                        type: object
+                      securityContext:
+                        description: SecurityContext holds container-level security
+                          attributes.
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            description: Adds and removes POSIX capabilities from
+                              running containers.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          privileged:
+                            type: boolean
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
                         type: object
                       tolerations:
                         description: Tolerations to be used in the Pod.
@@ -7567,6 +7647,46 @@ spec:
                             description: ResourceList is a set of (resource name,
                               quantity) pairs.
                             type: object
+                        type: object
+                      securityContext:
+                        description: SecurityContext holds container-level security
+                          attributes.
+                        properties:
+                          allowPrivilegeEscalation:
+                            type: boolean
+                          capabilities:
+                            description: Adds and removes POSIX capabilities from
+                              running containers.
+                            properties:
+                              add:
+                                description: Added capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              drop:
+                                description: Removed capabilities
+                                items:
+                                  description: Capability represent POSIX capabilities
+                                    type
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            type: object
+                          privileged:
+                            type: boolean
+                          readOnlyRootFilesystem:
+                            type: boolean
+                          runAsGroup:
+                            format: int64
+                            type: integer
+                          runAsNonRoot:
+                            type: boolean
+                          runAsUser:
+                            format: int64
+                            type: integer
                         type: object
                       tolerations:
                         description: Tolerations to be used in the Pod.

--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -79,7 +79,7 @@ func (b *Builder) BuildBackupJob(key types.NamespacedName, backup *mariadbv1alph
 		jobEnv(mariadb),
 		jobResources(backup.Spec.Resources),
 		mariadb,
-		jobSecurityContext(backup.Spec.SecurityContext),
+		backup.Spec.SecurityContext,
 	)
 	if err != nil {
 		return nil, err
@@ -92,7 +92,7 @@ func (b *Builder) BuildBackupJob(key types.NamespacedName, backup *mariadbv1alph
 		jobResources(backup.Spec.Resources),
 		mariadb,
 		b.env,
-		jobSecurityContext(backup.Spec.SecurityContext),
+		backup.Spec.SecurityContext,
 	)
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ func (b *Builder) BuildRestoreJob(key types.NamespacedName, restore *mariadbv1al
 		jobResources(restore.Spec.Resources),
 		mariadb,
 		b.env,
-		jobSecurityContext(restore.Spec.SecurityContext),
+		restore.Spec.SecurityContext,
 	)
 	if err != nil {
 		return nil, err
@@ -219,7 +219,7 @@ func (b *Builder) BuildRestoreJob(key types.NamespacedName, restore *mariadbv1al
 		jobEnv(mariadb),
 		jobResources(restore.Spec.Resources),
 		mariadb,
-		jobSecurityContext(restore.Spec.SecurityContext),
+		restore.Spec.SecurityContext,
 	)
 	if err != nil {
 		return nil, err
@@ -469,7 +469,7 @@ func (b *Builder) BuildSqlJob(key types.NamespacedName, sqlJob *mariadbv1alpha1.
 		sqlJobEnv(sqlJob),
 		resources,
 		mariadb,
-		jobSecurityContext(sqlJob.Spec.SecurityContext),
+		sqlJob.Spec.SecurityContext,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/builder/batch_container_builder.go
+++ b/pkg/builder/batch_container_builder.go
@@ -10,8 +10,7 @@ import (
 )
 
 func (b *Builder) jobContainer(name string, cmd *cmd.Command, image string, volumeMounts []corev1.VolumeMount, env []v1.EnvVar,
-	resources *corev1.ResourceRequirements, mariadb *mariadbv1alpha1.MariaDB,
-	securityContext *corev1.SecurityContext) (*corev1.Container, error) {
+	resources *corev1.ResourceRequirements, mariadb *mariadbv1alpha1.MariaDB, securityContext *mariadbv1alpha1.SecurityContext) (*corev1.Container, error) {
 	sc, err := b.buildContainerSecurityContext(securityContext)
 	if err != nil {
 		return nil, err
@@ -35,14 +34,14 @@ func (b *Builder) jobContainer(name string, cmd *cmd.Command, image string, volu
 
 func (b *Builder) jobMariadbOperatorContainer(cmd *cmd.Command, volumeMounts []corev1.VolumeMount, envVar []v1.EnvVar,
 	resources *corev1.ResourceRequirements, mariadb *mariadbv1alpha1.MariaDB, env *environment.OperatorEnv,
-	securityContext *corev1.SecurityContext) (*corev1.Container, error) {
+	securityContext *mariadbv1alpha1.SecurityContext) (*corev1.Container, error) {
 
 	return b.jobContainer("mariadb-operator", cmd, env.MariadbOperatorImage, volumeMounts, envVar, resources, mariadb, securityContext)
 }
 
 func (b *Builder) jobMariadbContainer(cmd *cmd.Command, volumeMounts []corev1.VolumeMount, envVar []v1.EnvVar,
 	resources *corev1.ResourceRequirements, mariadb *mariadbv1alpha1.MariaDB,
-	securityContext *corev1.SecurityContext) (*corev1.Container, error) {
+	securityContext *mariadbv1alpha1.SecurityContext) (*corev1.Container, error) {
 
 	return b.jobContainer("mariadb", cmd, mariadb.Spec.Image, volumeMounts, envVar, resources, mariadb, securityContext)
 }
@@ -125,13 +124,6 @@ func jobS3Env(s3 *mariadbv1alpha1.S3) []v1.EnvVar {
 func jobResources(resources *mariadbv1alpha1.ResourceRequirements) *corev1.ResourceRequirements {
 	if resources != nil {
 		return ptr.To(resources.ToKubernetesType())
-	}
-	return nil
-}
-
-func jobSecurityContext(securityContext *mariadbv1alpha1.SecurityContext) *corev1.SecurityContext {
-	if securityContext != nil {
-		return ptr.To(securityContext.ToKubernetesType())
 	}
 	return nil
 }

--- a/pkg/builder/batch_container_builder.go
+++ b/pkg/builder/batch_container_builder.go
@@ -10,7 +10,8 @@ import (
 )
 
 func (b *Builder) jobContainer(name string, cmd *cmd.Command, image string, volumeMounts []corev1.VolumeMount, env []v1.EnvVar,
-	resources *corev1.ResourceRequirements, mariadb *mariadbv1alpha1.MariaDB, securityContext *mariadbv1alpha1.SecurityContext) (*corev1.Container, error) {
+	resources *corev1.ResourceRequirements, mariadb *mariadbv1alpha1.MariaDB,
+	securityContext *mariadbv1alpha1.SecurityContext) (*corev1.Container, error) {
 	sc, err := b.buildContainerSecurityContext(securityContext)
 	if err != nil {
 		return nil, err

--- a/pkg/builder/batch_container_builder_test.go
+++ b/pkg/builder/batch_container_builder_test.go
@@ -19,7 +19,7 @@ func TestJobContainerSecurityContext(t *testing.T) {
 	envVar := []corev1.EnvVar{}
 	resources := &corev1.ResourceRequirements{}
 	mariadb := &mariadbv1alpha1.MariaDB{}
-	var securityContext *corev1.SecurityContext
+	var securityContext *mariadbv1alpha1.SecurityContext
 
 	container, err := builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)
 	if err != nil {
@@ -29,7 +29,7 @@ func TestJobContainerSecurityContext(t *testing.T) {
 		t.Error("expected SecurityContext to be nil")
 	}
 
-	securityContext = &corev1.SecurityContext{
+	securityContext = &mariadbv1alpha1.SecurityContext{
 		RunAsUser: ptr.To(mysqlUser),
 	}
 	container, err = builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -286,11 +286,7 @@ func (b *Builder) buildContainerWithTemplate(image string, pullPolicy corev1.Pul
 	opts ...mariadbPodOpt) (*corev1.Container, error) {
 	mariadbOpts := newMariadbPodOpts(opts...)
 
-	var securityContext *corev1.SecurityContext
-	if tpl.SecurityContext != nil {
-		securityContext = ptr.To(tpl.SecurityContext.ToKubernetesType())
-	}
-	sc, err := b.buildContainerSecurityContext(securityContext)
+	sc, err := b.buildContainerSecurityContext(tpl.SecurityContext)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/builder/securitycontext_builder.go
+++ b/pkg/builder/securitycontext_builder.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func (b *Builder) buildContainerSecurityContext(securityContext *corev1.SecurityContext) (*corev1.SecurityContext, error) {
+func (b *Builder) buildContainerSecurityContext(securityContext *mariadbv1alpha1.SecurityContext) (*corev1.SecurityContext, error) {
 	sccExists, err := b.discovery.SecurityContextConstrainstsExist()
 	if err != nil {
 		return nil, fmt.Errorf("error discovering SecurityContextConstraints: %v", err)
@@ -19,7 +19,10 @@ func (b *Builder) buildContainerSecurityContext(securityContext *corev1.Security
 	if sccExists {
 		return nil, nil
 	}
-	return securityContext, nil
+	if securityContext != nil {
+		return ptr.To(securityContext.ToKubernetesType()), nil
+	}
+	return nil, nil
 }
 
 func (b *Builder) buildPodSecurityContext(podSecurityContext *mariadbv1alpha1.PodSecurityContext) (*corev1.PodSecurityContext, error) {

--- a/pkg/builder/securitycontext_builder_test.go
+++ b/pkg/builder/securitycontext_builder_test.go
@@ -13,7 +13,7 @@ import (
 func TestBuildContainerSecurityContext(t *testing.T) {
 	builder := newDefaultTestBuilder(t)
 
-	sc, err := builder.buildContainerSecurityContext(&corev1.SecurityContext{
+	sc, err := builder.buildContainerSecurityContext(&mariadbv1alpha1.SecurityContext{
 		RunAsUser: ptr.To(mysqlUser),
 	})
 	if err != nil {
@@ -37,7 +37,7 @@ func TestBuildContainerSecurityContext(t *testing.T) {
 	}
 	builder = newTestBuilder(discovery)
 
-	sc, err = builder.buildContainerSecurityContext(&corev1.SecurityContext{
+	sc, err = builder.buildContainerSecurityContext(&mariadbv1alpha1.SecurityContext{
 		RunAsUser: ptr.To(mysqlUser),
 	})
 	if err != nil {

--- a/pkg/builder/securitycontext_builder_test.go
+++ b/pkg/builder/securitycontext_builder_test.go
@@ -5,7 +5,6 @@ import (
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/pkg/discovery"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )


### PR DESCRIPTION
Close https://github.com/mariadb-operator/mariadb-operator/issues/901
Related to https://github.com/mariadb-operator/mariadb-operator/pull/869