### PR TITLE
`MaxScale` improvements

### DIFF
--- a/api/v1alpha1/maxscale_types.go
+++ b/api/v1alpha1/maxscale_types.go
@@ -863,31 +863,6 @@ func (m *MaxScale) SetDefaults(env *environment.OperatorEnv, mariadb *MariaDB) {
 				Listener: MaxScaleListener{
 					Port: 3306,
 				},
-				Params: map[string]string{
-					"transaction_replay":  "true",
-					"master_accept_reads": "true",
-				},
-			},
-			{
-				Name:   "rconn-master-router",
-				Router: ServiceRouterReadConnRoute,
-				Listener: MaxScaleListener{
-					Port: 3307,
-				},
-				Params: map[string]string{
-					"router_options":      "master",
-					"master_accept_reads": "true",
-				},
-			},
-			{
-				Name:   "rconn-slave-router",
-				Router: ServiceRouterReadConnRoute,
-				Listener: MaxScaleListener{
-					Port: 3308,
-				},
-				Params: map[string]string{
-					"router_options": "slave",
-				},
 			},
 		}
 	}

--- a/api/v1alpha1/maxscale_types_test.go
+++ b/api/v1alpha1/maxscale_types_test.go
@@ -329,26 +329,6 @@ var _ = Describe("MaxScale types", func() {
 									Port: 3306,
 								},
 							},
-							{
-								Name:   "rconn-master-router",
-								Router: ServiceRouterReadConnRoute,
-								Listener: MaxScaleListener{
-									Port: 3307,
-									Params: map[string]string{
-										"router_options": "master",
-									},
-								},
-							},
-							{
-								Name:   "rconn-slave-router",
-								Router: ServiceRouterReadConnRoute,
-								Listener: MaxScaleListener{
-									Port: 3308,
-									Params: map[string]string{
-										"router_options": "slave",
-									},
-								},
-							},
 						},
 						Monitor: MaxScaleMonitor{
 							Module: MonitorModuleMariadb,
@@ -421,30 +401,6 @@ var _ = Describe("MaxScale types", func() {
 									Name:     "rw-router-listener",
 									Port:     3306,
 									Protocol: "MariaDBProtocol",
-								},
-							},
-							{
-								Name:   "rconn-master-router",
-								Router: ServiceRouterReadConnRoute,
-								Listener: MaxScaleListener{
-									Name:     "rconn-master-router-listener",
-									Port:     3307,
-									Protocol: "MariaDBProtocol",
-									Params: map[string]string{
-										"router_options": "master",
-									},
-								},
-							},
-							{
-								Name:   "rconn-slave-router",
-								Router: ServiceRouterReadConnRoute,
-								Listener: MaxScaleListener{
-									Name:     "rconn-slave-router-listener",
-									Port:     3308,
-									Protocol: "MariaDBProtocol",
-									Params: map[string]string{
-										"router_options": "slave",
-									},
 								},
 							},
 						},

--- a/config/samples/maxscale.yaml
+++ b/config/samples/maxscale.yaml
@@ -15,29 +15,9 @@ spec:
         transaction_replay: "true"
         transaction_replay_attempts: "10"
         transaction_replay_timeout: "5s"
-        max_slave_connections: "255"
-        max_replication_lag: "3s"
-        master_accept_reads: "true"
       listener:
         port: 3306
         protocol: MariaDBProtocol
-        params:
-          connection_metadata: "tx_isolation=auto"
-    - name: rconn-master-router
-      router: readconnroute
-      params:
-        router_options: "master"
-        max_replication_lag: "3s"
-        master_accept_reads: "true"
-      listener:
-        port: 3307
-    - name: rconn-slave-router
-      router: readconnroute
-      params:
-        router_options: "slave"
-        max_replication_lag: "3s"
-      listener:
-        port: 3308
 
   monitor:
     interval: 2s

--- a/docs/MAXSCALE.md
+++ b/docs/MAXSCALE.md
@@ -93,33 +93,8 @@ spec:
   services:
     - name: rw-router
       router: readwritesplit
