### PR TITLE
Feat: Add support for image digest and standardize image reference format

### DIFF
--- a/deploy/charts/mariadb-operator/templates/_helpers.tpl
+++ b/deploy/charts/mariadb-operator/templates/_helpers.tpl
@@ -56,9 +56,9 @@ Webhook common labels
 {{- define "mariadb-operator-webhook.labels" -}}
 helm.sh/chart: {{ include "mariadb-operator.chart" . }}
 {{ include "mariadb-operator-webhook.selectorLabels" . }}
-{{ if .Chart.AppVersion }}
+{{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{ end }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -104,9 +104,9 @@ Cert-controller common labels
 {{- define "mariadb-operator-cert-controller.labels" -}}
 helm.sh/chart: {{ include "mariadb-operator.chart" . }}
 {{ include "mariadb-operator-cert-controller.selectorLabels" . }}
-{{ if .Chart.AppVersion }}
+{{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{ end }}
+{{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
@@ -149,4 +149,22 @@ Create the name of the cert-controller service account to use
 {{- else }}
 {{- default "default" .Values.certController.serviceAccount.name }}
 {{- end }}
+{{- end }}
+
+{{/*
+Util function for generating the image URL based on the provided options.
+*/}}
+{{- define "image" -}}
+  {{- $defaultTag := index . 1 -}}
+  {{- with index . 0 -}}
+    {{- $repository := .repository | default "" -}}
+    {{- $digest := .digest -}}
+    {{- $tag := default $defaultTag .tag -}}
+    {{- printf "%s" $repository }}
+    {{- if $digest -}}
+      {{ printf "@%s" $digest }}
+    {{- else -}}
+      {{ printf ":%s" $tag }}
+    {{- end -}}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/mariadb-operator/templates/cert-controller-deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/cert-controller-deployment.yaml
@@ -4,22 +4,22 @@ kind: Deployment
 metadata:
   name: {{ include "mariadb-operator.fullname" . }}-cert-controller
   labels:
-    {{ include "mariadb-operator-cert-controller.labels" . | nindent 4 }}
+    {{- include "mariadb-operator-cert-controller.labels" . | nindent 4 }}
 spec:
-  {{ if .Values.certController.ha.enabled }}
+  {{- if .Values.certController.ha.enabled }}
   replicas: {{ .Values.certController.ha.replicas}}
-  {{ end }}
+  {{- end }}
   selector:
     matchLabels:
-      {{ include "mariadb-operator-cert-controller.selectorLabels" . | nindent 6 }}
+      {{- include "mariadb-operator-cert-controller.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{ with .Values.certController.podAnnotations }}
+      {{- with .Values.certController.podAnnotations }}
       annotations:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
+      {{- end }}
       labels:
-        {{ include "mariadb-operator-cert-controller.selectorLabels" . | nindent 8 }}
+        {{- include "mariadb-operator-cert-controller.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.certController.imagePullSecrets }}
       imagePullSecrets:
@@ -27,24 +27,24 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "mariadb-operator-cert-controller.serviceAccountName" . }}-cert-controller
       automountServiceAccountToken: {{ .Values.certController.serviceAccount.automount }}
-      {{ with .Values.certController.nodeSelector }}
+      {{- with .Values.certController.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.certController.tolerations }}
+      {{- end }}
+      {{- with .Values.certController.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.certController.affinity }}
+      {{- end }}
+      {{- with .Values.certController.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.certController.podSecurityContext }}
+      {{- end }}
+      {{- with .Values.certController.podSecurityContext }}
       securityContext:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
+      {{- end }}
       containers:
-        - image: "{{ .Values.certController.image.repository }}:{{ .Values.certController.image.tag | default .Chart.AppVersion }}"
+        - image: "{{ template "image" (tuple .Values.certController.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.certController.image.pullPolicy }}
           name: cert-controller
           args:

--- a/deploy/charts/mariadb-operator/templates/deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/deployment.yaml
@@ -3,22 +3,22 @@ kind: Deployment
 metadata:
   name: {{ include "mariadb-operator.fullname" . }}
   labels:
-    {{ include "mariadb-operator.labels" . | nindent 4 }}
+    {{- include "mariadb-operator.labels" . | nindent 4 }}
 spec:
-  {{ if .Values.ha.enabled }}
+  {{- if .Values.ha.enabled }}
   replicas: {{ .Values.ha.replicas}}
-  {{ end }}
+  {{- end }}
   selector:
     matchLabels:
-      {{ include "mariadb-operator.selectorLabels" . | nindent 6 }}
+      {{- include "mariadb-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{ with .Values.podAnnotations }}
+      {{- with .Values.podAnnotations }}
       annotations:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
+      {{- end }}
       labels:
-        {{ include "mariadb-operator.selectorLabels" . | nindent 8 }}
+        {{- include "mariadb-operator.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -27,24 +27,24 @@ spec:
       serviceAccountName: {{ include "mariadb-operator.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
       terminationGracePeriodSeconds: 10
-      {{ with .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.affinity }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.podSecurityContext }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
+      {{- end }}
       containers:
-        - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+        - image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: controller
           args:

--- a/deploy/charts/mariadb-operator/templates/webhook-config.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-config.yaml
@@ -5,16 +5,16 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: {{ $fullName }}-webhook
   labels:
-    {{ include "mariadb-operator-webhook.labels" . | nindent 4 }}
+    {{- include "mariadb-operator-webhook.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.webhook.cert.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "mariadb-operator.fullname" . }}-webhook-cert
     {{- else }}
     k8s.mariadb.com/webhook: ""
     {{- end }}
-    {{ with .Values.webhook.annotations }}
+    {{- with .Values.webhook.annotations }}
     {{ toYaml . | indent 4 }}
-    {{ end }}
+    {{- end }}
 webhooks:
 - admissionReviewVersions:
   - v1
@@ -42,16 +42,16 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ $fullName }}-webhook
   labels:
-    {{ include "mariadb-operator-webhook.labels" . | nindent 4 }}
+    {{- include "mariadb-operator-webhook.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.webhook.cert.certManager.enabled }}
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/{{ include "mariadb-operator.fullname" . }}-webhook-cert
     {{- else }}
     k8s.mariadb.com/webhook: ""
     {{- end }}
-    {{ with .Values.webhook.annotations }}
+    {{- with .Values.webhook.annotations }}
     {{ toYaml . | indent 4 }}
-    {{ end }}
+    {{- end }}
 webhooks:
   - admissionReviewVersions:
       - v1

--- a/deploy/charts/mariadb-operator/templates/webhook-deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-deployment.yaml
@@ -5,22 +5,22 @@ kind: Deployment
 metadata:
   name: {{ $fullName }}-webhook
   labels:
-    {{ include "mariadb-operator-webhook.labels" . | nindent 4 }}
+    {{- include "mariadb-operator-webhook.labels" . | nindent 4 }}
 spec:
-  {{ if .Values.webhook.ha.enabled }}
+  {{- if .Values.webhook.ha.enabled }}
   replicas: {{ .Values.webhook.ha.replicas}}
-  {{ end }}
+  {{- end }}
   selector:
     matchLabels:
-      {{ include "mariadb-operator-webhook.selectorLabels" . | nindent 6 }}
+      {{- include "mariadb-operator-webhook.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{ with .Values.webhook.podAnnotations }}
+      {{- with .Values.webhook.podAnnotations }}
       annotations:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
+      {{- end }}
       labels:
-        {{ include "mariadb-operator-webhook.selectorLabels" . | nindent 8 }}
+        {{- include "mariadb-operator-webhook.selectorLabels" . | nindent 8 }}
     spec:
       {{- with .Values.webhook.imagePullSecrets }}
       imagePullSecrets:
@@ -28,25 +28,25 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "mariadb-operator-webhook.serviceAccountName" . }}
       automountServiceAccountToken: {{ .Values.webhook.serviceAccount.automount }}
-      {{ with .Values.webhook.nodeSelector }}
+      {{- with .Values.webhook.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.webhook.tolerations }}
+      {{- end }}
+      {{- with .Values.webhook.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.webhook.affinity }}
+      {{- end }}
+      {{- with .Values.webhook.affinity }}
       affinity:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
-      {{ with .Values.webhook.podSecurityContext }}
+      {{- end }}
+      {{- with .Values.webhook.podSecurityContext }}
       securityContext:
         {{ toYaml . | nindent 8 }}
-      {{ end }}
+      {{- end }}
       hostNetwork: {{ .Values.webhook.hostNetwork }}
       containers:
-        - image: "{{ .Values.webhook.image.repository }}:{{ .Values.webhook.image.tag | default .Chart.AppVersion }}"
+        - image: "{{ template "image" (tuple .Values.webhook.image $.Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           name: webhook
           args:
@@ -93,14 +93,14 @@ spec:
               port: 8081
             initialDelaySeconds: 20
             periodSeconds: 5
-          {{ with .Values.webhook.resources }}
+          {{- with .Values.webhook.resources }}
           resources:
             {{ toYaml . | nindent 12 }}
-          {{ end }}
-          {{ with .Values.webhook.securityContext}}
+          {{- end }}
+          {{- with .Values.webhook.securityContext}}
           securityContext:
             {{ toYaml . | nindent 12 }}
-          {{ end }}
+          {{- end }}
       volumes:
         {{- if not .Values.webhook.cert.certManager.enabled }}
         - name: ca

--- a/deploy/charts/mariadb-operator/templates/webhook-service.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-service.yaml
@@ -4,12 +4,12 @@ kind: Service
 metadata:
   name: {{ include "mariadb-operator.fullname" . }}-webhook
   labels:
-    {{ include "mariadb-operator-webhook.labels" . | nindent 4 }}
+    {{- include "mariadb-operator-webhook.labels" . | nindent 4 }}
 spec:
   ports:
     - port: 443
       protocol: TCP
       targetPort: {{ .Values.webhook.port }}
   selector:
-    {{ include "mariadb-operator-webhook.selectorLabels" . | nindent 4 }}
+    {{- include "mariadb-operator-webhook.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -14,6 +14,8 @@ image:
   pullPolicy: IfNotPresent
   # -- Image tag to use. By default the chart appVersion is used
   tag: ""
+  # Setting a digest will override any tag
+  # digest: sha256:084a927ee9f3918a5c85d283f73822ae205757df352218de0b935853a0765060
 imagePullSecrets: []
 
 # -- Controller log level
@@ -136,6 +138,8 @@ webhook:
     pullPolicy: IfNotPresent
     # -- Image tag to use. By default the chart appVersion is used
     tag: ""
+    # Setting a digest will override any tag
+    # digest: sha256:084a927ee9f3918a5c85d283f73822ae205757df352218de0b935853a0765060
   imagePullSecrets: []
   ha:
     # -- Enable high availability
@@ -225,6 +229,8 @@ certController:
     pullPolicy: IfNotPresent
     # -- Image tag to use. By default the chart appVersion is used
     tag: ""
+    # Setting a digest will override any tag
+    # digest: sha256:084a927ee9f3918a5c85d283f73822ae205757df352218de0b935853a0765060
   imagePullSecrets: []
   ha:
     # -- Enable high availability


### PR DESCRIPTION
- Added an optional  field to allow referencing images using digest.
- Added a new helper function  for generating the image URL.
- Eliminate some unnecessary blank lines
- Added TestHelmImageTagAndDigest to test image reference handling for both tags and digests.

Closes #261 