### PR TITLE
ci: test-image{,-ent} display mariadb version

### DIFF
--- a/.github/workflows/test-image-ent.yml
+++ b/.github/workflows/test-image-ent.yml
@@ -13,6 +13,10 @@ jobs:
     name: "Test \"${{ inputs.mariadb_image }}\" enterprise image"
     runs-on: ubuntu-latest
     steps:
+      - name: MariaDB Version
+        run: |
+          docker run --rm ${{ inputs.mariadb_image }} mariadbd --version
+
       - name: Checkout code
         uses: actions/checkout@v4
 

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -13,6 +13,10 @@ jobs:
     name: "Test \"${{ inputs.mariadb_image }}\" image"
     runs-on: ubuntu-latest
     steps:
+      - name: MariaDB Version
+        run: |
+          docker run --rm ${{ inputs.mariadb_image }} mariadbd --version
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
because I pass sha hashes in CI sometimes and knowing the version is a good thing to know.