-      params:
-        transaction_replay: "true"
-        transaction_replay_attempts: "10"
-        transaction_replay_timeout: "5s"
-        max_slave_connections: "255"
-        max_replication_lag: "3s"
-        master_accept_reads: "true"
       listener:
         port: 3306
-        protocol: MariaDBProtocol
-        params:
-          connection_metadata: "tx_isolation=auto"
-    - name: rconn-master-router
-      router: readconnroute
-      params:
-        router_options: "master"
-        max_replication_lag: "3s"
-        master_accept_reads: "true"
-      listener:
-        port: 3307
-    - name: rconn-slave-router
-      router: readconnroute
-      params:
-        router_options: "slave"
-        max_replication_lag: "3s"
-      listener:
-        port: 3308
 
   monitor:
     interval: 2s
@@ -255,10 +230,7 @@ Refer to the [Reference](#reference) section for further detail.
 - `spec.servers` are inferred from `spec.mariaDbRef`.
 - `spec.monitor.module` is inferred from the `spec.mariaDbRef`.
 - `spec.monitor.cooperativeMonitoring` is set if [high availability](#high-availability) is enabled.
-- If `spec.services` is not provided, the following are configured by default:
-  - `readwritesplit` service on port `3306`.
-  - `readconnroute` service pointing to the primary node on port `3307`.
-  - `readconnroute` service pointing to the replica nodes on port `3308`.
+- If `spec.services` is not provided, a `readwritesplit` service is configured on port `3306` by default.
 
 ## Server configuration
 
@@ -467,12 +439,6 @@ spec:
   - name: rw-router-listener
     port: 3306
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: maxscale-galera
     app.kubernetes.io/name: maxscale
@@ -633,10 +599,6 @@ status:
     databaseVersion: 20
     maxScaleVersion: 20
   listeners:
-  - name: rconn-master-router-listener
-    state: Running
-  - name: rconn-slave-router-listener
-    state: Running
   - name: rw-router-listener
     state: Running
   monitor:
@@ -652,10 +614,6 @@ status:
   - name: mariadb-galera-2
     state: Slave, Synced, Running
   services:
-  - name: rconn-master-router
-    state: Started
-  - name: rconn-slave-router
-    state: Started
   - name: rw-router
     state: Started
 ```

--- a/examples/manifests/maxscale_external.yaml
+++ b/examples/manifests/maxscale_external.yaml
@@ -23,29 +23,9 @@ spec:
         transaction_replay: "true"
         transaction_replay_attempts: "10"
         transaction_replay_timeout: "5s"
-        max_slave_connections: "255"
-        max_replication_lag: "3s"
-        master_accept_reads: "true"
       listener:
         port: 3306
         protocol: MariaDBProtocol
-        params:
-          connection_metadata: "tx_isolation=auto"
-    - name: rconn-master-router
-      router: readconnroute
-      params:
-        router_options: "master"
-        max_replication_lag: "3s"
-        master_accept_reads: "true"
-      listener:
-        port: 3307
-    - name: rconn-slave-router
-      router: readconnroute
-      params:
-        router_options: "slave"
-        max_replication_lag: "3s"
-      listener:
-        port: 3308
 
   monitor:
     name: mariadb-monitor

--- a/examples/manifests/maxscale_galera.yaml
+++ b/examples/manifests/maxscale_galera.yaml
@@ -11,33 +11,8 @@ spec:
   services:
     - name: rw-router
       router: readwritesplit
-      params:
-        transaction_replay: "true"
-        transaction_replay_attempts: "10"
-        transaction_replay_timeout: "5s"
-        max_slave_connections: "255"
-        max_replication_lag: "3s"
-        master_accept_reads: "true"
       listener:
         port: 3306
-        protocol: MariaDBProtocol
-        params:
-          connection_metadata: "tx_isolation=auto"
-    - name: rconn-master-router
-      router: readconnroute
-      params:
-        router_options: "master"
-        max_replication_lag: "3s"
-        master_accept_reads: "true"
-      listener:
-        port: 3307
-    - name: rconn-slave-router
-      router: readconnroute
-      params:
-        router_options: "slave"
-        max_replication_lag: "3s"
-      listener:
-        port: 3308
 
   monitor:
     interval: 2s

--- a/hack/manifests/metallb/maxscale-galera-service.yaml
+++ b/hack/manifests/metallb/maxscale-galera-service.yaml
@@ -15,14 +15,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: maxscale-galera
     app.kubernetes.io/name: maxscale
@@ -46,14 +38,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: maxscale-galera
     app.kubernetes.io/name: maxscale
@@ -77,14 +61,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: maxscale-galera
     app.kubernetes.io/name: maxscale
@@ -108,14 +84,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: maxscale-galera
     app.kubernetes.io/name: maxscale
@@ -139,14 +107,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: mariadb-galera-maxscale
     app.kubernetes.io/name: maxscale
@@ -170,14 +130,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: mariadb-galera-maxscale
     app.kubernetes.io/name: maxscale
@@ -201,14 +153,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: mariadb-galera-maxscale
     app.kubernetes.io/name: maxscale
@@ -232,14 +176,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: mariadb-galera-maxscale
     app.kubernetes.io/name: maxscale

--- a/hack/manifests/metallb/maxscale-repl-service.yaml
+++ b/hack/manifests/metallb/maxscale-repl-service.yaml
@@ -15,14 +15,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: maxscale-repl
     app.kubernetes.io/name: maxscale
@@ -46,14 +38,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: maxscale-repl
     app.kubernetes.io/name: maxscale
@@ -77,14 +61,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: maxscale-repl
     app.kubernetes.io/name: maxscale
@@ -108,14 +84,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: maxscale-repl
     app.kubernetes.io/name: maxscale
@@ -139,14 +107,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: mariadb-repl-maxscale
     app.kubernetes.io/name: maxscale
@@ -170,14 +130,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: mariadb-repl-maxscale
     app.kubernetes.io/name: maxscale
@@ -201,14 +153,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: mariadb-repl-maxscale
     app.kubernetes.io/name: maxscale
@@ -232,14 +176,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: mariadb-repl-maxscale
     app.kubernetes.io/name: maxscale

--- a/hack/manifests/metallb/maxscale-service.yaml
+++ b/hack/manifests/metallb/maxscale-service.yaml
@@ -15,14 +15,6 @@ spec:
     port: 3306
     protocol: TCP
     targetPort: 3306
-  - name: rconn-master-router-listener
-    port: 3307
-    protocol: TCP
-    targetPort: 3307
-  - name: rconn-slave-router-listener
-    port: 3308
-    protocol: TCP
-    targetPort: 3308
   selector:
     app.kubernetes.io/instance: mxs-test
     app.kubernetes.io/name: maxscale

--- a/internal/controller/maxscale_controller.go
+++ b/internal/controller/maxscale_controller.go
@@ -879,7 +879,23 @@ func monitorGrantOpts(key types.NamespacedName, mxs *mariadbv1alpha1.MaxScale) [
 			},
 		}
 	}
-	return nil
+	return []auth.GrantOpts{
+		{
+			Key: key,
+			GrantOpts: builder.GrantOpts{
+				Privileges: []string{
+					"SLAVE MONITOR",
+				},
+				Database:    "*",
+				Table:       "*",
+				Username:    mxs.Spec.Auth.MonitorUsername,
+				Host:        "%",
+				GrantOption: false,
+				Metadata:    mxs.Spec.InheritMetadata,
+				MariaDBRef:  *mxs.Spec.MariaDBRef,
+			},
+		},
+	}
 }
 
 func (r *MaxScaleReconciler) reconcileAdmin(ctx context.Context, req *requestMaxScale) (ctrl.Result, error) {


### PR DESCRIPTION
- `readwritesplit` as default `MaxScale` router
- Added extra permissions to `galeramon`, to avoid logging errors 