### PR TITLE
`MaxScale` reconcile optimizations

### DIFF
--- a/api/v1alpha1/maxscale_types.go
+++ b/api/v1alpha1/maxscale_types.go
@@ -805,6 +805,18 @@ type MaxScaleStatus struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=status
 	TLS *MaxScaleTLSStatus `json:"tls,omitempty"`
+	// MonitorSpec is a hashed version of spec.monitor to be able to track changes during reconciliation.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	MonitorSpec string `json:"monitorSpec,omitempty"`
+	// ServersSpec is a hashed version of spec.servers to be able to track changes during reconciliation.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	ServersSpec string `json:"serversSpec,omitempty"`
+	// ServicesSpec is a hashed version of spec.services to be able to track changes during reconciliation.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=status
+	ServicesSpec string `json:"servicesSpec,omitempty"`
 }
 
 // SetCondition sets a status condition to MaxScale

--- a/api/v1alpha1/maxscale_types.go
+++ b/api/v1alpha1/maxscale_types.go
@@ -984,26 +984,26 @@ func (m *MaxScale) PodAPIUrl(podIndex int) string {
 
 // ServerIDs returns the servers indexed by ID.
 func (m *MaxScale) ServerIndex() ds.Index[MaxScaleServer] {
-	return ds.NewIndex[MaxScaleServer](m.Spec.Servers, func(mss MaxScaleServer) string {
+	return ds.NewIndex(m.Spec.Servers, func(mss MaxScaleServer) string {
 		return mss.Name
 	})
 }
 
 // ServerIDs returns the IDs of the servers.
 func (m *MaxScale) ServerIDs() []string {
-	return ds.Keys[MaxScaleServer](m.ServerIndex())
+	return ds.Keys(m.ServerIndex())
 }
 
 // ServiceIndex returns the services indexed by ID.
 func (m *MaxScale) ServiceIndex() ds.Index[MaxScaleService] {
-	return ds.NewIndex[MaxScaleService](m.Spec.Services, func(mss MaxScaleService) string {
+	return ds.NewIndex(m.Spec.Services, func(mss MaxScaleService) string {
 		return mss.Name
 	})
 }
 
 // ServiceIDs returns the IDs of the services.
 func (m *MaxScale) ServiceIDs() []string {
-	return ds.Keys[MaxScaleService](m.ServiceIndex())
+	return ds.Keys(m.ServiceIndex())
 }
 
 // ServiceForListener finds the service for a given listener
@@ -1027,14 +1027,14 @@ func (m *MaxScale) Listeners() []MaxScaleListener {
 
 // ListenerIndex returns the listeners indexed by ID.
 func (m *MaxScale) ListenerIndex() ds.Index[MaxScaleListener] {
-	return ds.NewIndex[MaxScaleListener](m.Listeners(), func(mss MaxScaleListener) string {
+	return ds.NewIndex(m.Listeners(), func(mss MaxScaleListener) string {
 		return mss.Name
 	})
 }
 
 // ListenerIDs returns the IDs of the listeners.
 func (m *MaxScale) ListenerIDs() []string {
-	return ds.Keys[MaxScaleListener](m.ListenerIndex())
+	return ds.Keys(m.ListenerIndex())
 }
 
 // DefaultPort returns the default port.

--- a/api/v1alpha1/maxscale_types.go
+++ b/api/v1alpha1/maxscale_types.go
@@ -862,7 +862,7 @@ func (m *MaxScale) SetDefaults(env *environment.OperatorEnv, mariadb *MariaDB) {
 		m.Spec.Image = env.RelatedMaxscaleImage
 	}
 	if m.Spec.RequeueInterval == nil {
-		m.Spec.RequeueInterval = &metav1.Duration{Duration: 10 * time.Second}
+		m.Spec.RequeueInterval = &metav1.Duration{Duration: 30 * time.Second}
 	}
 	for i := range m.Spec.Servers {
 		m.Spec.Servers[i].SetDefaults()

--- a/api/v1alpha1/maxscale_types_test.go
+++ b/api/v1alpha1/maxscale_types_test.go
@@ -78,7 +78,7 @@ var _ = Describe("MaxScale types", func() {
 								Protocol: "MariaDBBackend",
 							},
 						},
-						RequeueInterval: &metav1.Duration{Duration: 10 * time.Second},
+						RequeueInterval: &metav1.Duration{Duration: 30 * time.Second},
 						Services: []MaxScaleService{
 							{
 								Name:   "rw-router",
@@ -210,7 +210,7 @@ var _ = Describe("MaxScale types", func() {
 								Protocol: "MariaDBBackend",
 							},
 						},
-						RequeueInterval: &metav1.Duration{Duration: 10 * time.Second},
+						RequeueInterval: &metav1.Duration{Duration: 30 * time.Second},
 						Services: []MaxScaleService{
 							{
 								Name:   "rw-router",
@@ -392,7 +392,7 @@ var _ = Describe("MaxScale types", func() {
 						},
 						Image:           env.RelatedMaxscaleImage,
 						Replicas:        3,
-						RequeueInterval: &metav1.Duration{Duration: 10 * time.Second},
+						RequeueInterval: &metav1.Duration{Duration: 30 * time.Second},
 						Services: []MaxScaleService{
 							{
 								Name:   "rw-router",

--- a/config/crd/bases/k8s.mariadb.com_maxscales.yaml
+++ b/config/crd/bases/k8s.mariadb.com_maxscales.yaml
@@ -2383,6 +2383,10 @@ spec:
                 - name
                 - state
                 type: object
+              monitorSpec:
+                description: MonitorSpec is a hashed version of spec.monitor to be
+                  able to track changes during reconciliation.
+                type: string
               primaryServer:
                 description: PrimaryServer is the primary server in the MaxScale API.
                 type: string
@@ -2405,6 +2409,10 @@ spec:
                   - state
                   type: object
                 type: array
+              serversSpec:
+                description: ServersSpec is a hashed version of spec.servers to be
+                  able to track changes during reconciliation.
+                type: string
               services:
                 description: Services is the state of the services in the MaxScale
                   API.
@@ -2421,6 +2429,10 @@ spec:
                   - state
                   type: object
                 type: array
+              servicesSpec:
+                description: ServicesSpec is a hashed version of spec.services to
+                  be able to track changes during reconciliation.
+                type: string
               tls:
                 description: TLS aggregates the status of the certificates used by
                   the MaxScale instance.

--- a/deploy/charts/mariadb-operator-crds/templates/crds.yaml
+++ b/deploy/charts/mariadb-operator-crds/templates/crds.yaml
@@ -10174,6 +10174,10 @@ spec:
                 - name
                 - state
                 type: object
+              monitorSpec:
+                description: MonitorSpec is a hashed version of spec.monitor to be
+                  able to track changes during reconciliation.
+                type: string
               primaryServer:
                 description: PrimaryServer is the primary server in the MaxScale API.
                 type: string
@@ -10196,6 +10200,10 @@ spec:
                   - state
                   type: object
                 type: array
+              serversSpec:
+                description: ServersSpec is a hashed version of spec.servers to be
+                  able to track changes during reconciliation.
+                type: string
               services:
                 description: Services is the state of the services in the MaxScale
                   API.
@@ -10212,6 +10220,10 @@ spec:
                   - state
                   type: object
                 type: array
+              servicesSpec:
+                description: ServicesSpec is a hashed version of spec.services to
+                  be able to track changes during reconciliation.
+                type: string
               tls:
                 description: TLS aggregates the status of the certificates used by
                   the MaxScale instance.

--- a/internal/controller/mariadb_controller_tls.go
+++ b/internal/controller/mariadb_controller_tls.go
@@ -13,6 +13,7 @@ import (
 	certctrl "github.com/mariadb-operator/mariadb-operator/pkg/controller/certificate"
 	"github.com/mariadb-operator/mariadb-operator/pkg/controller/configmap"
 	"github.com/mariadb-operator/mariadb-operator/pkg/controller/secret"
+	"github.com/mariadb-operator/mariadb-operator/pkg/hash"
 	"github.com/mariadb-operator/mariadb-operator/pkg/metadata"
 	"github.com/mariadb-operator/mariadb-operator/pkg/pki"
 	"github.com/mariadb-operator/mariadb-operator/pkg/pod"
@@ -216,14 +217,14 @@ func (r *MariaDBReconciler) getTLSAnnotations(ctx context.Context, mariadb *mari
 	if err != nil {
 		return nil, fmt.Errorf("error getting server cert: %v", err)
 	}
-	annotations[metadata.TLSServerCertAnnotation] = hash(serverCert)
+	annotations[metadata.TLSServerCertAnnotation] = hash.Hash(serverCert)
 
 	configMapKeyRef := mariadb.TLSConfigMapKeyRef()
 	config, err := r.RefResolver.ConfigMapKeyRef(ctx, &configMapKeyRef, mariadb.Namespace)
 	if err != nil {
 		return nil, fmt.Errorf("error getting TLS config: %v", err)
 	}
-	annotations[metadata.ConfigTLSAnnotation] = hash(config)
+	annotations[metadata.ConfigTLSAnnotation] = hash.Hash(config)
 
 	return annotations, nil
 }
@@ -238,7 +239,7 @@ func (r *MariaDBReconciler) getTLSClientAnnotations(ctx context.Context, mariadb
 	if err != nil {
 		return nil, fmt.Errorf("error getting CA bundle: %v", err)
 	}
-	annotations[metadata.TLSCAAnnotation] = hash(ca)
+	annotations[metadata.TLSCAAnnotation] = hash.Hash(ca)
 
 	clientCertKeySelector := mariadbv1alpha1.SecretKeySelector{
 		LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
@@ -250,7 +251,7 @@ func (r *MariaDBReconciler) getTLSClientAnnotations(ctx context.Context, mariadb
 	if err != nil {
 		return nil, fmt.Errorf("error getting client cert: %v", err)
 	}
-	annotations[metadata.TLSClientCertAnnotation] = hash(clientCert)
+	annotations[metadata.TLSClientCertAnnotation] = hash.Hash(clientCert)
 
 	return annotations, nil
 }
@@ -340,7 +341,7 @@ func (h *certHandler) ShouldRenewCert(ctx context.Context, caKeyPair *pki.KeyPai
 		return false, fmt.Sprintf("Missing CA with serial number '%s' in CA bundle", serialNo.String()), nil
 	}
 
-	allPodsTrustingCA, err := h.ensureAllPodsTrustingCABundle(ctx, h.mdb, hash(caBundleBytes))
+	allPodsTrustingCA, err := h.ensureAllPodsTrustingCABundle(ctx, h.mdb, hash.Hash(caBundleBytes))
 	if err != nil {
 		return false, "", fmt.Errorf("error checking pod CAs: %v", err)
 	}

--- a/internal/controller/maxscale_controller_api.go
+++ b/internal/controller/maxscale_controller_api.go
@@ -44,14 +44,14 @@ func (m *maxScaleAPI) createAdminUser(ctx context.Context, username, password st
 		Account:  mxsclient.UserAccountAdmin,
 		Password: &password,
 	}
-	return m.client.User.Create(ctx, username, attrs)
+	return m.client.User.Create(ctx, username, &attrs)
 }
 
 func (m *maxScaleAPI) patchUser(ctx context.Context, username, password string) error {
 	attrs := mxsclient.UserAttributes{
 		Password: &password,
 	}
-	return m.client.User.Patch(ctx, username, attrs)
+	return m.client.User.Patch(ctx, username, &attrs)
 }
 
 // MaxScale API - Servers
@@ -61,7 +61,7 @@ func (m *maxScaleAPI) createServer(ctx context.Context, srv *mariadbv1alpha1.Max
 	if err != nil {
 		return fmt.Errorf("error getting server attributes: %v", err)
 	}
-	return m.client.Server.Create(ctx, srv.Name, *serverAttrs)
+	return m.client.Server.Create(ctx, srv.Name, serverAttrs)
 }
 
 func (m *maxScaleAPI) deleteServer(ctx context.Context, name string) error {
@@ -73,7 +73,7 @@ func (m *maxScaleAPI) patchServer(ctx context.Context, srv *mariadbv1alpha1.MaxS
 	if err != nil {
 		return fmt.Errorf("error getting server attributes: %v", err)
 	}
-	return m.client.Server.Patch(ctx, srv.Name, *serverAttrs)
+	return m.client.Server.Patch(ctx, srv.Name, serverAttrs)
 }
 
 func (m *maxScaleAPI) updateServerState(ctx context.Context, srv *mariadbv1alpha1.MaxScaleServer) error {
@@ -160,7 +160,7 @@ func (m *maxScaleAPI) createMonitor(ctx context.Context, rels *mxsclient.Relatio
 		return fmt.Errorf("error getting monitor attributes: %v", err)
 	}
 
-	return m.client.Monitor.Create(ctx, m.mxs.Spec.Monitor.Name, *attrs, mxsclient.WithRelationships(rels))
+	return m.client.Monitor.Create(ctx, m.mxs.Spec.Monitor.Name, attrs, mxsclient.WithRelationships(rels))
 }
 
 func (m *maxScaleAPI) patchMonitor(ctx context.Context, rels *mxsclient.Relationships) error {
@@ -168,7 +168,7 @@ func (m *maxScaleAPI) patchMonitor(ctx context.Context, rels *mxsclient.Relation
 	if err != nil {
 		return fmt.Errorf("error getting monitor attributes: %v", err)
 	}
-	return m.client.Monitor.Patch(ctx, m.mxs.Spec.Monitor.Name, *attrs, mxsclient.WithRelationships(rels))
+	return m.client.Monitor.Patch(ctx, m.mxs.Spec.Monitor.Name, attrs, mxsclient.WithRelationships(rels))
 }
 
 func (m *maxScaleAPI) updateMonitorState(ctx context.Context) error {
@@ -209,7 +209,7 @@ func (m *maxScaleAPI) createService(ctx context.Context, svc *mariadbv1alpha1.Ma
 	if err != nil {
 		return fmt.Errorf("error getting service attributes: %v", err)
 	}
-	return m.client.Service.Create(ctx, svc.Name, *attrs, mxsclient.WithRelationships(rels))
+	return m.client.Service.Create(ctx, svc.Name, attrs, mxsclient.WithRelationships(rels))
 }
 
 func (m *maxScaleAPI) deleteService(ctx context.Context, name string) error {
@@ -221,7 +221,7 @@ func (m *maxScaleAPI) patchService(ctx context.Context, svc *mariadbv1alpha1.Max
 	if err != nil {
 		return fmt.Errorf("error getting service attributes: %v", err)
 	}
-	return m.client.Service.Patch(ctx, svc.Name, *attrs, mxsclient.WithRelationships(rels))
+	return m.client.Service.Patch(ctx, svc.Name, attrs, mxsclient.WithRelationships(rels))
 }
 
 func (m *maxScaleAPI) updateServiceState(ctx context.Context, svc *mariadbv1alpha1.MaxScaleService) error {
@@ -273,7 +273,7 @@ func (m *maxScaleAPI) updateListenerState(ctx context.Context, listener *mariadb
 	return m.client.Listener.Start(ctx, listener.Name)
 }
 
-func (m *maxScaleAPI) listenerAttributes(listener *mariadbv1alpha1.MaxScaleListener) mxsclient.ListenerAttributes {
+func (m *maxScaleAPI) listenerAttributes(listener *mariadbv1alpha1.MaxScaleListener) *mxsclient.ListenerAttributes {
 	attrs := mxsclient.ListenerAttributes{
 		Parameters: mxsclient.ListenerParameters{
 			Port:     listener.Port,
@@ -290,7 +290,7 @@ func (m *maxScaleAPI) listenerAttributes(listener *mariadbv1alpha1.MaxScaleListe
 		attrs.Parameters.SSLVerifyPeerCertificate = m.mxs.ShouldVerifyPeerCertificate()
 		attrs.Parameters.SSLVerifyPeerHost = m.mxs.ShouldVerifyPeerHost()
 	}
-	return attrs
+	return &attrs
 }
 
 // MaxScale API - MaxScale
@@ -329,7 +329,7 @@ func (m *maxScaleAPI) patchMaxScaleConfigSync(ctx context.Context) error {
 		},
 	}
 
-	return m.client.MaxScale.Patch(ctx, attrs)
+	return m.client.MaxScale.Patch(ctx, &attrs)
 }
 
 // MaxScale client

--- a/internal/controller/maxscale_controller_metrics.go
+++ b/internal/controller/maxscale_controller_metrics.go
@@ -12,6 +12,7 @@ import (
 	labels "github.com/mariadb-operator/mariadb-operator/pkg/builder/labels"
 	builderpki "github.com/mariadb-operator/mariadb-operator/pkg/builder/pki"
 	"github.com/mariadb-operator/mariadb-operator/pkg/controller/secret"
+	"github.com/mariadb-operator/mariadb-operator/pkg/hash"
 	"github.com/mariadb-operator/mariadb-operator/pkg/metadata"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -122,7 +123,7 @@ func (r *MaxScaleReconciler) getExporterPodAnnotations(ctx context.Context, mxs 
 		return nil, fmt.Errorf("error getting metrics config Secret: %v", err)
 	}
 	podAnnotations := map[string]string{
-		metadata.ConfigAnnotation: hash(config),
+		metadata.ConfigAnnotation: hash.Hash(config),
 	}
 
 	if mxs.IsTLSEnabled() {

--- a/internal/controller/maxscale_controller_tls.go
+++ b/internal/controller/maxscale_controller_tls.go
@@ -8,6 +8,7 @@ import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	certctrl "github.com/mariadb-operator/mariadb-operator/pkg/controller/certificate"
 	"github.com/mariadb-operator/mariadb-operator/pkg/controller/secret"
+	"github.com/mariadb-operator/mariadb-operator/pkg/hash"
 	"github.com/mariadb-operator/mariadb-operator/pkg/metadata"
 	"github.com/mariadb-operator/mariadb-operator/pkg/pki"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -173,7 +174,7 @@ func (r *MaxScaleReconciler) getTLSAnnotations(ctx context.Context, mxs *mariadb
 		if err != nil {
 			return nil, fmt.Errorf("error getting Secret \"%s\": %v", secretKeySelector.Name, err)
 		}
-		annotations[annotation] = hash(cert)
+		annotations[annotation] = hash.Hash(cert)
 	}
 
 	return annotations, nil
@@ -189,7 +190,7 @@ func (r *MaxScaleReconciler) getTLSAdminAnnotations(ctx context.Context, mxs *ma
 	if err != nil {
 		return nil, fmt.Errorf("error getting CA bundle: %v", err)
 	}
-	annotations[metadata.TLSCAAnnotation] = hash(ca)
+	annotations[metadata.TLSCAAnnotation] = hash.Hash(ca)
 
 	adminCertKeySelector := mariadbv1alpha1.SecretKeySelector{
 		LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
@@ -201,7 +202,7 @@ func (r *MaxScaleReconciler) getTLSAdminAnnotations(ctx context.Context, mxs *ma
 	if err != nil {
 		return nil, fmt.Errorf("error getting admin cert: %v", err)
 	}
-	annotations[metadata.TLSAdminCertAnnotation] = hash(adminCert)
+	annotations[metadata.TLSAdminCertAnnotation] = hash.Hash(adminCert)
 
 	return annotations, nil
 }

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -2,10 +2,28 @@ package hash
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 )
 
 // Hash computes a hash from the given input string.
 func Hash(config string) string {
 	return fmt.Sprintf("%x", sha256.Sum256([]byte(config)))
+}
+
+// HashJSON computes the hash from a JSON object.
+func HashJSON(v any) (string, error) {
+	// IMPORTANT: Map values are sorted in order to obtain a canonical representation.
+	// From the json.Marhsal docs: https://pkg.go.dev/encoding/json#Marshal
+	// Map values encode as JSON objects. The map's key type must either be a string, an integer type, or implement encoding.TextMarshaler.
+	// The map keys are sorted and used as JSON object keys by applying the following rules, subject to the UTF-8 coercion described
+	// for string values above:
+	// - keys of any string type are used directly
+	// - keys that implement encoding.TextMarshaler are marshaled
+	// - integer keys are converted to strings
+	bytes, err := json.Marshal(v)
+	if err != nil {
+		return "", fmt.Errorf("error mashaling JSON: %v", err)
+	}
+	return Hash(string(bytes)), nil
 }

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -7,8 +7,8 @@ import (
 )
 
 // Hash computes a hash from the given input string.
-func Hash(config string) string {
-	return fmt.Sprintf("%x", sha256.Sum256([]byte(config)))
+func Hash(v string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(v)))
 }
 
 // HashJSON computes the hash from a JSON object.

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -1,0 +1,11 @@
+package hash
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+// Hash computes a hash from the given input string.
+func Hash(config string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(config)))
+}

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -1,0 +1,76 @@
+package hash
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type TestStruct struct {
+	Field1 string `json:"field1"`
+	Field2 int    `json:"field2"`
+}
+
+func TestHashJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   any
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Struct",
+			input:   TestStruct{Field1: "value1", Field2: 42},
+			want:    Hash(`{"field1":"value1","field2":42}`),
+			wantErr: false,
+		},
+		{
+			name:    "Slice of structs",
+			input:   []TestStruct{{Field1: "value1", Field2: 42}, {Field1: "value2", Field2: 84}},
+			want:    Hash(`[{"field1":"value1","field2":42},{"field1":"value2","field2":84}]`),
+			wantErr: false,
+		},
+		{
+			name:    "Empty struct",
+			input:   TestStruct{},
+			want:    Hash(`{"field1":"","field2":0}`),
+			wantErr: false,
+		},
+		{
+			name: "Map",
+			input: map[string]string{
+				"a": "1",
+				"d": "4",
+				"b": "2",
+				"e": "5",
+				"c": "3",
+			},
+			want:    Hash(`{"a":"1","b":"2","c":"3","d":"4","e":"5"}`),
+			wantErr: false,
+		},
+		{
+			name:    "Nil",
+			input:   nil,
+			want:    Hash("null"),
+			wantErr: false,
+		},
+		{
+			name:    "Invalid input type",
+			input:   make(chan int),
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := HashJSON(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/maxscale/client/generic_client.go
+++ b/pkg/maxscale/client/generic_client.go
@@ -67,7 +67,7 @@ func (c *GenericClient[T]) ListIndex(ctx context.Context, options ...Option) (ds
 	if err != nil {
 		return nil, err
 	}
-	return ds.NewIndex[Data[T]](list, func(d Data[T]) string {
+	return ds.NewIndex(list, func(d Data[T]) string {
 		return d.ID
 	}), nil
 }
@@ -77,7 +77,7 @@ func (c *GenericClient[T]) AllExists(ctx context.Context, ids []string, options 
 	if err != nil {
 		return false, nil
 	}
-	return ds.AllExists[Data[T]](index, ids...), nil
+	return ds.AllExists(index, ids...), nil
 }
 
 func (c *GenericClient[T]) Get(ctx context.Context, name string, options ...Option) (*Data[T], error) {

--- a/pkg/maxscale/client/listener.go
+++ b/pkg/maxscale/client/listener.go
@@ -51,12 +51,12 @@ type ListenerAttributes struct {
 }
 
 type ListenerClient struct {
-	GenericClient[ListenerAttributes]
+	GenericClient[*ListenerAttributes]
 }
 
 func NewListenerClient(client *mdbhttp.Client) *ListenerClient {
 	return &ListenerClient{
-		GenericClient: NewGenericClient[ListenerAttributes](
+		GenericClient: NewGenericClient[*ListenerAttributes](
 			client,
 			"listeners",
 			ObjectTypeListeners,

--- a/pkg/maxscale/client/maxscale.go
+++ b/pkg/maxscale/client/maxscale.go
@@ -54,7 +54,7 @@ type MaxScaleAttributes struct {
 }
 
 type MaxScaleClient struct {
-	GenericClient[MaxScaleAttributes]
+	GenericClient[*MaxScaleAttributes]
 	client *mdbhttp.Client
 }
 
@@ -64,21 +64,21 @@ func NewMaxScaleClient(client *mdbhttp.Client) *MaxScaleClient {
 	}
 }
 
-func (m *MaxScaleClient) Get(ctx context.Context) (*Data[MaxScaleAttributes], error) {
+func (m *MaxScaleClient) Get(ctx context.Context) (*Data[*MaxScaleAttributes], error) {
 	res, err := m.client.Get(ctx, "maxscale", nil)
 	if err != nil {
 		return nil, err
 	}
-	var object Object[MaxScaleAttributes]
+	var object Object[*MaxScaleAttributes]
 	if err := handleResponse(res, &object); err != nil {
 		return nil, err
 	}
 	return &object.Data, nil
 }
 
-func (m *MaxScaleClient) Patch(ctx context.Context, attributes MaxScaleAttributes) error {
-	object := &Object[MaxScaleAttributes]{
-		Data: Data[MaxScaleAttributes]{
+func (m *MaxScaleClient) Patch(ctx context.Context, attributes *MaxScaleAttributes) error {
+	object := &Object[*MaxScaleAttributes]{
+		Data: Data[*MaxScaleAttributes]{
 			Type:       ObjectTypeMaxScale,
 			Attributes: attributes,
 		},

--- a/pkg/maxscale/client/monitor.go
+++ b/pkg/maxscale/client/monitor.go
@@ -49,12 +49,12 @@ type MonitorAttributes struct {
 }
 
 type MonitorClient struct {
-	GenericClient[MonitorAttributes]
+	GenericClient[*MonitorAttributes]
 }
 
 func NewMonitorClient(client *mdbhttp.Client) *MonitorClient {
 	return &MonitorClient{
-		GenericClient: NewGenericClient[MonitorAttributes](
+		GenericClient: NewGenericClient[*MonitorAttributes](
 			client,
 			"monitors",
 			ObjectTypeMonitors,

--- a/pkg/maxscale/client/server.go
+++ b/pkg/maxscale/client/server.go
@@ -63,12 +63,12 @@ func (s *ServerAttributes) IsMaster() bool {
 }
 
 type ServerClient struct {
-	GenericClient[ServerAttributes]
+	GenericClient[*ServerAttributes]
 }
 
 func NewServerClient(client *mdbhttp.Client) *ServerClient {
 	return &ServerClient{
-		GenericClient: NewGenericClient[ServerAttributes](
+		GenericClient: NewGenericClient[*ServerAttributes](
 			client,
 			"servers",
 			ObjectTypeServers,

--- a/pkg/maxscale/client/service.go
+++ b/pkg/maxscale/client/service.go
@@ -46,12 +46,12 @@ type ServiceAttributes struct {
 }
 
 type ServiceClient struct {
-	GenericClient[ServiceAttributes]
+	GenericClient[*ServiceAttributes]
 }
 
 func NewServiceClient(client *mdbhttp.Client) *ServiceClient {
 	return &ServiceClient{
-		GenericClient: NewGenericClient[ServiceAttributes](
+		GenericClient: NewGenericClient[*ServiceAttributes](
 			client,
 			"services",
 			ObjectTypeServices,

--- a/pkg/maxscale/client/user.go
+++ b/pkg/maxscale/client/user.go
@@ -19,12 +19,12 @@ type UserAttributes struct {
 }
 
 type UserClient struct {
-	GenericClient[UserAttributes]
+	GenericClient[*UserAttributes]
 }
 
 func NewUserClient(client *mdbhttp.Client) *UserClient {
 	return &UserClient{
-		GenericClient: NewGenericClient[UserAttributes](
+		GenericClient: NewGenericClient[*UserAttributes](
 			client,
 			"users/inet",
 			ObjectTypeUsers,


### PR DESCRIPTION
- Use references in `MaxScale` APIs to avoid copying structs
- Hash `MaxScale` spec to track changes and avoid unnecesary reconciliations: avoid hitting MaxScale whenever possible, save bandwidth and minimize resource usage on the operator side
- Pre-creating and reusing client objects on every reconciliation cycle
- Set default `requeueInterval` to 30s