### PR TITLE
Fix: crash when SQLJob has unknown dependencies

### DIFF
--- a/internal/controller/sqljob_controller.go
+++ b/internal/controller/sqljob_controller.go
@@ -125,9 +125,7 @@ func (r *SqlJobReconciler) waitForDependencies(ctx context.Context, sqlJob *v1al
 			}
 
 			logger.Info(msg)
-			if err := r.patchStatus(ctx, sqlJob, r.ConditionComplete.PatcherFailed(msg)); err != nil {
-				return false, ctrl.Result{}, err
-			}
+			return false, ctrl.Result{RequeueAfter: r.RequeueInterval}, r.patchStatus(ctx, sqlJob, r.ConditionComplete.PatcherFailed(msg))
 		}
 		if !sqlJobDep.IsComplete() {
 			msg := fmt.Sprintf("Dependency '%s' not ready", dep.Name)


### PR DESCRIPTION
Added error handling for unresolved dependencies to prevent the operator from crashing.

Fixes #577 