### PR TITLE
Fix `restore.spec.databases` doesn't exist

### DIFF
--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -317,7 +317,7 @@ spec:
     name: mariadb
   backupRef:
     name: backup
-  databases: db1
+  database: db1
 ```
 
 There are a couple of points to consider here:


### PR DESCRIPTION
```sh
$ k explain restore.spec.databases
GROUP:      k8s.mariadb.com
KIND:       Restore
VERSION:    v1alpha1

error: field "databases" does not exist
```
but 
```sh
k explain restore.spec.database
GROUP:      k8s.mariadb.com
KIND:       Restore
VERSION:    v1alpha1

FIELD: database <string>


DESCRIPTION:
    Database defines the logical database to be restored. If not provided, all
    databases available in the backup are restored.
    IMPORTANT: The database must previously exist.
```

Therefore the key of specification of the database to restore should be singular.