### PR TITLE
fix: don't reconcile mariadb cr if it's marked for deletion

### DIFF
--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -122,6 +122,13 @@ func (r *MariaDBReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.Get(ctx, req.NamespacedName, &mariadb); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	// Skip reconciliation if the MariaDB CR is being deleted
+	if !mariadb.DeletionTimestamp.IsZero() {
+		log.FromContext(ctx).Info("MariaDB is being deleted, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
 	phases := []reconcilePhaseMariaDB{
 		{
 			Name:      "Spec",

--- a/pkg/controller/statefulset/statefulset.go
+++ b/pkg/controller/statefulset/statefulset.go
@@ -37,6 +37,11 @@ func (r *StatefulSetReconciler) ReconcileWithUpdates(ctx context.Context, desire
 		return nil
 	}
 
+	// If StatefulSet is being deleted, don't update it
+	if !existingSts.DeletionTimestamp.IsZero() {
+		return nil
+	}
+
 	if shouldUpdate {
 		patch := client.MergeFrom(existingSts.DeepCopy())
 		existingSts.Spec.Template = desiredSts.Spec.Template


### PR DESCRIPTION
MariaDB CR should not be reconciled when marked for deletion.

Fixes https://github.com/mariadb-operator/mariadb-operator/issues/1123

Related to: https://mariadb-community.slack.com/archives/C06AWJBAC1H/p1736934983515949