### PR TITLE
Fix TLS defaults in embedded `MaxScale`

### DIFF
--- a/docs/releases/RELEASE_0.37.1_HEADER.md.gotmpl
+++ b/docs/releases/RELEASE_0.37.1_HEADER.md.gotmpl
@@ -1,0 +1,158 @@
+**`{{ .ProjectName }}` [0.37.1](https://github.com/mariadb-operator/mariadb-operator/releases/tag/0.37.1) is here!** 🦭
+
+We're excited to introduce __[TLS](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/TLS.md)__ 🔐 support in this release, one of the major features of `mariadb-operator` so far! ✨ Check out the __[TLS docs](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/TLS.md)__, our [example catalog](https://github.com/mariadb-operator/mariadb-operator/tree/main/examples/manifests) and the release notes below to start using it.
+
+> [!WARNING]
+> Be sure to follow the __[UPGRADE GUIDE](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/releases/UPGRADE_0.37.1.md)__ to ensure a seamless transition from previous versions.
+
+### Issue certificates for `MariaDB` and `MaxScale`
+
+Issuing and configuring TLS certificates for your instances has never been easier, you just need to set `tls.enabled=true`:
+
+```yaml
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb-galera
+spec:
+  ...
+  tls:
+    enabled: true
+```
+
+```yaml
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MaxScale
+metadata:
+  name: maxscale
+spec:
+  ...
+  mariaDbRef:
+    name: mariadb-galera
+  tls:
+    enabled: true
+```
+
+A self-signed Certificate Authority (CA) will be automatically generated to issue leaf certificates for your instances. The operator will also manage a CA bundle that your applications can use in order to establish trust. 
+
+TLS will be enabled by default in `MariaDB`, but it will not enforced. You can enforce TLS connections by setting `tls.required=true` to ensure that all connections are encrypted. In the case of `MaxScale`, TLS will only be enabled if you explicitly set `tls.enabled=true` or the referred `MariaDB` (via `mariaDbRef`) instance enforces TLS.
+
+
+### Native integration with cert-manager
+
+[cert-manager](https://cert-manager.io/) is the de facto standard for managing certificates in Kubernetes. This certificate controller simplifies the automatic provisioning, management, and renewal of certificates. It supports a variety of [certificate backends](https://cert-manager.io/docs/configuration/issuers/) (e.g. in-cluster, Hashicorp Vault), which are configured using `Issuer` or `ClusterIssuer` resources.
+
+In your `MariaDB` and `MaxScale` resources, you can directly reference `ClusterIssuer` or `Issuer` objects to seamlessly issue certificates:
+
+```yaml
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb-galera
+spec:
+  ...
+  tls:
+    enabled: true
+    serverCertIssuerRef:
+      name: root-ca
+      kind: ClusterIssuer
+    clientCertIssuerRef:
+      name: root-ca
+      kind: ClusterIssuer
+```
+```yaml
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MaxScale
+metadata:
+  name: maxscale-galera
+spec:
+  ...
+  tls:
+    enabled: true
+    adminCertIssuerRef:
+      name: root-ca
+      kind: ClusterIssuer
+    listenerCertIssuerRef:
+      name: root-ca
+      kind: ClusterIssuer
+``` 
+
+Under the scenes, the operator will create cert-manager's `Certificate` resources with all the required Subject Alternative Names (SANs) required by your instances. These certificates will be automatically managed by cert-manager and the CA bundle will be updated by the operator so you can establish trust with your instances.
+
+The advantage of this approach is that you can use any of the [cert-manager's certificate backends](https://cert-manager.io/docs/configuration/issuers/), such as the in-cluster CA or HashiCorp Vault, and potentially reuse the same `Issuer`/`ClusterIssuer` with multiple instances.
+
+### Certificate rotation
+
+Whether the certificates are managed by the operator or by cert-manager, they will be automatically renewed before expiration. Additionally, the operator will update the CA bundle whenever the CAs are rotated, temporarily retaining the old CA in the bundle to ensure a seamless update process.
+
+In both scenarios, the standard [update strategies](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/UPDATES.md) apply, allowing you to control how the `Pods` are restarted during certificate rotation.
+
+### TLS requirements for `Users`
+
+We have extended our `User` SQL resource to include TLS-specific requirements for user connections over TLS. For example, if you want to enforce the use of a valid x509 certificate for a user to connect:
+
+```yaml
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: user
+spec:
+  ...
+  require:
+    x509: true
+```
+
+To restrict the subject of the user's certificate and/or require a specific issuer, you may set:
+
+```yaml
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: user
+spec:
+  ...
+  require:
+    issuer: "/CN=mariadb-galera-ca"
+    subject: "/CN=mariadb-galera-client"
+```
+
+If any of these TLS requirements are not satisfied, the user will be unable to connect to the instance.
+
+### Automatic updates when Galera options are changed
+
+Whenever Galera options are changed, for example, adding `providerOptions`:
+
+```diff
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb-galera
+spec:
+  ...
+  galera:
+    enabled: true
++   providerOptions:
++     gcs.fc_limit: '64'
+```
+
+An update is now automatically triggered, and the `Pods` are restarted according to the configured [update strategy](https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/UPDATES.md).
+ 
+### Community contributions
+
+- [Support startupProbe in MariaDB and MaxScale](https://github.com/mariadb-operator/mariadb-operator/pull/1053) by @vixns
+- [Prevent deadlocks on Database reconcile while transactions are running](https://github.com/mariadb-operator/mariadb-operator/pull/1127) by @vixns
+- [Update CronJob template on reconcile](https://github.com/mariadb-operator/mariadb-operator/pull/1124) by @vixns
+- [Operator configuration via helm](https://github.com/mariadb-operator/mariadb-operator/pull/1098) by @sakazuki and @indigo-saito
+- [Support EKS Service Accounts in S3](https://github.com/mariadb-operator/mariadb-operator/pull/1115) by @Skaronator
+- [Add support for configuring priorityClassName, topologySpreadConstraints, PDB in Helm Chart](https://github.com/mariadb-operator/mariadb-operator/pull/1133) by @Skaronator
+- [Exclude dollar signs from generated passwords](https://github.com/mariadb-operator/mariadb-operator/pull/1135) by @simonhammes
+- [Fix examples SqlJob secret reference](https://github.com/mariadb-operator/mariadb-operator/pull/1090) by @driv
+- [FLUSH PRIVILEGES unnecessary for user/grant manipulation](https://github.com/mariadb-operator/mariadb-operator/pull/1083) by @grooverdan
+
+Huge thanks to our awesome contributors! 🙇
+
+---
+
+We value your feedback! If you encounter any issues or have suggestions, please [open an issue on GitHub](https://github.com/mariadb-operator/mariadb-operator/issues/new/choose). Your input is crucial to improve `{{ .ProjectName }}`🦭.
+
+Join us on Slack: **[MariaDB Community Slack](https://r.mariadb.com/join-community-slack)**.

--- a/docs/releases/UPGRADE_0.37.1.md
+++ b/docs/releases/UPGRADE_0.37.1.md
@@ -1,0 +1,70 @@
+# Upgrade guide 0.37.1
+
+This guide illustrates, step by step, how to migrate to `0.37.1` from previous versions.
+
+> [!WARNING]
+> Avoid skipping intermediate version upgrades. Always upgrade progressively, one version at a time, and follow the upgrade guide step by step.
+
+> [!CAUTION]
+> With the introduction of TLS, breaking changes in the Galera data-plane have been introduced. Make sure you follow the migration steps to upgrade without any issues.
+
+
+### Migration steps
+
+1. Uninstall you current `mariadb-operator` for preventing conflicts:
+```bash
+helm uninstall mariadb-operator
+```
+
+2. Upgrade `mariadb-operator-crds` to `0.37.1`:
+```bash
+helm repo update mariadb-operator
+helm upgrade --install mariadb-operator-crds  mariadb-operator/mariadb-operator-crds --version 0.37.1
+```
+
+3. The Galera data-plane must be updated, even if you are not planning to use TLS. By setting `updateStrategy.autoUpdateDataPlane=true` in your `MariaDB` resources, the operator will automatically update the data-plane for you as part of the rolling upgrade.
+```diff
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb-galera
+spec:
+  updateStrategy:
++   autoUpdateDataPlane: true
+```
+
+Alternatively, you can also do this manually:
+```diff
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb
+spec:
+  galera:
+    agent:
+-      image: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.36.0
++      image: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.37.1
+    initContainer:
+-      image: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.36.0
++      image: docker-registry3.mariadb.com/mariadb-operator/mariadb-operator:0.37.1
+```
+
+4. Upgrade `mariadb-operator` to `0.37.1`. This will trigger a rolling upgrade, make sure it finishes successfully before proceeding with the next step. Refer to the [updates documentation](../UPDATES.md) for further information about update strategies:
+```bash 
+helm repo update mariadb-operator
+helm upgrade --install mariadb-operator mariadb-operator/mariadb-operator --version 0.37.1 
+```
+
+5. If needed, set back `autoUpdateDataPlane=false` in `MariaDB` to avoid unexpected data-plane updates in the future:
+```diff
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: mariadb-galera
+spec:
+  updateStrategy:
++   autoUpdateDataPlane: false
+-   autoUpdateDataPlane: true
+```
+
+6. If you plan to use TLS, please refer to the __[TLS documentation](../TLS.md)__. 

--- a/pkg/builder/maxscale_builder.go
+++ b/pkg/builder/maxscale_builder.go
@@ -43,6 +43,7 @@ func (b *Builder) BuildMaxScale(key types.NamespacedName, mdb *mariadbv1alpha1.M
 			RequeueInterval:      mdbmxs.RequeueInterval,
 		},
 	}
+	// TLS should be enforced in MariaDB to be enabled in MaxScale by default
 	if mxs.Spec.TLS == nil && mdb != nil && mdb.IsTLSRequired() {
 		mxs.Spec.TLS = &mariadbv1alpha1.MaxScaleTLS{
 			Enabled: true,

--- a/pkg/builder/maxscale_builder.go
+++ b/pkg/builder/maxscale_builder.go
@@ -43,9 +43,9 @@ func (b *Builder) BuildMaxScale(key types.NamespacedName, mdb *mariadbv1alpha1.M
 			RequeueInterval:      mdbmxs.RequeueInterval,
 		},
 	}
-	if mxs.Spec.TLS == nil {
+	if mxs.Spec.TLS == nil && mdb != nil && mdb.IsTLSRequired() {
 		mxs.Spec.TLS = &mariadbv1alpha1.MaxScaleTLS{
-			Enabled: mdb.IsTLSEnabled(),
+			Enabled: true,
 		}
 	}
 	if err := controllerutil.SetControllerReference(mdb, &mxs, b.scheme); err != nil {

--- a/pkg/builder/maxscale_builder_test.go
+++ b/pkg/builder/maxscale_builder_test.go
@@ -5,6 +5,7 @@ import (
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 )
 
 func TestMaxScaleMeta(t *testing.T) {
@@ -73,18 +74,6 @@ func TestMaxScaleTLS(t *testing.T) {
 		wantTLS *mariadbv1alpha1.MaxScaleTLS
 	}{
 		{
-			name: "tls enabled in MariaDB",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					TLS: &mariadbv1alpha1.TLS{
-						Enabled: true,
-					},
-				},
-			},
-			mdbmxs:  &mariadbv1alpha1.MariaDBMaxScaleSpec{},
-			wantTLS: &mariadbv1alpha1.MaxScaleTLS{Enabled: true},
-		},
-		{
 			name: "tls not enabled in MariaDB",
 			mariadb: &mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
@@ -94,7 +83,32 @@ func TestMaxScaleTLS(t *testing.T) {
 				},
 			},
 			mdbmxs:  &mariadbv1alpha1.MariaDBMaxScaleSpec{},
-			wantTLS: &mariadbv1alpha1.MaxScaleTLS{Enabled: false},
+			wantTLS: nil,
+		},
+		{
+			name: "tls enabled in MariaDB",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					TLS: &mariadbv1alpha1.TLS{
+						Enabled: true,
+					},
+				},
+			},
+			mdbmxs:  &mariadbv1alpha1.MariaDBMaxScaleSpec{},
+			wantTLS: nil,
+		},
+		{
+			name: "tls required in MariaDB",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					TLS: &mariadbv1alpha1.TLS{
+						Enabled:  true,
+						Required: ptr.To(true),
+					},
+				},
+			},
+			mdbmxs:  &mariadbv1alpha1.MariaDBMaxScaleSpec{},
+			wantTLS: &mariadbv1alpha1.MaxScaleTLS{Enabled: true},
 		},
 		{
 			name: "tls explicitly set in MaxScaleSpec",


### PR DESCRIPTION
When applying [this manifest](https://github.com/mariadb-operator/mariadb-operator/blob/main/examples/manifests/mariadb_galera_maxscale.yaml), the `MaxScale` resource reports the following error:

```bash
Status:
  Conditions:
    Last Transition Time:  2025-01-28T17:32:36Z
    Message:               'spec.tls.serverCASecretRef' and 'spec.tls.ServerCertSecretRef' fieldsmust be set in order to communicate with MariaDB server
```

This PR fixes the previous issue and aligns the defaults with the premise: `MaxScale` TLS should only be set by default if `MariaDB` TLS is enforced. 