### PR TITLE
Relabeling metrics for ServiceMonitor

### DIFF
--- a/deploy/charts/mariadb-operator/templates/cert-controller-servicemonitor.yaml
+++ b/deploy/charts/mariadb-operator/templates/cert-controller-servicemonitor.yaml
@@ -33,4 +33,12 @@ spec:
   - port: metrics
     interval: {{ .Values.certController.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.certController.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.certController.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml .Values.certController.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.certController.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml .Values.certController.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
 {{ end }}

--- a/deploy/charts/mariadb-operator/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/mariadb-operator/templates/metrics-servicemonitor.yaml
@@ -33,4 +33,12 @@ spec:
   - port: metrics
     interval: {{ .Values.metrics.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.metrics.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.metrics.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml .Values.metrics.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.metrics.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml .Values.metrics.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
 {{ end }}

--- a/deploy/charts/mariadb-operator/templates/webhook-servicemonitor.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook-servicemonitor.yaml
@@ -33,4 +33,12 @@ spec:
   - port: metrics
     interval: {{ .Values.webhook.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.webhook.serviceMonitor.scrapeTimeout }}
+    {{- if .Values.webhook.serviceMonitor.metricRelabelings }}
+    metricRelabelings:
+      {{- toYaml .Values.webhook.serviceMonitor.metricRelabelings | nindent 6 }}
+    {{- end }}
+    {{- if .Values.webhook.serviceMonitor.relabelings }}
+    relabelings:
+      {{- toYaml .Values.webhook.serviceMonitor.relabelings | nindent 6 }}
+    {{- end }}
 {{- end }}

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -187,7 +187,9 @@ webhook:
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
     scrapeTimeout: 25s
+    # MetricRelabelConfigs to apply to samples before ingestion.
     metricRelabelings: []
+    # RelabelConfigs to apply to samples before scraping.
     relabelings: []
   serviceAccount:
     # -- Specifies whether a service account should be created
@@ -261,7 +263,9 @@ certController:
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
     scrapeTimeout: 25s
+    # MetricRelabelConfigs to apply to samples before ingestion.
     metricRelabelings: []
+    # RelabelConfigs to apply to samples before scraping.
     relabelings: []
   serviceAccount:
     # -- Specifies whether a service account should be created

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -47,7 +47,9 @@ metrics:
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
     scrapeTimeout: 25s
+    # MetricRelabelConfigs to apply to samples before ingestion.
     metricRelabelings: []
+    # RelabelConfigs to apply to samples before scraping.
     relabelings: []
 
 serviceAccount:

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -47,6 +47,8 @@ metrics:
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
     scrapeTimeout: 25s
+    metricRelabelings: []
+    relabelings: []
 
 serviceAccount:
   # -- Specifies whether a service account should be created
@@ -183,6 +185,8 @@ webhook:
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
     scrapeTimeout: 25s
+    metricRelabelings: []
+    relabelings: []
   serviceAccount:
     # -- Specifies whether a service account should be created
     enabled: true
@@ -255,6 +259,8 @@ certController:
     interval: 30s
     # -- Timeout if metrics can't be retrieved in given time interval
     scrapeTimeout: 25s
+    metricRelabelings: []
+    relabelings: []
   serviceAccount:
     # -- Specifies whether a service account should be created
     enabled: true


### PR DESCRIPTION
Add a feature to add relabeling metrics like that:

```yaml
      relabelings:
      - action: replace
        replacement: my-k8s-cluster
        targetLabel: cluster
```