### PR TITLE
Fix command and args on Maxscale resource

### DIFF
--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -133,9 +133,12 @@ func (b *Builder) maxscaleContainers(mxs *mariadbv1alpha1.MaxScale) ([]corev1.Co
 
 	container.Name = MaxScaleContainerName
 	container.Command = command.Command
+	if tpl.Command != nil {
+		container.Command = tpl.Command
+	}
 	container.Args = command.Args
 	if len(tpl.Args) > 0 {
-		container.Args = append(container.Args, tpl.Args...)
+		container.Args = tpl.Args
 	}
 	container.Ports = []corev1.ContainerPort{
 		{


### PR DESCRIPTION
Despite the  API documentation showing the `command` and `args` are available on the Maxscale resource, the current implementation ignores the `command` and just appends args to the default `args`. 
This behaviour blocks us from using custom Maxscale images with different commands and args.
On this PR I'm changing the MaxscaleContainer builder to use the custom values when provided. I'm also adding some tests to cover these scenarios.