### PR TITLE
Support for pprof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ cover.*
 
 # Documentation site
 /site
+
+# pprof
+pprof.out

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -80,6 +80,9 @@ var (
 	webhookPort    int
 	webhookCertDir string
 
+	pprofEnabled bool
+	pprofAddr    string
+
 	featureMaxScaleSuspend bool
 )
 
@@ -123,6 +126,9 @@ func init() {
 	rootCmd.Flags().StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs",
 		"Directory containing the TLS certificate for the webhook server. 'tls.crt' and 'tls.key' must be present in this directory."+
 			"This only applies if the webhook server is enabled.")
+
+	rootCmd.Flags().BoolVar(&pprofEnabled, "pprof", false, "Enable the pprof server.")
+	rootCmd.Flags().StringVar(&pprofAddr, "pprof-addr", ":6060", "The address the pprof endpoint binds to.")
 
 	rootCmd.Flags().BoolVar(&featureMaxScaleSuspend, "feature-maxscale-suspend", false, "Feature flag to enable MaxScale resource suspension.")
 }
@@ -174,6 +180,11 @@ var rootCmd = &cobra.Command{
 				Port:    webhookPort,
 			})
 		}
+		if pprofEnabled {
+			setupLog.Info("Enabling pprof")
+			mgrOpts.PprofBindAddress = pprofAddr
+		}
+
 		if env.WatchNamespace != "" {
 			namespaces, err := env.WatchNamespaces()
 			if err != nil {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -127,7 +127,7 @@ func init() {
 		"Directory containing the TLS certificate for the webhook server. 'tls.crt' and 'tls.key' must be present in this directory."+
 			"This only applies if the webhook server is enabled.")
 
-	rootCmd.Flags().BoolVar(&pprofEnabled, "pprof", false, "Enable the pprof server.")
+	rootCmd.Flags().BoolVar(&pprofEnabled, "pprof", false, "Enable the pprof HTTP server.")
 	rootCmd.Flags().StringVar(&pprofAddr, "pprof-addr", ":6060", "The address the pprof endpoint binds to.")
 
 	rootCmd.Flags().BoolVar(&featureMaxScaleSuspend, "feature-maxscale-suspend", false, "Feature flag to enable MaxScale resource suspension.")

--- a/deploy/charts/mariadb-operator/README.md
+++ b/deploy/charts/mariadb-operator/README.md
@@ -96,6 +96,8 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | pdb.maxUnavailable | int | `1` | Maximum number of unavailable Pods. You may also give a percentage, like `50%` |
 | podAnnotations | object | `{}` | Annotations to add to controller Pod |
 | podSecurityContext | object | `{}` | Security context to add to controller Pod |
+| pprof.enabled | bool | `false` | Enable the pprof HTTP server. |
+| pprof.port | int | `6060` | The port where the pprof HTTP server listens. |
 | priorityClassName | string | `""` | priorityClassName to add to controller Pod |
 | rbac.aggregation.enabled | bool | `true` | Specifies whether the cluster roles aggrate to view and edit predefinied roles |
 | rbac.enabled | bool | `true` | Specifies whether RBAC resources should be created |

--- a/deploy/charts/mariadb-operator/templates/operator/deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/operator/deployment.yaml
@@ -60,6 +60,10 @@ spec:
             {{- if .Values.ha.enabled }}
             - --leader-elect
             {{- end }}
+            {{- if .Values.pprof.enabled }}
+            - --pprof
+            - --pprof-addr={{ printf ":%d" .Values.pprof.port }}
+            {{- end }}
             {{- range .Values.extraArgs }}
             - {{ . }}
             {{- end }}
@@ -67,6 +71,11 @@ spec:
             - containerPort: 8080
               protocol: TCP
               name: metrics
+          {{- if .Values.pprof.enabled }}
+            - containerPort: {{ .Values.pprof.port }}
+              protocol: TCP
+              name: pprof
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: mariadb-operator-env

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -115,6 +115,11 @@ pdb:
   enabled: false
   # -- Maximum number of unavailable Pods. You may also give a percentage, like `50%`
   maxUnavailable: 1
+pprof:
+  # -- Enable the pprof HTTP server.
+  enabled: false
+  # -- The port where the pprof HTTP server listens.
+  port: 6060
 webhook:
   # -- Specifies whether the webhook should be created.
   enabled: true


### PR DESCRIPTION
Support for [pprof](https://pkg.go.dev/net/http/pprof@go1.24.2):
- In development via `make pprof`
- When installing the helm chart via `pprof.enabled=true`