### PR TITLE
Exclude dollar signs from generated passwords

### DIFF
--- a/pkg/controller/secret/controller.go
+++ b/pkg/controller/secret/controller.go
@@ -22,7 +22,7 @@ type SecretReconciler struct {
 
 func NewSecretReconciler(client client.Client, builder *builder.Builder) (*SecretReconciler, error) {
 	generator, err := password.NewGenerator(&password.GeneratorInput{
-		Symbols: "~!@$%^&*()_+-={}|[]:<>/",
+		Symbols: "~!@%^&*()_+-={}|[]:<>/",
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating password generator: %v", err)


### PR DESCRIPTION
mysqld_exporter is unable to parse these from its config file, leading to errors

Closes #716 