### PR TITLE
Support replication for non-default port

### DIFF
--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -152,6 +152,7 @@ func (r *ReplicationConfig) changeMaster(ctx context.Context, mariadb *mariadbv1
 			mariadb.InternalServiceKey().Name,
 		),
 		User:     replUser,
+		Port:     mariadb.Spec.Port,
 		Password: password,
 		Gtid:     gtidString,
 		Retries:  *mariadb.Replication().Replica.ConnectionRetries,

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -510,6 +510,7 @@ func (c *Client) WaitForReplicaGtid(ctx context.Context, gtid string, timeout ti
 type ChangeMasterOpts struct {
 	Connection string
 	Host       string
+	Port       int32
 	User       string
 	Password   string
 	Gtid       string
@@ -519,6 +520,7 @@ type ChangeMasterOpts struct {
 func (c *Client) ChangeMaster(ctx context.Context, opts *ChangeMasterOpts) error {
 	tpl := createTpl("change-master.sql", `CHANGE MASTER '{{ .Connection }}' TO
 MASTER_HOST='{{ .Host }}',
+MASTER_PORT={{ .Port }},
 MASTER_USER='{{ .User }}',
 MASTER_PASSWORD='{{ .Password }}',
 MASTER_USE_GTID={{ .Gtid }},


### PR DESCRIPTION
Support replication for non-default port

Fixes #948 

https://mariadb.com/kb/en/change-master-to/#master_port
there was a warning clause but I think it won't be a problem since MASTER_USE_GTID is used.

> If you set the value of the MASTER_PORT option in a CHANGE MASTER command, then the replica assumes that the primary is different from before, even if you set the value of this option to the same value it had previously. In this scenario, the replica will consider the old values for the primary's [binary log](https://mariadb.com/kb/en/binary-log/) file name and position to be invalid for the new primary. As a side effect, if you do not explicitly set the values of the [MASTER_LOG_FILE](https://mariadb.com/kb/en/change-master-to/#master_log_file) and [MASTER_LOG_POS](https://mariadb.com/kb/en/change-master-to/#master_log_pos) options in the statement, then the statement will be implicitly appended with MASTER_LOG_FILE='' and MASTER_LOG_POS=4. However, if you enable [GTID](https://mariadb.com/kb/en/gtid/) mode for replication by setting the [MASTER_USE_GTID](https://mariadb.com/kb/en/change-master-to/#master_use_gtid) option to some value other than no in the statement, then these values will effectively be ignored anyway.


### Test 1: initial replication start log 
mariadb-1 pod
```
2024-10-28  4:45:20 23 [Note] 'CHANGE MASTER TO executed'. Previous state master_host='', master_port='3306', master_log_file='', master_log_pos='4'. New state master_host='mariadb-operator-0.mariadb-operator-internal', master_port='9306', master_log_file='', master_log_pos='4'.
2024-10-28  4:45:20 23 [Note] Previous Using_Gtid=Slave_Pos. New Using_Gtid=Current_Pos
2024-10-28  4:45:20 24 [Note] Master 'mariadb-operator': Slave I/O thread: Start semi-sync replication to master 'repl@mariadb-operator-0.mariadb-operator-internal:9306' in log '' at position 4
2024-10-28  4:45:20 25 [Note] Master 'mariadb-operator': Slave SQL thread initialized, starting replication in log 'FIRST' at position 4, relay log './mariadb-operator-relay-bin-mariadb@002doperator.000001' position: 4; GTID position ''
2024-10-28  4:45:20 24 [Note] Master 'mariadb-operator': Slave I/O thread: connected to master 'repl@mariadb-operator-0.mariadb-operator-internal:9306',replication starts at GTID position ''
```

### Test 2: master pod killed to test failover

1) mariadb-1 pod
```
2024-10-28  4:48:46 25 [Note] Master 'mariadb-operator': Error reading relay log event: slave SQL thread was killed
2024-10-28  4:48:46 25 [Note] Master 'mariadb-operator': Slave SQL thread exiting, replication stopped in log 'mariadb-operator-bin.000002' at position 946; GTID position '0-1-4', master: mariadb-operator-0.mariadb-operator-internal:9306
2024-10-28  4:48:46 24 [Note] Master 'mariadb-operator': Slave I/O thread killed during or after a reconnect done to recover from failed read
2024-10-28  4:48:46 24 [Note] Master 'mariadb-operator': Slave I/O thread exiting, read up to log 'mariadb-operator-bin.000002', position 946; GTID position 0-1-4, master mariadb-operator-0.mariadb-operator-internal:9306
2024-10-28  4:48:48 24 [Note] Master 'mariadb-operator': cannot connect to master to kill slave io_thread's connection
2024-10-28  4:48:48 579 [Note] Semi-sync replication enabled on the master.
2024-10-28  4:48:48 0 [Note] Starting ack receiver thread
2024-10-28  4:48:48 579 [Note] Semi-sync replication enabled on the master.
2024-10-28  4:48:48 0 [Note] Starting ack receiver thread
2024-10-28  4:49:11 618 [Note] Start semi-sync binlog_dump to slave (server_id: 10), pos(./mariadb-operator-bin.000001, 4)
```

2) mariadb-0 pod
```
Version: '10.11.9-MariaDB-ubu2204-log'  socket: '/run/mysqld/mysqld.sock'  port: 9306  mariadb.org binary distribution
2024-10-28  4:49:11 24 [Note] 'CHANGE MASTER TO executed'. Previous state master_host='', master_port='3306', master_log_file='', master_log_pos='4'. New state master_host='mariadb-operator-1.mariadb-operator-internal', master_port='9306', master_log_file='', master_log_pos='4'.
2024-10-28  4:49:11 24 [Note] Previous Using_Gtid=Slave_Pos. New Using_Gtid=Current_Pos
2024-10-28  4:49:11 25 [Note] Master 'mariadb-operator': Slave I/O thread: Start semi-sync replication to master 'repl@mariadb-operator-1.mariadb-operator-internal:9306' in log '' at position 4
2024-10-28  4:49:11 26 [Note] Master 'mariadb-operator': Slave SQL thread initialized, starting replication in log 'FIRST' at position 4, relay log './mariadb-operator-relay-bin-mariadb@002doperator.000001' position: 4; GTID position ''
2024-10-28  4:49:11 25 [Note] Master 'mariadb-operator': Slave I/O thread: connected to master 'repl@mariadb-operator-1.mariadb-operator-internal:9306',replication starts at GTID 
```

3) mariadb status
```
replicationStatus:
      mariadb-operator-0: Slave
      mariadb-operator-1: Master
```

tested on local env
also tested /w maxscale