### PR TITLE
Update release workflow to create go pkg compatible tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,8 +183,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: 
       - args
-      - release
-      - release-ent
       - goreleaser
     steps:
       - name: Checkout
@@ -219,9 +217,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: 
     - args
-    - release
-    - release-ent
-    - goreleaser
     - helm
     steps:
       - name: Checkout
@@ -246,10 +241,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: 
       - args
-      - release
-      - release-ent
-      - goreleaser
-      - helm
       - olm
     steps:
       - name: Checkout
@@ -264,3 +255,27 @@ jobs:
             -f version=${{ needs.args.outputs.VERSION }} alias=latest
         env:
           GITHUB_TOKEN: "${{ secrets.GHA_TOKEN }}"
+
+  gopkg:
+    name: Go package
+    runs-on: ubuntu-latest
+    needs: 
+    - args
+    - docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: "${{ secrets.GHA_TOKEN }}"
+          ref: "${{ github.event.repository.default_branch }}"
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Push Go package compatible tag
+        run: |
+          git tag "v${{ needs.args.outputs.VERSION }}"
+          git push --tags

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,32 +236,12 @@ jobs:
           git tag "olm-${{ needs.args.outputs.VERSION }}"
           git push --tags
 
-  docs:
-    name: Documentation
-    runs-on: ubuntu-latest
-    needs: 
-      - args
-      - olm
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Dispatch docs workflow
-        run: |
-          gh workflow run docs.yml \
-            --repo mariadb-operator/mariadb-operator \
-            -f version=${{ needs.args.outputs.VERSION }} alias=latest
-        env:
-          GITHUB_TOKEN: "${{ secrets.GHA_TOKEN }}"
-
   gopkg:
     name: Go package
     runs-on: ubuntu-latest
     needs: 
-    - args
-    - docs
+      - args
+      - olm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -279,3 +259,23 @@ jobs:
         run: |
           git tag "v${{ needs.args.outputs.VERSION }}"
           git push --tags
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    needs: 
+      - args
+      - gopkg
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Dispatch docs workflow
+        run: |
+          gh workflow run docs.yml \
+            --repo mariadb-operator/mariadb-operator \
+            -f version=${{ needs.args.outputs.VERSION }} alias=latest
+        env:
+          GITHUB_TOKEN: "${{ secrets.GHA_TOKEN }}"


### PR DESCRIPTION
pkg.go.dev seems to only accept tags with the `v[0-9]+.[0-9]+.[0-9]+` format. This PR adds an extra step in the release process to create a go pkg compatible tag.

Previous tags have been pushed manually:
- https://pkg.go.dev/github.com/mariadb-operator/mariadb-operator?tab=versions