### PR TITLE
Fix `nodeAffinity` defaults

### DIFF
--- a/api/v1alpha1/base_types.go
+++ b/api/v1alpha1/base_types.go
@@ -3,7 +3,6 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/mariadb-operator/mariadb-operator/pkg/webhook"
@@ -215,22 +214,22 @@ type AffinityConfig struct {
 
 // SetDefaults sets reasonable defaults.
 func (a *AffinityConfig) SetDefaults(antiAffinityInstances ...string) {
-	if ptr.Deref(a.AntiAffinityEnabled, false) && reflect.ValueOf(a.Affinity).IsZero() && len(antiAffinityInstances) > 0 {
-		a.Affinity = Affinity{
-			PodAntiAffinity: &PodAntiAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: []PodAffinityTerm{
-					{
-						LabelSelector: &LabelSelector{
-							MatchExpressions: []LabelSelectorRequirement{
-								{
-									Key:      "app.kubernetes.io/instance",
-									Operator: metav1.LabelSelectorOpIn,
-									Values:   antiAffinityInstances,
-								},
+	antiAffinityEnabled := ptr.Deref(a.AntiAffinityEnabled, false)
+
+	if antiAffinityEnabled && len(antiAffinityInstances) > 0 && a.Affinity.PodAntiAffinity == nil {
+		a.Affinity.PodAntiAffinity = &PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []PodAffinityTerm{
+				{
+					LabelSelector: &LabelSelector{
+						MatchExpressions: []LabelSelectorRequirement{
+							{
+								Key:      "app.kubernetes.io/instance",
+								Operator: metav1.LabelSelectorOpIn,
+								Values:   antiAffinityInstances,
 							},
 						},
-						TopologyKey: "kubernetes.io/hostname",
 					},
+					TopologyKey: "kubernetes.io/hostname",
 				},
 			},
 		}

--- a/api/v1alpha1/base_types_test.go
+++ b/api/v1alpha1/base_types_test.go
@@ -364,6 +364,66 @@ var _ = Describe("Base types", func() {
 					},
 				},
 			),
+			Entry(
+				"AntiAffinity and nodeAffinity",
+				&AffinityConfig{
+					AntiAffinityEnabled: ptr.To(true),
+					Affinity: Affinity{
+						NodeAffinity: &NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &NodeSelector{
+								NodeSelectorTerms: []NodeSelectorTerm{
+									{
+										MatchExpressions: []NodeSelectorRequirement{
+											{
+												Key:      "kubernetes.io/hostname",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"node1", "node2"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				[]string{"mariadb"},
+				&AffinityConfig{
+					AntiAffinityEnabled: ptr.To(true),
+					Affinity: Affinity{
+						PodAntiAffinity: &PodAntiAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: []PodAffinityTerm{
+								{
+									LabelSelector: &LabelSelector{
+										MatchExpressions: []LabelSelectorRequirement{
+											{
+												Key:      "app.kubernetes.io/instance",
+												Operator: metav1.LabelSelectorOpIn,
+												Values:   []string{"mariadb"},
+											},
+										},
+									},
+									TopologyKey: "kubernetes.io/hostname",
+								},
+							},
+						},
+						NodeAffinity: &NodeAffinity{
+							RequiredDuringSchedulingIgnoredDuringExecution: &NodeSelector{
+								NodeSelectorTerms: []NodeSelectorTerm{
+									{
+										MatchExpressions: []NodeSelectorRequirement{
+											{
+												Key:      "kubernetes.io/hostname",
+												Operator: corev1.NodeSelectorOpIn,
+												Values:   []string{"node1", "node2"},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			),
 		)
 	})
 


### PR DESCRIPTION
Related to https://github.com/mariadb-operator/mariadb-operator/pull/935 and https://github.com/mariadb-operator/mariadb-operator/issues/933

Keep `affinity.nodeAffinity` values specified by the user if `affinity.antiAffinityEnabled` is set to `true`. This will result in the `affinity` having both `nodeAffinity` and `podAffinity`. 