### PR TITLE
Use unnamed replication connection

### DIFF
--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -20,9 +20,8 @@ import (
 )
 
 var (
-	replUser       = "repl"
-	replUserHost   = "%"
-	connectionName = "mariadb-operator"
+	replUser     = "repl"
+	replUserHost = "%"
 )
 
 type ReplicationConfig struct {
@@ -89,7 +88,7 @@ func (r *ReplicationConfig) ConfigureReplica(ctx context.Context, mariadb *maria
 	if err := r.changeMaster(ctx, mariadb, client, primaryPodIndex); err != nil {
 		return fmt.Errorf("error changing master: %v", err)
 	}
-	if err := client.StartSlave(ctx, connectionName); err != nil {
+	if err := client.StartSlave(ctx); err != nil {
 		return fmt.Errorf("error starting slave: %v", err)
 	}
 	return nil
@@ -158,7 +157,6 @@ func (r *ReplicationConfig) changeMaster(ctx context.Context, mariadb *mariadbv1
 
 	changeMasterOpts := []sql.ChangeMasterOpt{
 		changeMasterHostOpt,
-		sql.WithChangeMasterConnection(connectionName),
 		sql.WithChangeMasterPort(mariadb.Spec.Port),
 		sql.WithChangeMasterCredentials(replUser, password),
 		sql.WithChangeMasterGtid(gtidString),

--- a/pkg/controller/replication/switchover.go
+++ b/pkg/controller/replication/switchover.go
@@ -360,7 +360,7 @@ func (r *ReplicationReconciler) resetSlave(ctx context.Context, client *sqlClien
 	if err := client.ResetSlavePos(ctx); err != nil {
 		return fmt.Errorf("error resetting slave position: %v", err)
 	}
-	return client.StartSlave(ctx, connectionName)
+	return client.StartSlave(ctx)
 }
 
 func (r *ReplicationReconciler) currentPrimaryReady(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB) (bool, error) {

--- a/pkg/sql/sql_test.go
+++ b/pkg/sql/sql_test.go
@@ -41,7 +41,7 @@ func TestBuildChangeMasterQuery(t *testing.T) {
 				WithChangeMasterCredentials("repl", "password"),
 				WithChangeMasterGtid("CurrentPos"),
 			},
-			wantQuery: `CHANGE MASTER 'mariadb-operator' TO
+			wantQuery: `CHANGE MASTER TO
 MASTER_HOST='127.0.0.1',
 MASTER_PORT=3306,
 MASTER_USER='repl',
@@ -71,7 +71,7 @@ MASTER_CONNECT_RETRY=10;
 				WithChangeMasterGtid("CurrentPos"),
 				WithChangeMasterSSL("/etc/pki/client.crt", "/etc/pki/client.key", "/etc/pki/ca.crt"),
 			},
-			wantQuery: `CHANGE MASTER 'mariadb-operator' TO
+			wantQuery: `CHANGE MASTER TO
 MASTER_HOST='127.0.0.1',
 MASTER_PORT=3306,
 MASTER_USER='repl',


### PR DESCRIPTION
Closes https://github.com/mariadb-operator/mariadb-operator/issues/1116

Named connections seem to be used for multi-master replication, which is not our case: https://mariadb.com/kb/en/multi-source-replication/

With this change, `ResetAllSlaves()` completely nukes the slave connection on the master after a switchover, so `SHOW ALL SLAVES STATUS\G` on the new master shows nothing and exporter does not report fake broken slave metrics.

TO DO: decide how to handle migration of existing mariadb instances to the new version, if that is accepted.