### PR TITLE
Refactor backup compression

### DIFF
--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -206,7 +205,7 @@ func cleanupFile(fileName string, logger logr.Logger) error {
 	if !s3 || !cleanupTargetFile {
 		return nil
 	}
-	filePath := filepath.Join(path, fileName)
+	filePath := backup.GetFilePath(path, fileName)
 	logger.Info("cleaning up target file", "file", filePath)
 
 	return os.Remove(filePath)

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -21,7 +21,7 @@ func init() {
 var restoreCommand = &cobra.Command{
 	Use:   "restore",
 	Short: "Restore.",
-	Long:  `Finds the target backup file to implement point in time recovery.`,
+	Long:  `Fetches backup files from multiple storage types and matches the one closest to the target recovery time.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := log.SetupLoggerWithCommand(cmd); err != nil {
 			fmt.Printf("error setting up logger: %v\n", err)

--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -69,15 +69,15 @@ var restoreCommand = &cobra.Command{
 			logger.Error(err, "error getting backup compressor")
 			os.Exit(1)
 		}
-		backupFile, err := backupCompressor.Decompress(backupTargetFile)
+		backupTargetFile, err = backupCompressor.Decompress(backupTargetFile)
 		if err != nil {
 			logger.Error(err, "error decompressing backup", "file", backupTargetFile)
 			os.Exit(1)
 		}
 
-		logger.Info("writing target file", "file", targetFilePath)
-		if err := writeTargetFile(backupFile); err != nil {
-			logger.Error(err, "error writing target file", "file", targetFilePath)
+		logger.Info("writing target file", "file", targetFilePath, "file-content", backupTargetFile)
+		if err := writeTargetFile(backupTargetFile); err != nil {
+			logger.Error(err, "error writing target file", "file", backupTargetFile)
 			os.Exit(1)
 		}
 	},
@@ -90,8 +90,8 @@ func getTargetTime() (time.Time, error) {
 	return backup.ParseBackupDate(targetTimeRaw)
 }
 
-func writeTargetFile(backupTargetFilePath string) error {
-	return os.WriteFile(targetFilePath, []byte(backupTargetFilePath), 0777)
+func writeTargetFile(backupTargetFile string) error {
+	return os.WriteFile(targetFilePath, []byte(backupTargetFile), 0777)
 }
 
 func getBackupCompressorWithFile(fileName string) (backup.BackupCompressor, error) {

--- a/cmd/init/main.go
+++ b/cmd/init/main.go
@@ -53,7 +53,7 @@ func init() {
 var RootCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Init.",
-	Long:  `Init container for Galera and co-operates with mariadb-operator.`,
+	Long:  `Init container for Galera that co-operates with mariadb-operator.`,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if err := log.SetupLoggerWithCommand(cmd); err != nil {

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -126,17 +126,18 @@ func ParseBackupDate(timeRaw string) (time.Time, error) {
 	return t, nil
 }
 
+// GetFilePath returns the path to a backup file.
+func GetFilePath(path, fileName string) string {
+	if filepath.IsAbs(fileName) {
+		return fileName
+	}
+	return filepath.Join(path, fileName)
+}
+
 func parseDateInBackupFile(fileName string) (time.Time, error) {
 	parts := strings.Split(fileName, ".")
 	if len(parts) != 3 && len(parts) != 4 {
 		return time.Time{}, fmt.Errorf("invalid backup file name: %s", fileName)
 	}
 	return ParseBackupDate(parts[1])
-}
-
-func getFilePath(path, fileName string) string {
-	if filepath.IsAbs(fileName) {
-		return fileName
-	}
-	return filepath.Join(path, fileName)
 }

--- a/pkg/backup/backup.go
+++ b/pkg/backup/backup.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -131,4 +132,11 @@ func parseDateInBackupFile(fileName string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("invalid backup file name: %s", fileName)
 	}
 	return ParseBackupDate(parts[1])
+}
+
+func getFilePath(path, fileName string) string {
+	if filepath.IsAbs(fileName) {
+		return fileName
+	}
+	return filepath.Join(path, fileName)
 }

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -464,6 +464,49 @@ func TestGetUncompressedBackupFile(t *testing.T) {
 	}
 }
 
+func TestGetFilePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		path         string
+		fileName     string
+		wantFilePath string
+	}{
+		{
+			name:         "empty path",
+			path:         "",
+			fileName:     "backup.2023-12-22T13:00:00Z.foo.sql",
+			wantFilePath: "backup.2023-12-22T13:00:00Z.foo.sql",
+		},
+		{
+			name:         "add path",
+			path:         "/backup",
+			fileName:     "backup.2023-12-22T13:00:00Z.foo.sql",
+			wantFilePath: "/backup/backup.2023-12-22T13:00:00Z.foo.sql",
+		},
+		{
+			name:         "already has relative path",
+			path:         "/backup",
+			fileName:     "mariadb/backup.2023-12-22T13:00:00Z.foo.sql",
+			wantFilePath: "/backup/mariadb/backup.2023-12-22T13:00:00Z.foo.sql",
+		},
+		{
+			name:         "already has absolute path",
+			path:         "/backup",
+			fileName:     "/backup/backup.2023-12-22T13:00:00Z.foo.sql",
+			wantFilePath: "/backup/backup.2023-12-22T13:00:00Z.foo.sql",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filePath := GetFilePath(tt.path, tt.fileName)
+			if tt.wantFilePath != filePath {
+				t.Fatalf("unexpected file path, expected: %v got: %v", tt.wantFilePath, filePath)
+			}
+		})
+	}
+}
+
 func testTimeFn(t time.Time) func() time.Time {
 	return func() time.Time { return t }
 }

--- a/pkg/backup/compression.go
+++ b/pkg/backup/compression.go
@@ -1,0 +1,172 @@
+package backup
+
+import (
+	"compress/gzip"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/dsnet/compress/bzip2"
+	"github.com/hashicorp/go-multierror"
+)
+
+type BackupCompressor interface {
+	Compress(fileName string) error
+	Decompress(fileName string) (string, error)
+}
+
+type NopCompressor struct {
+	basePath string
+}
+
+func NewNopCompressor(basePath string) BackupCompressor {
+	return &NopCompressor{
+		basePath: basePath,
+	}
+}
+
+func (c *NopCompressor) Compress(fileName string) error {
+	return nil
+}
+
+func (c *NopCompressor) Decompress(fileName string) (string, error) {
+	return getFilePath(c.basePath, fileName), nil
+}
+
+type GzipBackupCompressor struct {
+	basePath string
+}
+
+func NewGzipBackupCompressor(basePath string) BackupCompressor {
+	return &GzipBackupCompressor{
+		basePath: basePath,
+	}
+}
+
+func (c *GzipBackupCompressor) Compress(fileName string) error {
+	return compressFile(c.basePath, fileName, func(dst io.Writer, src io.Reader) error {
+		writer := gzip.NewWriter(dst)
+		defer writer.Close()
+		_, err := io.Copy(writer, src)
+		return err
+	})
+}
+
+func (c *GzipBackupCompressor) Decompress(fileName string) (string, error) {
+	return uncompressFile(c.basePath, fileName, func(dst io.Writer, src io.Reader) error {
+		reader, err := gzip.NewReader(src)
+		if err != nil {
+			return err
+		}
+		defer reader.Close()
+		_, err = io.Copy(dst, reader)
+		return err
+	})
+}
+
+type Bzip2BackupCompressor struct {
+	basePath string
+}
+
+func NewBzip2BackupCompressor(basePath string) BackupCompressor {
+	return &Bzip2BackupCompressor{
+		basePath: basePath,
+	}
+}
+
+func (c *Bzip2BackupCompressor) Compress(fileName string) error {
+	return compressFile(c.basePath, fileName, func(dst io.Writer, src io.Reader) error {
+		writer, err := bzip2.NewWriter(dst,
+			&bzip2.WriterConfig{Level: bzip2.DefaultCompression})
+		if err != nil {
+			return err
+		}
+		defer writer.Close()
+		_, err = io.Copy(writer, src)
+		return err
+	})
+}
+
+func (c *Bzip2BackupCompressor) Decompress(fileName string) (string, error) {
+	return uncompressFile(c.basePath, fileName, func(dst io.Writer, src io.Reader) error {
+		reader, err := bzip2.NewReader(src,
+			&bzip2.ReaderConfig{})
+		if err != nil {
+			return err
+		}
+		defer reader.Close()
+		_, err = io.Copy(dst, reader)
+		return err
+	})
+}
+
+func getFilePath(path, fileName string) string {
+	if filepath.IsAbs(fileName) {
+		return fileName
+	}
+	return filepath.Join(path, fileName)
+}
+
+func compressFile(path, fileName string, compressFn func(dst io.Writer, src io.Reader) error) error {
+	filePath := getFilePath(path, fileName)
+	compressedFilePath := filePath + ".tmp"
+
+	// compressedFilePath must be closed before renaming. See: https://github.com/mariadb-operator/mariadb-operator/issues/1007
+	if err := func() error {
+		plainFile, err := os.Open(filePath)
+		if err != nil {
+			return err
+		}
+		defer plainFile.Close()
+
+		compressedFile, err := os.Create(compressedFilePath)
+		if err != nil {
+			return err
+		}
+		defer compressedFile.Close()
+
+		return compressFn(compressedFile, plainFile)
+	}(); err != nil {
+		var errBundle *multierror.Error
+		errBundle = multierror.Append(errBundle, err)
+
+		if err := os.Remove(compressedFilePath); err != nil && !os.IsNotExist(err) {
+			errBundle = multierror.Append(errBundle, err)
+		}
+		return errBundle
+	}
+
+	if err := os.Remove(filePath); err != nil {
+		return err
+	}
+	if err := os.Rename(compressedFilePath, filePath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func uncompressFile(path, fileName string, uncompressFn func(dst io.Writer, src io.Reader) error) (string, error) {
+	filePath := getFilePath(path, fileName)
+
+	compressedFile, err := os.Open(filePath)
+	if err != nil {
+		return "", err
+	}
+	defer compressedFile.Close()
+
+	plainFileName, err := GetUncompressedBackupFile(fileName)
+	if err != nil {
+		return "", err
+	}
+	plainFile, err := os.Create(getFilePath(path, plainFileName))
+	if err != nil {
+		return "", err
+	}
+	defer plainFile.Close()
+
+	if err := uncompressFn(plainFile, compressedFile); err != nil {
+		return "", err
+	}
+
+	return plainFileName, nil
+}

--- a/pkg/backup/compression.go
+++ b/pkg/backup/compression.go
@@ -53,7 +53,7 @@ func (c *GzipBackupCompressor) Compress(fileName string) error {
 }
 
 func (c *GzipBackupCompressor) Decompress(fileName string) (string, error) {
-	return uncompressFile(c.basePath, fileName, func(dst io.Writer, src io.Reader) error {
+	return decompressFile(c.basePath, fileName, func(dst io.Writer, src io.Reader) error {
 		reader, err := gzip.NewReader(src)
 		if err != nil {
 			return err
@@ -88,7 +88,7 @@ func (c *Bzip2BackupCompressor) Compress(fileName string) error {
 }
 
 func (c *Bzip2BackupCompressor) Decompress(fileName string) (string, error) {
-	return uncompressFile(c.basePath, fileName, func(dst io.Writer, src io.Reader) error {
+	return decompressFile(c.basePath, fileName, func(dst io.Writer, src io.Reader) error {
 		reader, err := bzip2.NewReader(src,
 			&bzip2.ReaderConfig{})
 		if err != nil {
@@ -145,7 +145,7 @@ func compressFile(path, fileName string, compressFn func(dst io.Writer, src io.R
 	return nil
 }
 
-func uncompressFile(path, fileName string, uncompressFn func(dst io.Writer, src io.Reader) error) (string, error) {
+func decompressFile(path, fileName string, uncompressFn func(dst io.Writer, src io.Reader) error) (string, error) {
 	filePath := getFilePath(path, fileName)
 
 	compressedFile, err := os.Open(filePath)

--- a/pkg/backup/compression.go
+++ b/pkg/backup/compression.go
@@ -4,7 +4,6 @@ import (
 	"compress/gzip"
 	"io"
 	"os"
-	"path/filepath"
 
 	"github.com/dsnet/compress/bzip2"
 	"github.com/go-logr/logr"
@@ -105,13 +104,6 @@ func (c *Bzip2BackupCompressor) Decompress(fileName string) (string, error) {
 	})
 }
 
-func getFilePath(path, fileName string) string {
-	if filepath.IsAbs(fileName) {
-		return fileName
-	}
-	return filepath.Join(path, fileName)
-}
-
 func compressFile(path, fileName string, logger logr.Logger, compressFn func(dst io.Writer, src io.Reader) error) error {
 	filePath := getFilePath(path, fileName)
 	logger.Info("compressing backup", "file", filePath)
@@ -166,7 +158,8 @@ func decompressFile(path, fileName string, logger logr.Logger, uncompressFn func
 	if err != nil {
 		return "", err
 	}
-	plainFile, err := os.Create(getFilePath(path, plainFileName))
+	plainFilePath := getFilePath(path, plainFileName)
+	plainFile, err := os.Create(plainFilePath)
 	if err != nil {
 		return "", err
 	}
@@ -176,5 +169,5 @@ func decompressFile(path, fileName string, logger logr.Logger, uncompressFn func
 		return "", err
 	}
 
-	return plainFileName, nil
+	return plainFilePath, nil
 }

--- a/pkg/backup/compression.go
+++ b/pkg/backup/compression.go
@@ -30,7 +30,7 @@ func (c *NopCompressor) Compress(fileName string) error {
 }
 
 func (c *NopCompressor) Decompress(fileName string) (string, error) {
-	return getFilePath(c.basePath, fileName), nil
+	return GetFilePath(c.basePath, fileName), nil
 }
 
 type GzipBackupCompressor struct {
@@ -105,7 +105,7 @@ func (c *Bzip2BackupCompressor) Decompress(fileName string) (string, error) {
 }
 
 func compressFile(path, fileName string, logger logr.Logger, compressFn func(dst io.Writer, src io.Reader) error) error {
-	filePath := getFilePath(path, fileName)
+	filePath := GetFilePath(path, fileName)
 	logger.Info("compressing backup", "file", filePath)
 
 	compressedFilePath := filePath + ".tmp"
@@ -145,7 +145,7 @@ func compressFile(path, fileName string, logger logr.Logger, compressFn func(dst
 }
 
 func decompressFile(path, fileName string, logger logr.Logger, uncompressFn func(dst io.Writer, src io.Reader) error) (string, error) {
-	filePath := getFilePath(path, fileName)
+	filePath := GetFilePath(path, fileName)
 	logger.Info("decompressing file", "file", filePath)
 
 	compressedFile, err := os.Open(filePath)
@@ -158,7 +158,7 @@ func decompressFile(path, fileName string, logger logr.Logger, uncompressFn func
 	if err != nil {
 		return "", err
 	}
-	plainFilePath := getFilePath(path, plainFileName)
+	plainFilePath := GetFilePath(path, plainFileName)
 	plainFile, err := os.Create(plainFilePath)
 	if err != nil {
 		return "", err

--- a/pkg/backup/compression_test.go
+++ b/pkg/backup/compression_test.go
@@ -4,13 +4,15 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/go-logr/logr"
 )
 
 func TestBackupCompressors(t *testing.T) {
 	content := "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
 	tests := []struct {
 		name            string
-		newCompressorFn func(basePath string) BackupCompressor
+		newCompressorFn func(basePath string, logger logr.Logger) BackupCompressor
 		fileName        string
 	}{
 		{
@@ -38,7 +40,7 @@ func TestBackupCompressors(t *testing.T) {
 			}
 			defer os.RemoveAll(dir)
 
-			compressor := tt.newCompressorFn(dir)
+			compressor := tt.newCompressorFn(dir, logger)
 
 			filePath := filepath.Join(dir, tt.fileName)
 			if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {

--- a/pkg/backup/compression_test.go
+++ b/pkg/backup/compression_test.go
@@ -1,0 +1,65 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBackupCompressors(t *testing.T) {
+	content := "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+	tests := []struct {
+		name            string
+		newCompressorFn func(basePath string) BackupCompressor
+		fileName        string
+	}{
+		{
+			name:            "nop",
+			newCompressorFn: NewNopCompressor,
+			fileName:        "backup.2023-12-18T16:14:00Z.sql",
+		},
+		{
+			name:            "gzip",
+			newCompressorFn: NewGzipBackupCompressor,
+			fileName:        "backup.2023-12-18T16:14:00Z.gzip.sql",
+		},
+		{
+			name:            "bzip2",
+			newCompressorFn: NewBzip2BackupCompressor,
+			fileName:        "backup.2023-12-18T16:14:00Z.bzip2.sql",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir, err := os.MkdirTemp("", "backup_test")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(dir)
+
+			compressor := tt.newCompressorFn(dir)
+
+			filePath := filepath.Join(dir, tt.fileName)
+			if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+				t.Fatalf("Failed to write test file: %v", err)
+			}
+
+			if err := compressor.Compress(filePath); err != nil {
+				t.Fatalf("Failed to compress test file: %v", err)
+			}
+			decompressedFileName, err := compressor.Decompress(filePath)
+			if err != nil {
+				t.Fatalf("Failed to decompress test file: %v", err)
+			}
+
+			decompressedContent, err := os.ReadFile(decompressedFileName)
+			if err != nil {
+				t.Fatalf("Failed to read decompressed file: %v", err)
+			}
+			if string(decompressedContent) != content {
+				t.Errorf("Decompressed content does not match original content:\nGot: %s\nWant: %s", decompressedContent, content)
+			}
+		})
+	}
+}

--- a/pkg/backup/storage.go
+++ b/pkg/backup/storage.go
@@ -56,7 +56,7 @@ func (f *FileSystemBackupStorage) Pull(ctx context.Context, fileName string) err
 }
 
 func (f *FileSystemBackupStorage) Delete(ctx context.Context, fileName string) error {
-	return os.Remove(filepath.Join(f.basePath, fileName))
+	return os.Remove(getFilePath(f.basePath, fileName))
 }
 
 func (f *FileSystemBackupStorage) shouldProcessBackupFile(fileName string, logger logr.Logger) bool {
@@ -152,14 +152,18 @@ func (s *S3BackupStorage) List(ctx context.Context) ([]string, error) {
 
 func (s *S3BackupStorage) Push(ctx context.Context, fileName string) error {
 	s3FilePath := s.prefixedFileName(fileName)
-	filePath := filepath.Join(s.basePath, fileName)
+	filePath := getFilePath(s.basePath, fileName)
+	fmt.Printf("S3 FILE PATH: \"%s\"\n", s3FilePath)
+	fmt.Printf("FILE PATH: \"%s\"\n", filePath)
 	_, err := s.client.FPutObject(ctx, s.bucket, s3FilePath, filePath, minio.PutObjectOptions{})
 	return err
 }
 
 func (s *S3BackupStorage) Pull(ctx context.Context, fileName string) error {
 	s3FilePath := s.prefixedFileName(fileName)
-	filePath := filepath.Join(s.basePath, fileName)
+	filePath := getFilePath(s.basePath, fileName)
+	fmt.Printf("S3 FILE PATH: \"%s\"\n", s3FilePath)
+	fmt.Printf("FILE PATH: \"%s\"\n", filePath)
 	return s.client.FGetObject(ctx, s.bucket, s3FilePath, filePath, minio.GetObjectOptions{})
 }
 
@@ -178,15 +182,14 @@ func (s *S3BackupStorage) shouldProcessBackupFile(fileName string, logger logr.L
 }
 
 func (s *S3BackupStorage) prefixedFileName(fileName string) string {
+	baseFileName := filepath.Base(fileName)
 	prefix := s.getPrefix()
-	if strings.HasPrefix(fileName, prefix) {
-		return fileName
-	}
-	return prefix + fileName
+	return prefix + baseFileName
 }
 
 func (s *S3BackupStorage) unprefixedFilename(fileName string) string {
-	return strings.TrimPrefix(fileName, s.getPrefix())
+	baseFileName := filepath.Base(fileName)
+	return strings.TrimPrefix(baseFileName, s.getPrefix())
 }
 
 func (s *S3BackupStorage) getPrefix() string {

--- a/pkg/backup/storage.go
+++ b/pkg/backup/storage.go
@@ -56,7 +56,7 @@ func (f *FileSystemBackupStorage) Pull(ctx context.Context, fileName string) err
 }
 
 func (f *FileSystemBackupStorage) Delete(ctx context.Context, fileName string) error {
-	return os.Remove(getFilePath(f.basePath, fileName))
+	return os.Remove(GetFilePath(f.basePath, fileName))
 }
 
 func (f *FileSystemBackupStorage) shouldProcessBackupFile(fileName string, logger logr.Logger) bool {
@@ -152,18 +152,14 @@ func (s *S3BackupStorage) List(ctx context.Context) ([]string, error) {
 
 func (s *S3BackupStorage) Push(ctx context.Context, fileName string) error {
 	s3FilePath := s.prefixedFileName(fileName)
-	filePath := getFilePath(s.basePath, fileName)
-	fmt.Printf("S3 FILE PATH: \"%s\"\n", s3FilePath)
-	fmt.Printf("FILE PATH: \"%s\"\n", filePath)
+	filePath := GetFilePath(s.basePath, fileName)
 	_, err := s.client.FPutObject(ctx, s.bucket, s3FilePath, filePath, minio.PutObjectOptions{})
 	return err
 }
 
 func (s *S3BackupStorage) Pull(ctx context.Context, fileName string) error {
 	s3FilePath := s.prefixedFileName(fileName)
-	filePath := getFilePath(s.basePath, fileName)
-	fmt.Printf("S3 FILE PATH: \"%s\"\n", s3FilePath)
-	fmt.Printf("FILE PATH: \"%s\"\n", filePath)
+	filePath := GetFilePath(s.basePath, fileName)
 	return s.client.FGetObject(ctx, s.bucket, s3FilePath, filePath, minio.GetObjectOptions{})
 }
 

--- a/pkg/backup/storage.go
+++ b/pkg/backup/storage.go
@@ -178,14 +178,11 @@ func (s *S3BackupStorage) shouldProcessBackupFile(fileName string, logger logr.L
 }
 
 func (s *S3BackupStorage) prefixedFileName(fileName string) string {
-	baseFileName := filepath.Base(fileName)
-	prefix := s.getPrefix()
-	return prefix + baseFileName
+	return s.getPrefix() + filepath.Base(fileName)
 }
 
 func (s *S3BackupStorage) unprefixedFilename(fileName string) string {
-	baseFileName := filepath.Base(fileName)
-	return strings.TrimPrefix(baseFileName, s.getPrefix())
+	return strings.TrimPrefix(filepath.Base(fileName), s.getPrefix())
 }
 
 func (s *S3BackupStorage) getPrefix() string {

--- a/pkg/backup/storage_test.go
+++ b/pkg/backup/storage_test.go
@@ -16,6 +16,12 @@ func TestS3PrefixedFile(t *testing.T) {
 			wantFileName:  "backup.2023-12-18T16:14:00Z.sql",
 		},
 		{
+			name:          "no prefix with file path",
+			backupStorage: &S3BackupStorage{},
+			fileName:      "backup/backup.2023-12-18T16:14:00Z.sql",
+			wantFileName:  "backup.2023-12-18T16:14:00Z.sql",
+		},
+		{
 			name: "prefix",
 			backupStorage: &S3BackupStorage{
 				S3BackupStorageOpts: S3BackupStorageOpts{
@@ -23,6 +29,16 @@ func TestS3PrefixedFile(t *testing.T) {
 				},
 			},
 			fileName:     "backup.2023-12-18T16:14:00Z.sql",
+			wantFileName: "mariadb/backup.2023-12-18T16:14:00Z.sql",
+		},
+		{
+			name: "prefix with file path",
+			backupStorage: &S3BackupStorage{
+				S3BackupStorageOpts: S3BackupStorageOpts{
+					Prefix: "mariadb",
+				},
+			},
+			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
 			wantFileName: "mariadb/backup.2023-12-18T16:14:00Z.sql",
 		},
 		{
@@ -36,6 +52,16 @@ func TestS3PrefixedFile(t *testing.T) {
 			wantFileName: "mariadb/backup.2023-12-18T16:14:00Z.sql",
 		},
 		{
+			name: "prefix with trailing slash and file path",
+			backupStorage: &S3BackupStorage{
+				S3BackupStorageOpts: S3BackupStorageOpts{
+					Prefix: "mariadb/",
+				},
+			},
+			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
+			wantFileName: "mariadb/backup.2023-12-18T16:14:00Z.sql",
+		},
+		{
 			name: "nested prefix",
 			backupStorage: &S3BackupStorage{
 				S3BackupStorageOpts: S3BackupStorageOpts{
@@ -43,6 +69,16 @@ func TestS3PrefixedFile(t *testing.T) {
 				},
 			},
 			fileName:     "backup.2023-12-18T16:14:00Z.sql",
+			wantFileName: "backups/production/mariadb/backup.2023-12-18T16:14:00Z.sql",
+		},
+		{
+			name: "nested prefix with file path",
+			backupStorage: &S3BackupStorage{
+				S3BackupStorageOpts: S3BackupStorageOpts{
+					Prefix: "backups/production/mariadb",
+				},
+			},
+			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
 			wantFileName: "backups/production/mariadb/backup.2023-12-18T16:14:00Z.sql",
 		},
 		{
@@ -81,6 +117,12 @@ func TestS3UnprefixedFile(t *testing.T) {
 			wantFileName:  "backup.2023-12-18T16:14:00Z.sql",
 		},
 		{
+			name:          "no prefix with file path",
+			backupStorage: &S3BackupStorage{},
+			fileName:      "backup/backup.2023-12-18T16:14:00Z.sql",
+			wantFileName:  "backup.2023-12-18T16:14:00Z.sql",
+		},
+		{
 			name: "prefix",
 			backupStorage: &S3BackupStorage{
 				S3BackupStorageOpts: S3BackupStorageOpts{
@@ -88,6 +130,16 @@ func TestS3UnprefixedFile(t *testing.T) {
 				},
 			},
 			fileName:     "mariadb/backup.2023-12-18T16:14:00Z.sql",
+			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
+		},
+		{
+			name: "prefix with file path",
+			backupStorage: &S3BackupStorage{
+				S3BackupStorageOpts: S3BackupStorageOpts{
+					Prefix: "mariadb",
+				},
+			},
+			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
 			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
 		},
 		{

--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -3,6 +3,7 @@ package command
 import (
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -236,21 +237,24 @@ func (b *BackupCommand) MariadbRestore(restore *mariadbv1alpha1.Restore,
 }
 
 func (b *BackupCommand) newBackupFile() string {
+	var fileName string
 	if b.Compression == mariadbv1alpha1.CompressNone {
-		return fmt.Sprintf(
+		fileName = fmt.Sprintf(
 			"backup.$(date -u +'%s').sql",
 			"%Y-%m-%dT%H:%M:%SZ",
 		)
+	} else {
+		fileName = fmt.Sprintf(
+			"backup.$(date -u +'%s').%v.sql",
+			"%Y-%m-%dT%H:%M:%SZ",
+			b.Compression,
+		)
 	}
-	return fmt.Sprintf(
-		"backup.$(date -u +'%s').%v.sql",
-		"%Y-%m-%dT%H:%M:%SZ",
-		b.Compression,
-	)
+	return filepath.Join(b.Path, fileName)
 }
 
 func (b *BackupCommand) getTargetFilePath() string {
-	return fmt.Sprintf("%s/$(cat '%s')", b.Path, b.TargetFilePath)
+	return fmt.Sprintf("$(cat '%s')", b.TargetFilePath)
 }
 
 func (b *BackupCommand) mariadbDumpArgs(backup *mariadbv1alpha1.Backup, mariab *mariadbv1alpha1.MariaDB) []string {


### PR DESCRIPTION
Follow up PR to abstract backup compression in order to make it reusable, as we will need this for physical backups at some point.

Related PRs:
- https://github.com/mariadb-operator/mariadb-operator/pull/836
- https://github.com/mariadb-operator/mariadb-operator/pull/897
- https://github.com/mariadb-operator/mariadb-operator/pull/1008