### PR TITLE
Remove `sessionAffinity` from MaxScale GUI `Service`. Add first ready `Pod` to the `Service` selector to implement sticky sessions

### DIFF
--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -671,7 +671,7 @@ func (r *MariaDBReconciler) reconcilePrimaryService(ctx context.Context, mariadb
 	serviceLabels :=
 		labels.NewLabelsBuilder().
 			WithMariaDBSelectorLabels(mariadb).
-			WithStatefulSetPod(mariadb, *mariadb.Status.CurrentPrimaryPodIndex).
+			WithStatefulSetPod(mariadb.ObjectMeta, *mariadb.Status.CurrentPrimaryPodIndex).
 			Build()
 	opts := builder.ServiceOpts{
 		Ports:          ports,

--- a/pkg/builder/labels/labels.go
+++ b/pkg/builder/labels/labels.go
@@ -3,6 +3,7 @@ package builder
 import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/pkg/statefulset"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -37,8 +38,8 @@ func (b *LabelsBuilder) WithInstance(instance string) *LabelsBuilder {
 	return b
 }
 
-func (b *LabelsBuilder) WithStatefulSetPod(mdb *mariadbv1alpha1.MariaDB, podIndex int) *LabelsBuilder {
-	b.labels[statefulSetPodName] = statefulset.PodName(mdb.ObjectMeta, podIndex)
+func (b *LabelsBuilder) WithStatefulSetPod(objMeta metav1.ObjectMeta, podIndex int) *LabelsBuilder {
+	b.labels[statefulSetPodName] = statefulset.PodName(objMeta, podIndex)
 	return b
 }
 


### PR DESCRIPTION
Close https://github.com/mariadb-operator/mariadb-operator/issues/858

MaxScale GUI `Service` uses `sessionAffinity` to avoid load balancing GUI requests and therefore, end up landing in a different `Pod`, resulting in unexpected logouts, as this new `Pod` does not recognize the user session.

When using an API gateway in front of the MaxScale GUI `Service`, if it doesn't have `sessionAffinity` configured in its `Service`, it will result in the previous undesired behaviour as well. See https://github.com/mariadb-operator/mariadb-operator/issues/858#issuecomment-2431398474

To overcome this, we are pointing the MaxScale GUI `Service` to a specific `Pod`, dynamically updating this `Pod` in case that it goes down. This is done in a consistent and predictable way to avoid sending GUI requests to new MaxScale `Pods` whenever possible.