### PR TITLE
Make `maxUserConnections` mutable

### DIFF
--- a/api/v1alpha1/user_types.go
+++ b/api/v1alpha1/user_types.go
@@ -32,11 +32,11 @@ type UserSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	PasswordPlugin PasswordPlugin `json:"passwordPlugin,omitempty"`
-	// MaxUserConnections defines the maximum number of connections that the User can establish.
+	// MaxUserConnections defines the maximum number of simultaneous connections that the User can establish.
 	// +optional
 	// +kubebuilder:default=10
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
-	MaxUserConnections int32 `json:"maxUserConnections,omitempty" webhook:"inmutable"`
+	MaxUserConnections int32 `json:"maxUserConnections,omitempty"`
 	// Name overrides the default name provided by metadata.name.
 	// +optional
 	// +kubebuilder:validation:MaxLength=80

--- a/api/v1alpha1/user_webhook_test.go
+++ b/api/v1alpha1/user_webhook_test.go
@@ -162,7 +162,7 @@ var _ = Describe("User webhook", func() {
 				func(umdb *User) {
 					umdb.Spec.MaxUserConnections = 20
 				},
-				true,
+				false,
 			),
 			Entry(
 				"Duplicate authentication methods",

--- a/config/crd/bases/k8s.mariadb.com_users.yaml
+++ b/config/crd/bases/k8s.mariadb.com_users.yaml
@@ -84,8 +84,8 @@ spec:
                 type: object
               maxUserConnections:
                 default: 10
-                description: MaxUserConnections defines the maximum number of connections
-                  that the User can establish.
+                description: MaxUserConnections defines the maximum number of simultaneous
+                  connections that the User can establish.
                 format: int32
                 type: integer
               name:

--- a/deploy/charts/mariadb-operator-crds/templates/crds.yaml
+++ b/deploy/charts/mariadb-operator-crds/templates/crds.yaml
@@ -9863,8 +9863,8 @@ spec:
                 type: object
               maxUserConnections:
                 default: 10
-                description: MaxUserConnections defines the maximum number of connections
-                  that the User can establish.
+                description: MaxUserConnections defines the maximum number of simultaneous
+                  connections that the User can establish.
                 format: int32
                 type: integer
               name:

--- a/examples/manifests/user.yaml
+++ b/examples/manifests/user.yaml
@@ -10,11 +10,11 @@ spec:
   passwordSecretKeyRef:
     name: mariadb
     key: password
-  # This field is immutable and defaults to 10
+  # This field defaults to 10
   maxUserConnections: 20
   host: "%"
   # Delete the resource in the database whenever the CR gets deleted.
   # Alternatively, you can specify Skip in order to omit deletion.
-  cleanupPolicy: Delete  
+  cleanupPolicy: Delete
   requeueInterval: 30s
   retryInterval: 5s

--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -140,9 +140,7 @@ func (wr *wrappedUserReconciler) Reconcile(ctx context.Context, mdbClient *sqlCl
 		}
 		createUserOpts = append(createUserOpts, sqlClient.WithIdentifiedBy(password))
 	}
-	if wr.user.Spec.MaxUserConnections > 0 {
-		createUserOpts = append(createUserOpts, sqlClient.WithMaxUserConnections(wr.user.Spec.MaxUserConnections))
-	}
+	createUserOpts = append(createUserOpts, sqlClient.WithMaxUserConnections(wr.user.Spec.MaxUserConnections))
 
 	username := wr.user.UsernameOrDefault()
 	hostname := wr.user.HostnameOrDefault()

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -275,9 +275,7 @@ func (c *Client) CreateUser(ctx context.Context, accountName string, createUserO
 	} else if opts.IdentifiedBy != "" {
 		query += fmt.Sprintf("IDENTIFIED BY '%s' ", opts.IdentifiedBy)
 	}
-	if opts.MaxUserConnections > 0 {
-		query += fmt.Sprintf("WITH MAX_USER_CONNECTIONS %d ", opts.MaxUserConnections)
-	}
+	query += fmt.Sprintf("WITH MAX_USER_CONNECTIONS %d ", opts.MaxUserConnections)
 	if opts.IdentifiedBy == "" && opts.IdentifiedByPassword == "" && opts.IdentifiedVia == "" {
 		query += "ACCOUNT LOCK PASSWORD EXPIRE "
 	}
@@ -310,6 +308,7 @@ func (c *Client) AlterUser(ctx context.Context, accountName string, createUserOp
 	} else {
 		query += fmt.Sprintf("IDENTIFIED BY '%s' ", opts.IdentifiedBy)
 	}
+	query += fmt.Sprintf("WITH MAX_USER_CONNECTIONS %d ", opts.MaxUserConnections)
 
 	query += ";"
 


### PR DESCRIPTION
This PR closes https://github.com/mariadb-operator/mariadb-operator/issues/685

Similar PR made recently by another contributor https://github.com/mariadb-operator/mariadb-operator/pull/723

According to MySQL [documentation](https://dev.mysql.com/doc/refman/8.4/en/user-resources.html), when `MAX_USER_CONNECTIONS` is set to `0`, it falls back to the global `max_user_connections` value. I believe this applies to MariaDB as well.

So I suggest that we simplify the logic by always setting the limit implicitly. 

P.S.: I've left the current default limit of 10 connections. But personally, I think it should be 0 by default. This way, out of the box everyone will be limited to the server setting, and only specific (ab)users could be tweaked if needed.