### PR TITLE
Use printf to add hosts to /etc/hosts

### DIFF
--- a/hack/add_host.sh
+++ b/hack/add_host.sh
@@ -10,5 +10,5 @@ if grep -q "^$IP\s*$HOSTNAME" /etc/hosts; then
   echo "\"$HOSTNAME\" host already exists in /etc/hosts"
 else
   echo "Adding \"$HOSTNAME\" to /etc/hosts";
-  sudo -- sh -c -e "echo '# mariadb-operator\n$IP\t$HOSTNAME' >> /etc/hosts";
+  sudo -- sh -c -e "printf '# mariadb-operator\n%s\t%s\n' '$IP' '$HOSTNAME' >> /etc/hosts";
 fi


### PR DESCRIPTION
`echo` behaves differently across various shells and systems.
The current approach is reported to work in the devcontainer and Ubuntu where `sh` is a symlink to `dash`.
 Unfortunately, this is different in Fedora where special symbols like `\n` and `\t` do not get expanded in `echo` command without `-e` option.
This leads to invalid entries in `/etc/hosts` after running `make net`.
I suggest that we use `printf` in this specific case to make the hack portable and predictable.
