### PR TITLE
ci github workflows - optional mariadb_version

### DIFF
--- a/.github/workflows/test-image-ent.yml
+++ b/.github/workflows/test-image-ent.yml
@@ -7,6 +7,10 @@ on:
         description: "MariaDB image used to run the tests"
         required: true
         type: string
+      mariadb_version:
+        description: "MariaDB version related by image if not obvious via tag"
+        required: false
+        type: string
 
 jobs:
   test:
@@ -45,6 +49,7 @@ jobs:
         run: make test-int-ent
         env:
           RELATED_IMAGE_MARIADB_ENT: "${{ inputs.mariadb_image }}"
+          MARIADB_ENTRYPOINT_VERSION_ENT: "${{ inputs.mariadb_version }}"
 
       - name: Tell the MariaDB Folks that failed
         if: ${{ failure() }}
@@ -56,4 +61,4 @@ jobs:
           to: "Buildbot"
           type: "stream"
           topic: "CI - MariaDB Operator"
-          content: "There was an error running MariaDB Operator integration tests on ${{ inputs.mariadb_image }} - URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          content: "There was an error running MariaDB Operator integration tests on ${{ inputs.mariadb_image }} version(${{ inputs.mariadb_version }}) - URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -7,6 +7,10 @@ on:
         description: "MariaDB image used to run the tests"
         required: true
         type: string
+      mariadb_version:
+        description: "MariaDB version related by image if not obvious via tag"
+        required: false
+        type: string
 
 jobs:
   test:
@@ -37,6 +41,7 @@ jobs:
         run: make test-int
         env:
           RELATED_IMAGE_MARIADB: "${{ inputs.mariadb_image }}"
+          MARIADB_ENTRYPOINT_VERSION: "${{ inputs.mariadb_version }}"
 
       - name: Tell the MariaDB Folks that failed
         if: ${{ failure() }}
@@ -48,5 +53,5 @@ jobs:
           to: "Buildbot"
           type: "stream"
           topic: "CI - MariaDB Operator"
-          content: "There was an error running MariaDB Operator integration tests on ${{ inputs.mariadb_image }} - URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
+          content: "There was an error running MariaDB Operator integration tests on ${{ inputs.mariadb_image }} version(${{ inputs.mariadb_version }}) - URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}."
 


### PR DESCRIPTION
This enables workflows to be triggered by sha hash, but provides the version so the operator knows what version it is working with.

Only required if the mariadb_image doesn't include a tag.