### PR TITLE
fix: exclude # symbol from password generator

### DIFF
--- a/pkg/controller/secret/controller.go
+++ b/pkg/controller/secret/controller.go
@@ -22,7 +22,7 @@ type SecretReconciler struct {
 
 func NewSecretReconciler(client client.Client, builder *builder.Builder) (*SecretReconciler, error) {
 	generator, err := password.NewGenerator(&password.GeneratorInput{
-		Symbols: "~!@#$%^&*()_+-={}|[]:<>/",
+		Symbols: "~!@$%^&*()_+-={}|[]:<>/",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating password generator: %v", err)


### PR DESCRIPTION
- \# is treated as a comment in  configuration files, leading to failed parsing when the password contains this character.

The # symbol has been excluded from the global password generator to prevent these issues with mysqld-exporter.

Closes #716 