### PR TITLE
Enable `temp-pool` by default

### DIFF
--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -1044,6 +1044,7 @@ func (r *MariaDBReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 func defaultConfig(mariadb *mariadbv1alpha1.MariaDB) (string, error) {
 	tpl := createTpl("0-default.cnf", `[mariadb]
 skip-name-resolve
+temp-pool
 {{- with .TimeZone }}
 default_time_zone = {{ . }}
 {{- end }}

--- a/internal/controller/mariadb_controller_test.go
+++ b/internal/controller/mariadb_controller_test.go
@@ -64,6 +64,7 @@ var _ = Describe("MariaDB spec", func() {
 			&mariadbv1alpha1.MariaDB{},
 			`[mariadb]
 skip-name-resolve
+temp-pool
 `,
 		),
 		Entry(
@@ -75,6 +76,7 @@ skip-name-resolve
 			},
 			`[mariadb]
 skip-name-resolve
+temp-pool
 default_time_zone = UTC
 `,
 		),
@@ -161,7 +163,7 @@ var _ = Describe("MariaDB", func() {
 			g.Expect(cm.ObjectMeta.Labels).To(HaveKeyWithValue("k8s.mariadb.com/test", "test"))
 			g.Expect(cm.ObjectMeta.Annotations).NotTo(BeNil())
 			g.Expect(cm.ObjectMeta.Annotations).To(HaveKeyWithValue("k8s.mariadb.com/test", "test"))
-			g.Expect(cm.Data).To(HaveKeyWithValue("0-default.cnf", "[mariadb]\nskip-name-resolve\n"))
+			g.Expect(cm.Data).To(HaveKeyWithValue("0-default.cnf", "[mariadb]\nskip-name-resolve\ntemp-pool\n"))
 			return true
 		}, testTimeout, testInterval).Should(BeTrue())
 


### PR DESCRIPTION
See: https://jira.mariadb.org/browse/MDEV-34577