### PR TITLE
Perform proper switchover before updating master in semi-sync replication

### DIFF
--- a/api/v1alpha1/mariadb_replication_types.go
+++ b/api/v1alpha1/mariadb_replication_types.go
@@ -264,6 +264,8 @@ func (m *MariaDB) IsReplicationConfigured() bool {
 	return m.Status.ReplicationStatus.IsReplicationConfigured()
 }
 
+var ErrPrimarySwitchoverRequired = errors.New("primary switchover is required")
+
 // IsSwitchingPrimary indicates whether the primary is being switched.
 func (m *MariaDB) IsSwitchingPrimary() bool {
 	return meta.IsStatusConditionFalse(m.Status.Conditions, ConditionTypePrimarySwitched)

--- a/api/v1alpha1/mariadb_replication_types.go
+++ b/api/v1alpha1/mariadb_replication_types.go
@@ -1,7 +1,6 @@
 package v1alpha1
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -257,14 +256,10 @@ var (
 	}
 )
 
-var ErrReplicationNotConfigured = errors.New("replication is not configured")
-
 // IsReplicationConfigured indicates whether replication has been configured.
 func (m *MariaDB) IsReplicationConfigured() bool {
 	return m.Status.ReplicationStatus.IsReplicationConfigured()
 }
-
-var ErrPrimarySwitchoverRequired = errors.New("primary switchover is required")
 
 // IsSwitchingPrimary indicates whether the primary is being switched.
 func (m *MariaDB) IsSwitchingPrimary() bool {

--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -241,6 +241,9 @@ func shouldSkipPhase(err error) bool {
 	if errors.Is(err, mariadbv1alpha1.ErrReplicationNotConfigured) {
 		return true
 	}
+	if errors.Is(err, mariadbv1alpha1.ErrPrimarySwitchoverRequired) {
+		return true
+	}
 	return false
 }
 


### PR DESCRIPTION
Hello again! This PR continues efforts made in https://github.com/mariadb-operator/mariadb-operator/pull/947
Now, when we have 1) allowed switchover during statefulset update and 2) ensured that restarted replicas are configured, we can actually trigger proper switchover instead of brute force master deletion. 

This seems to be working as designed. If you find the idea valid, please feel free to edit and modify it as you see fit to bring it to the project's standards and your vision.

P.S. Since the switchover logic includes a configurable sync timeout, I did not inject a hardcoded sleep step here. But perhaps we should add it anyway to not rely that heavy on the switchover timeout.
