### PR TITLE
fix: HostPath not properly copied into StorageVolumeSource struct

### DIFF
--- a/api/v1alpha1/kubernetes_volume_types.go
+++ b/api/v1alpha1/kubernetes_volume_types.go
@@ -151,6 +151,9 @@ func (v StorageVolumeSource) ToKubernetesType() corev1.VolumeSource {
 	if v.CSI != nil {
 		volumeSource.CSI = ptr.To(v.CSI.ToKubernetesType())
 	}
+	if v.HostPath != nil {
+		volumeSource.HostPath = ptr.To(v.HostPath.ToKubernetesType())
+	}
 	if v.PersistentVolumeClaim != nil {
 		volumeSource.PersistentVolumeClaim = ptr.To(v.PersistentVolumeClaim.ToKubernetesType())
 	}


### PR DESCRIPTION
I screwed up in #1192 as I forgot to add `HostPath` to `func (v StorageVolumeSource) ToKubernetesType()`...

This PR fixes that issue and also adds a test to avoid these kind of mistakes in the future. The test ensures that any field implemented in `StorageVolumeSource` is copied into the `corev1.VolumeSource` in the (backup) job and fails if this is not done. This is done using reflection to ensure the test fails when the `StorageVolumeSource` is modified without understanding anything else (like I did in #1192).