### PR TITLE
Add mariadb-cluster helm chart

### DIFF
--- a/deploy/charts/mariadb-cluster/.helmignore
+++ b/deploy/charts/mariadb-cluster/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/mariadb-cluster/Chart.yaml
+++ b/deploy/charts/mariadb-cluster/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: mariadb-cluster
+description: Create MariaDB cluster managed by mariadb-operator
+home: https://github.com/mariadb-operator/mariadb-operator
+icon: https://mariadb-operator.github.io/mariadb-operator/assets/mariadb_profile.svg
+type: application
+version: 0.38.1
+appVersion: "0.38.1"
+kubeVersion: ">=1.26.0-0"
+maintainers:
+  - email: martin.montes@mariadb.com
+    name: mmontes11
+keywords:
+  - mariadb
+  - mysql
+  - operator
+  - mariadb-operator
+  - database
+  - maxscale

--- a/deploy/charts/mariadb-cluster/templates/_helpers.tpl
+++ b/deploy/charts/mariadb-cluster/templates/_helpers.tpl
@@ -1,0 +1,95 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mariadb-cluster.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mariadb-cluster.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mariadb-cluster.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mariadb-cluster.labels" -}}
+helm.sh/chart: {{ include "mariadb-cluster.chart" . }}
+{{ include "mariadb-cluster.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mariadb-cluster.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mariadb-cluster.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Validate Database CRs
+*/}}
+{{- define "mariadb-cluster.validateDatabases" -}}
+{{- range .Values.databases }}
+{{- if not .name }}
+{{- fail "It is required to specify `.name` for each Database" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Validate User CRs
+*/}}
+{{- define "mariadb-cluster.validateUsers" -}}
+{{- range .Values.users }}
+{{- if not .name }}
+{{- fail "It is required to specify `.name` for each User" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Validate Grant CRs
+*/}}
+{{- define "mariadb-cluster.validateGrants" -}}
+{{- range .Values.grants }}
+{{- if not .username }}
+{{- fail "It is required to specify `.username` for each Grant" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Validate Backup CRs
+*/}}
+{{- define "mariadb-cluster.validateBackups" -}}
+{{- range .Values.backups }}
+{{- if not .storage }}
+{{- fail "It is required to specify `.storage` for each Backup" }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/mariadb-cluster/templates/backup.yaml
+++ b/deploy/charts/mariadb-cluster/templates/backup.yaml
@@ -1,0 +1,15 @@
+{{- include "mariadb-cluster.validateBackups" . -}}
+{{- range $i, $backup := .Values.backups }}
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Backup
+metadata:
+  name: {{ include "mariadb-cluster.fullname" $ }}-{{ $i }}
+  labels:
+    {{- include "mariadb-cluster.labels" $ | nindent 4 }}
+spec:
+  mariaDbRef:
+    name: {{ include "mariadb-cluster.fullname" $ }}
+    namespace: {{ $.Release.Namespace }}
+  {{- toYaml (unset (deepCopy $backup) "mariaDbRef" ) | nindent 2 }}
+{{- end }}

--- a/deploy/charts/mariadb-cluster/templates/database.yaml
+++ b/deploy/charts/mariadb-cluster/templates/database.yaml
@@ -1,0 +1,15 @@
+{{- include "mariadb-cluster.validateDatabases" . -}}
+{{- range .Values.databases }}
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Database
+metadata:
+  name: {{ include "mariadb-cluster.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "mariadb-cluster.labels" $ | nindent 4 }}
+spec:
+  mariaDbRef:
+    name: {{ include "mariadb-cluster.fullname" $ }}
+    namespace: {{ $.Release.Namespace }}
+  {{- toYaml (unset (deepCopy .) "mariaDbRef" ) | nindent 2 }}
+{{- end }}

--- a/deploy/charts/mariadb-cluster/templates/grant.yaml
+++ b/deploy/charts/mariadb-cluster/templates/grant.yaml
@@ -1,0 +1,15 @@
+{{- include "mariadb-cluster.validateGrants" . -}}
+{{- range .Values.grants }}
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: Grant
+metadata:
+  name: {{ include "mariadb-cluster.fullname" $ }}-{{ .username }}
+  labels:
+    {{- include "mariadb-cluster.labels" $ | nindent 4 }}
+spec:
+  mariaDbRef:
+    name: {{ include "mariadb-cluster.fullname" $ }}
+    namespace: {{ $.Release.Namespace }}
+  {{- toYaml (unset (deepCopy .) "mariaDbRef" ) | nindent 2 }}
+{{- end }}

--- a/deploy/charts/mariadb-cluster/templates/mariadb.yaml
+++ b/deploy/charts/mariadb-cluster/templates/mariadb.yaml
@@ -1,0 +1,8 @@
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: MariaDB
+metadata:
+  name: {{ include "mariadb-cluster.fullname" . }}
+  labels:
+    {{- include "mariadb-cluster.labels" . | nindent 4 }}
+spec:
+  {{- toYaml .Values.mariadb | nindent 2 }}

--- a/deploy/charts/mariadb-cluster/templates/user.yaml
+++ b/deploy/charts/mariadb-cluster/templates/user.yaml
@@ -1,0 +1,15 @@
+{{- include "mariadb-cluster.validateUsers" . -}}
+{{- range .Values.users }}
+---
+apiVersion: k8s.mariadb.com/v1alpha1
+kind: User
+metadata:
+  name: {{ include "mariadb-cluster.fullname" $ }}-{{ .name }}
+  labels:
+    {{- include "mariadb-cluster.labels" $ | nindent 4 }}
+spec:
+  mariaDbRef:
+    name: {{ include "mariadb-cluster.fullname" $ }}
+    namespace: {{ $.Release.Namespace }}
+  {{- toYaml (unset (deepCopy .) "mariaDbRef" ) | nindent 2 }}
+{{- end }}

--- a/deploy/charts/mariadb-cluster/values.yaml
+++ b/deploy/charts/mariadb-cluster/values.yaml
@@ -1,0 +1,148 @@
+nameOverride: ""
+fullnameOverride: ""
+
+# -- MariaDB CR
+# https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/API_REFERENCE.md#mariadbspec
+mariadb:
+  # affinity: {}
+  # args: []
+  # bootstrapFrom: {}
+  # command: []
+  # connection: {}
+  # database: ""
+  # env: []
+  # envFrom: []
+  galera:
+    enabled: true
+  # image: ""
+  # imagePullPolicy: ""
+  # imagePullSecrets: []
+  # inheritMetadata: {}
+  # initContainers: []
+  # livenessProbe: {}
+  # maxScale: {}
+  # maxScaleRef: {}
+  metrics:
+    enabled: true
+  # myCnf: |
+  #   [mariadb]
+  #   innodb_buffer_pool_size=1024M
+  #   ignore_db_dirs=lost+found
+  #   max_allowed_packet=256M
+  # myCnfConfigMapKeyRef: {}
+  # nodeSelector: {}
+  # passwordPlugin: {}
+  # passwordSecretKeyRef: {}
+  # podDisruptionBudget: {}
+  # podMetadata: {}
+  # podSecurityContext: {}
+  # port: ""
+  # primaryConnection: {}
+  # primaryService: {}
+  # priorityClassName: ""
+  # readinessProbe: {}
+  replicas: 3
+  # replicasAllowEvenNumber: false
+  # replication:
+  #   enabled: true
+  # resources: {}
+  rootPasswordSecretKeyRef:
+    name: mariadb-cluster-root-password
+    key: ROOT_PASSWORD
+  # secondaryConnection: {}
+  # secondaryService: {}
+  # securityContext: {}
+  # service: {}
+  # serviceAccountName: ""
+  # servicePorts: []
+  # sidecarContainers: []
+  # startupProbe: {}
+  storage:
+    size: 1Gi
+  # suspend: false
+  # timeZone: ""
+  # tls: {}
+  # tolerations: []
+  # topologySpreadConstraints: []
+  # updateStrategy: {}
+  # username: ""
+  # volumeMounts: []
+  # volumes: []
+
+# -- The list of Database CRs. The `.mariaDbRef` keys will be ignored. The `.name` keys are required to generate distinct CR names.
+# https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/API_REFERENCE.md#databasespec
+databases: []
+  # - characterSet: utf8
+  #   cleanupPolicy: Delete
+  #   collate: utf8_general_ci
+  #   name: foo
+  #   requeueInterval: 1h
+  #   retryInterval: 3m
+
+# -- The list of User CRs. The `.mariaDbRef` keys will be ignored. The `.name` keys are required to generate distinct CR names.
+# https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/API_REFERENCE.md#userspec
+users: []
+  # - cleanupPolicy: Delete
+  #   host: "%"
+  #   maxUserConnections: 100
+  #   name: foo
+  #   passwordHashSecretKeyRef: {}
+  #   passwordPlugin: {}
+  #   passwordSecretKeyRef: {}
+  #   requeueInterval: 1h
+  #   require: {}
+  #   retryInterval: 3m
+
+# -- The list of Grant CRs. The `.mariaDbRef` keys will be ignored. The `.username` keys are used to generate distinct CR names.
+# https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/API_REFERENCE.md#grantspec
+grants: []
+  # - cleanupPolicy: Delete
+  #   database: foo
+  #   grantOption: false
+  #   host: "%"
+  #   privileges:
+  #     - ALL PRIVILEGES
+  #   requeueInterval: 1h
+  #   retryInterval: 3m
+  #   table: "*"
+  #   username: foo
+
+# -- The list of Backup CRs. The `.mariaDbRef` keys will be ignored. The CR names will have list index suffixes.
+# https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/API_REFERENCE.md#backupspec
+backups: []
+  # - affinity: {}
+  #   args: []
+  #   backoffLimit: 2
+  #   compression: gzip
+  #   databases: []
+  #   failedJobsHistoryLimit: 3
+  #   ignoreGlobalPriv: true
+  #   imagePullSecrets: []
+  #   inheritMetadata: {}
+  #   logLevel: info
+  #   maxRetention: 336h
+  #   nodeSelector: {}
+  #   podMetadata: {}
+  #   podSecurityContext: {}
+  #   priorityClassName: ""
+  #   resources: {}
+  #   restartPolicy: OnFailure
+  #   schedule:
+  #     cron: "0 0 * * *"
+  #   securityContext: {}
+  #   serviceAccountName: ""
+  #   stagingStorage: {}
+  #   storage:
+  #     s3:
+  #       bucket: backups
+  #       endpoint: minio.minio.svc.cluster.local:9000
+  #       prefix: mariadb
+  #       accessKeyIdSecretKeyRef:
+  #         name: mariadb-cluster-aws-creds
+  #         key: AWS_ACCESS_KEY_ID
+  #       secretAccessKeySecretKeyRef:
+  #         name: mariadb-cluster-aws-creds
+  #         key: AWS_SECRET_ACCESS_KEY
+  #   successfulJobsHistoryLimit: 3
+  #   timeZone: ""
+  #   tolerations: []

--- a/internal/helmtest/mariadb_cluster_test.go
+++ b/internal/helmtest/mariadb_cluster_test.go
@@ -1,0 +1,276 @@
+package test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	clusterHelmReleaseName = "mariadb-cluster"
+	clusterHelmChartPath   = "../../deploy/charts/mariadb-cluster"
+	clusterHelmNamespace   = "default"
+)
+
+func TestClusterHelmMariaDB(t *testing.T) {
+	RegisterTestingT(t)
+
+	replicas := 3
+	storageSize := "1Gi"
+	rootPasswordSecretKeyRefKey := "ROOT_PASSWORD"
+	rootPasswordSecretKeyRefName := "mariadb-cluster-passwords"
+
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"mariadb.galera.enabled":                "true",
+			"mariadb.metrics.enabled":               "true",
+			"mariadb.replicas":                      strconv.Itoa(replicas),
+			"mariadb.storage.size":                  storageSize,
+			"mariadb.rootPasswordSecretKeyRef.key":  rootPasswordSecretKeyRefKey,
+			"mariadb.rootPasswordSecretKeyRef.name": rootPasswordSecretKeyRefName,
+		},
+	}
+
+	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/mariadb.yaml"})
+	var mariadb v1alpha1.MariaDB
+	helm.UnmarshalK8SYaml(t, renderedData, &mariadb)
+
+	Expect(mariadb.Spec.Galera.Enabled).To(BeTrue())
+	Expect(mariadb.Spec.Metrics.Enabled).To(BeTrue())
+	Expect(mariadb.Spec.Replicas).To(Equal(int32(replicas)))
+	Expect(mariadb.Spec.Storage.Size.String()).To(Equal(storageSize))
+	Expect(mariadb.Spec.RootPasswordSecretKeyRef.Key).To(Equal(rootPasswordSecretKeyRefKey))
+	Expect(mariadb.Spec.RootPasswordSecretKeyRef.Name).To(Equal(rootPasswordSecretKeyRefName))
+}
+
+func TestClusterHelmDatabase(t *testing.T) {
+	RegisterTestingT(t)
+
+	characterSet := "utf8"
+	cleanupPolicy := "Delete"
+	collate := "utf8_general_ci"
+	name := "foo"
+	requeueInterval := "1h"
+	retryInterval := "3m"
+
+	durationInterval, _ := time.ParseDuration(requeueInterval)
+	durationRetry, _ := time.ParseDuration(retryInterval)
+	requeueIntervalDuration := &v1.Duration{Duration: durationInterval}
+	retryIntervalDuration := &v1.Duration{Duration: durationRetry}
+
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"databases[0].characterSet":         characterSet,
+			"databases[0].cleanupPolicy":        cleanupPolicy,
+			"databases[0].collate":              collate,
+			"databases[0].name":                 name,
+			"databases[0].requeueInterval":      requeueInterval,
+			"databases[0].retryInterval":        retryInterval,
+			"databases[0].mariaDBRef.name":      "cluster",
+			"databases[0].mariaDBRef.namespace": "namespace",
+		},
+	}
+
+	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/database.yaml"})
+	var database v1alpha1.Database
+	helm.UnmarshalK8SYaml(t, renderedData, &database)
+
+	Expect(database.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
+	Expect(database.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
+	Expect(database.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
+	Expect(database.Spec.CharacterSet).To(Equal(characterSet))
+	Expect(*database.Spec.CleanupPolicy).To(Equal(v1alpha1.CleanupPolicy(cleanupPolicy)))
+	Expect(database.Spec.Collate).To(Equal(collate))
+	Expect(database.Spec.Name).To(Equal(name))
+	Expect(database.Spec.RequeueInterval).To(Equal(requeueIntervalDuration))
+	Expect(database.Spec.RetryInterval).To(Equal(retryIntervalDuration))
+
+	delete(opts.SetValues, "databases[0].name")
+	_, err := helm.RenderTemplateE(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/database.yaml"})
+	Expect(err).To(HaveOccurred())
+}
+
+func TestClusterHelmUser(t *testing.T) {
+	RegisterTestingT(t)
+
+	cleanupPolicy := "Delete"
+	host := "%"
+	maxUserConnections := 100
+	name := "foo"
+	passwordSecretKeyRefKey := "FOO_PASSWORD"
+	passwordSecretKeyRefName := "mariadb-cluster-passwords"
+	requeueInterval := "1h"
+	retryInterval := "3m"
+
+	durationInterval, _ := time.ParseDuration(requeueInterval)
+	durationRetry, _ := time.ParseDuration(retryInterval)
+	requeueIntervalDuration := &v1.Duration{Duration: durationInterval}
+	retryIntervalDuration := &v1.Duration{Duration: durationRetry}
+
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"users[0].cleanupPolicy":             cleanupPolicy,
+			"users[0].host":                      host,
+			"users[0].maxUserConnections":        strconv.Itoa(maxUserConnections),
+			"users[0].name":                      name,
+			"users[0].passwordSecretKeyRef.key":  passwordSecretKeyRefKey,
+			"users[0].passwordSecretKeyRef.name": passwordSecretKeyRefName,
+			"users[0].requeueInterval":           requeueInterval,
+			"users[0].retryInterval":             retryInterval,
+			"users[0].mariaDBRef.name":           "cluster",
+			"users[0].mariaDBRef.namespace":      "namespace",
+		},
+	}
+
+	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/user.yaml"})
+	var user v1alpha1.User
+	helm.UnmarshalK8SYaml(t, renderedData, &user)
+
+	Expect(user.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
+	Expect(user.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
+	Expect(user.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
+	Expect(*user.Spec.CleanupPolicy).To(Equal(v1alpha1.CleanupPolicy(cleanupPolicy)))
+	Expect(user.Spec.Host).To(Equal(host))
+	Expect(user.Spec.MaxUserConnections).To(Equal(int32(maxUserConnections)))
+	Expect(user.Spec.Name).To(Equal(name))
+	Expect(user.Spec.PasswordSecretKeyRef.Key).To(Equal(passwordSecretKeyRefKey))
+	Expect(user.Spec.PasswordSecretKeyRef.Name).To(Equal(passwordSecretKeyRefName))
+	Expect(user.Spec.RequeueInterval).To(Equal(requeueIntervalDuration))
+	Expect(user.Spec.RetryInterval).To(Equal(retryIntervalDuration))
+
+	delete(opts.SetValues, "users[0].name")
+	_, err := helm.RenderTemplateE(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/user.yaml"})
+	Expect(err).To(HaveOccurred())
+}
+
+func TestClusterHelmGrant(t *testing.T) {
+	RegisterTestingT(t)
+
+	cleanupPolicy := "Delete"
+	database := "foo"
+	host := "%"
+	username := "foo"
+	privilegeSelect := "SELECT"
+	privilegeProcess := "PROCESS"
+	requeueInterval := "1h"
+	retryInterval := "3m"
+	table := "*"
+
+	durationInterval, _ := time.ParseDuration(requeueInterval)
+	durationRetry, _ := time.ParseDuration(retryInterval)
+	requeueIntervalDuration := &v1.Duration{Duration: durationInterval}
+	retryIntervalDuration := &v1.Duration{Duration: durationRetry}
+
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"grants[0].cleanupPolicy":        cleanupPolicy,
+			"grants[0].database":             database,
+			"grants[0].host":                 host,
+			"grants[0].grantOption":          "false",
+			"grants[0].username":             username,
+			"grants[0].privileges[0]":        privilegeSelect,
+			"grants[0].privileges[1]":        privilegeProcess,
+			"grants[0].requeueInterval":      requeueInterval,
+			"grants[0].retryInterval":        retryInterval,
+			"grants[0].table":                table,
+			"grants[0].mariaDBRef.name":      "cluster",
+			"grants[0].mariaDBRef.namespace": "namespace",
+		},
+	}
+
+	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/grant.yaml"})
+	var grant v1alpha1.Grant
+	helm.UnmarshalK8SYaml(t, renderedData, &grant)
+
+	Expect(grant.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, username)))
+	Expect(grant.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
+	Expect(grant.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
+	Expect(*grant.Spec.CleanupPolicy).To(Equal(v1alpha1.CleanupPolicy(cleanupPolicy)))
+	Expect(grant.Spec.Database).To(Equal(database))
+	Expect(*grant.Spec.Host).To(Equal(host))
+	Expect(grant.Spec.GrantOption).To(BeFalse())
+	Expect(grant.Spec.Username).To(Equal(username))
+	Expect(grant.Spec.Privileges[0]).To(Equal(privilegeSelect))
+	Expect(grant.Spec.Privileges[1]).To(Equal(privilegeProcess))
+	Expect(grant.Spec.RequeueInterval).To(Equal(requeueIntervalDuration))
+	Expect(grant.Spec.RetryInterval).To(Equal(retryIntervalDuration))
+	Expect(grant.Spec.Table).To(Equal(table))
+
+	delete(opts.SetValues, "grants[0].username")
+	_, err := helm.RenderTemplateE(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/grant.yaml"})
+	Expect(err).To(HaveOccurred())
+}
+
+func TestClusterHelmBackup(t *testing.T) {
+	RegisterTestingT(t)
+
+	maxRetention := "336h"
+	compression := "gzip"
+	bucket := "backups"
+	endpoint := "minio.minio.svc.cluster.local:9000"
+	region := "us-east-1"
+	prefix := "mariadb-cluster"
+	accessKeyIdSecretKeyRefKey := "AWS_ACCESS_KEY_ID"
+	accessKeyIdSecretKeyRefName := "mariadb-cluster-passwords"
+	secretAccessKeySecretKeyRefKey := "AWS_SECRET_ACCESS_KEY"
+	secretAccessKeySecretKeyRefName := "mariadb-cluster-passwords"
+	cron := "0 0 * * *"
+
+	durationMaxRetention, _ := time.ParseDuration(maxRetention)
+	durationMaxRetentionDuration := &v1.Duration{Duration: durationMaxRetention}
+
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"backups[0].maxRetention":                                maxRetention,
+			"backups[0].compression":                                 compression,
+			"backups[0].storage.s3.bucket":                           bucket,
+			"backups[0].storage.s3.prefix":                           prefix,
+			"backups[0].storage.s3.endpoint":                         endpoint,
+			"backups[0].storage.s3.region":                           region,
+			"backups[0].storage.s3.accessKeyIdSecretKeyRef.key":      accessKeyIdSecretKeyRefKey,
+			"backups[0].storage.s3.accessKeyIdSecretKeyRef.name":     accessKeyIdSecretKeyRefName,
+			"backups[0].storage.s3.secretAccessKeySecretKeyRef.key":  secretAccessKeySecretKeyRefKey,
+			"backups[0].storage.s3.secretAccessKeySecretKeyRef.name": secretAccessKeySecretKeyRefName,
+			"backups[0].schedule.cron":                               cron,
+			"backups[0].mariaDBRef.name":                             "cluster",
+			"backups[0].mariaDBRef.namespace":                        "namespace",
+		},
+	}
+
+	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/backup.yaml"})
+	var backup v1alpha1.Backup
+	helm.UnmarshalK8SYaml(t, renderedData, &backup)
+
+	Expect(backup.Name).To(Equal(fmt.Sprintf("%s-%d", clusterHelmReleaseName, 0)))
+	Expect(backup.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
+	Expect(backup.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
+	Expect(&backup.Spec.MaxRetention).To(Equal(durationMaxRetentionDuration))
+	Expect(backup.Spec.Compression).To(Equal(v1alpha1.CompressAlgorithm(compression)))
+	Expect(backup.Spec.Storage.S3.Bucket).To(Equal(bucket))
+	Expect(backup.Spec.Storage.S3.Prefix).To(Equal(prefix))
+	Expect(backup.Spec.Storage.S3.Endpoint).To(Equal(endpoint))
+	Expect(backup.Spec.Storage.S3.Region).To(Equal(region))
+	Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Key).To(Equal(accessKeyIdSecretKeyRefKey))
+	Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Name).To(Equal(accessKeyIdSecretKeyRefName))
+	Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Key).To(Equal(secretAccessKeySecretKeyRefKey))
+	Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Name).To(Equal(secretAccessKeySecretKeyRefName))
+	Expect(backup.Spec.Schedule.Cron).To(Equal(cron))
+
+	delete(opts.SetValues, "backups[0].storage.s3.bucket")
+	delete(opts.SetValues, "backups[0].storage.s3.prefix")
+	delete(opts.SetValues, "backups[0].storage.s3.endpoint")
+	delete(opts.SetValues, "backups[0].storage.s3.region")
+	delete(opts.SetValues, "backups[0].storage.s3.accessKeyIdSecretKeyRef.key")
+	delete(opts.SetValues, "backups[0].storage.s3.accessKeyIdSecretKeyRef.name")
+	delete(opts.SetValues, "backups[0].storage.s3.secretAccessKeySecretKeyRef.key")
+	delete(opts.SetValues, "backups[0].storage.s3.secretAccessKeySecretKeyRef.name")
+
+	_, err := helm.RenderTemplateE(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/backup.yaml"})
+	Expect(err).To(HaveOccurred())
+}

--- a/internal/helmtest/mariadb_operator_test.go
+++ b/internal/helmtest/mariadb_operator_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 var (
-	helmReleaseName = "mariadb-operator"
-	helmChartPath   = "../../deploy/charts/mariadb-operator"
-	testNamespace   = "test"
+	operatorHelmReleaseName = "mariadb-operator"
+	operatorHelmChartPath   = "../../deploy/charts/mariadb-operator"
+	operatorTestNamespace   = "test"
 )
 
-func TestHelmExtraEnvFrom(t *testing.T) {
+func TestOperatorHelmExtraEnvFrom(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		// see https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set
@@ -28,7 +28,9 @@ func TestHelmExtraEnvFrom(t *testing.T) {
 		},
 	}
 
-	deploymentData := helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/deployment.yaml"})
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/deployment.yaml"})
 	var deployment appsv1.Deployment
 	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
 
@@ -54,18 +56,20 @@ func TestHelmExtraEnvFrom(t *testing.T) {
 	Expect(container.EnvFrom).To(ContainElement(secretEnvFrom))
 }
 
-func TestHelmCurrentNamespaceOnly(t *testing.T) {
+func TestOperatorHelmCurrentNamespaceOnly(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
 			"currentNamespaceOnly": `true`,
 		},
 		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: testNamespace,
+			Namespace: operatorTestNamespace,
 		},
 	}
 
-	deploymentData := helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/deployment.yaml"})
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/deployment.yaml"})
 	var deployment appsv1.Deployment
 	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
 
@@ -74,7 +78,7 @@ func TestHelmCurrentNamespaceOnly(t *testing.T) {
 
 	env := corev1.EnvVar{
 		Name:  "WATCH_NAMESPACE",
-		Value: testNamespace,
+		Value: operatorTestNamespace,
 	}
 	Expect(container.Env).To(ContainElement(env))
 
@@ -95,10 +99,10 @@ func TestHelmCurrentNamespaceOnly(t *testing.T) {
 		"templates/webhook/serviceaccount.yaml",
 		"templates/webhook/servicemonitor.yaml",
 	}
-	testHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
 }
 
-func TestHelmClusterWide(t *testing.T) {
+func TestOperatorHelmClusterWide(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
@@ -106,11 +110,13 @@ func TestHelmClusterWide(t *testing.T) {
 			"metrics.enabled":                  `true`,
 		},
 		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: testNamespace,
+			Namespace: operatorTestNamespace,
 		},
 	}
 
-	deploymentData := helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/deployment.yaml"})
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/deployment.yaml"})
 	var deployment appsv1.Deployment
 	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
 
@@ -119,7 +125,7 @@ func TestHelmClusterWide(t *testing.T) {
 
 	env := corev1.EnvVar{
 		Name:  "WATCH_NAMESPACE",
-		Value: testNamespace,
+		Value: operatorTestNamespace,
 	}
 	Expect(container.Env).ToNot(ContainElement(env))
 
@@ -135,10 +141,10 @@ func TestHelmClusterWide(t *testing.T) {
 	unexpectedTemplates := []string{
 		"templates/operator/rbac-namespace.yaml",
 	}
-	testHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
 }
 
-func TestHelmCertManager(t *testing.T) {
+func TestOperatorHelmCertManager(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
@@ -154,10 +160,10 @@ func TestHelmCertManager(t *testing.T) {
 		"templates/cert-controller/rbac.yaml",
 		"templates/cert-controller/serviceaccount.yaml",
 	}
-	testHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
 }
 
-func TestHelmMetrics(t *testing.T) {
+func TestOperatorHelmMetrics(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
@@ -169,10 +175,10 @@ func TestHelmMetrics(t *testing.T) {
 		"templates/cert-controller/servicemonitor.yaml",
 		"templates/webhook/servicemonitor.yaml",
 	}
-	testHelmTemplates(t, opts, expectedTemplates, nil)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, nil)
 }
 
-func TestHelmWebhook(t *testing.T) {
+func TestOperatorHelmWebhook(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
@@ -186,7 +192,7 @@ func TestHelmWebhook(t *testing.T) {
 		"templates/webhook/serviceaccount.yaml",
 	}
 	unexpectedTemplates := []string{}
-	testHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
 
 	opts = &helm.Options{
 		SetValues: map[string]string{
@@ -201,10 +207,10 @@ func TestHelmWebhook(t *testing.T) {
 		"templates/webhook/serviceaccount.yaml",
 		"templates/webhook/pdb.yaml",
 	}
-	testHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
 }
 
-func TestHelmCertController(t *testing.T) {
+func TestOperatorHelmCertController(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
@@ -217,7 +223,7 @@ func TestHelmCertController(t *testing.T) {
 		"templates/cert-controller/serviceaccount.yaml",
 	}
 	unexpectedTemplates := []string{}
-	testHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
 
 	opts = &helm.Options{
 		SetValues: map[string]string{
@@ -231,21 +237,23 @@ func TestHelmCertController(t *testing.T) {
 		"templates/cert-controller/serviceaccount.yaml",
 		"templates/cert-controller/pdb.yaml",
 	}
-	testHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
 }
 
-func TestHelmHaEnabled(t *testing.T) {
+func TestOperatorHelmHaEnabled(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
 			"ha.enabled": `true`,
 		},
 		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: testNamespace,
+			Namespace: operatorTestNamespace,
 		},
 	}
 
-	deploymentData := helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/deployment.yaml"})
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/deployment.yaml"})
 	var deployment appsv1.Deployment
 	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
 
@@ -257,17 +265,17 @@ func TestHelmHaEnabled(t *testing.T) {
 	Expect(container.Args).To(ContainElement("--leader-elect"))
 }
 
-func TestHelmPDBEnabled(t *testing.T) {
+func TestOperatorHelmPDBEnabled(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
 			"pdb.enabled": `true`,
 		},
 		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: testNamespace,
+			Namespace: operatorTestNamespace,
 		},
 	}
-	pdbData := helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/pdb.yaml"})
+	pdbData := helm.RenderTemplate(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{"templates/operator/pdb.yaml"})
 	var pdb policyv1.PodDisruptionBudget
 	helm.UnmarshalK8SYaml(t, pdbData, &pdb)
 	maxUnavailable := pdb.Spec.MaxUnavailable.IntValue()
@@ -279,10 +287,10 @@ func TestHelmPDBEnabled(t *testing.T) {
 			"pdb.maxUnavailable": "50%",
 		},
 		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: testNamespace,
+			Namespace: operatorTestNamespace,
 		},
 	}
-	pdbData = helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/pdb.yaml"})
+	pdbData = helm.RenderTemplate(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{"templates/operator/pdb.yaml"})
 	helm.UnmarshalK8SYaml(t, pdbData, &pdb)
 	maxUnavailablePercent := pdb.Spec.MaxUnavailable.String()
 	Expect(maxUnavailablePercent).To(Equal("50%"))
@@ -291,36 +299,36 @@ func TestHelmPDBEnabled(t *testing.T) {
 		"templates/operator/pdb.yaml",
 	}
 	unexpectedTemplates := []string{}
-	testHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
 
 	opts = &helm.Options{
 		SetValues: map[string]string{
 			"pdb.enabled": `false`,
 		},
 		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: testNamespace,
+			Namespace: operatorTestNamespace,
 		},
 	}
 	expectedTemplates = []string{}
 	unexpectedTemplates = []string{
 		"templates/operator/pdb.yaml",
 	}
-	testHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
+	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
 }
 
-func testHelmTemplates(t *testing.T, opts *helm.Options, expectedTemplates, unexpectedTemplates []string) {
+func testOperatorHelmTemplates(t *testing.T, opts *helm.Options, expectedTemplates, unexpectedTemplates []string) {
 	for _, tpl := range expectedTemplates {
-		_, err := helm.RenderTemplateE(t, opts, helmChartPath, helmReleaseName, []string{tpl})
+		_, err := helm.RenderTemplateE(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{tpl})
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	for _, tpl := range unexpectedTemplates {
-		_, err := helm.RenderTemplateE(t, opts, helmChartPath, helmReleaseName, []string{tpl})
+		_, err := helm.RenderTemplateE(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{tpl})
 		Expect(err).To(HaveOccurred())
 	}
 }
 
-func TestHelmImageTagAndDigest(t *testing.T) {
+func TestOperatorHelmImageTagAndDigest(t *testing.T) {
 	RegisterTestingT(t)
 
 	repository := "docker-registry3.mariadb.com/mariadb-operator/mariadb-operator"
@@ -335,7 +343,9 @@ func TestHelmImageTagAndDigest(t *testing.T) {
 		},
 	}
 
-	renderedData := helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/deployment.yaml"})
+	renderedData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/deployment.yaml"})
 	var deployment appsv1.Deployment
 	helm.UnmarshalK8SYaml(t, renderedData, &deployment)
 
@@ -350,7 +360,7 @@ func TestHelmImageTagAndDigest(t *testing.T) {
 		},
 	}
 
-	renderedData = helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/deployment.yaml"})
+	renderedData = helm.RenderTemplate(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{"templates/operator/deployment.yaml"})
 	helm.UnmarshalK8SYaml(t, renderedData, &deployment)
 
 	container = deployment.Spec.Template.Spec.Containers[0]
@@ -358,7 +368,7 @@ func TestHelmImageTagAndDigest(t *testing.T) {
 	Expect(container.Image).To(ContainSubstring(repository + ":" + tag))
 }
 
-func TestHelmConfigMap(t *testing.T) {
+func TestOperatorHelmConfigMap(t *testing.T) {
 	RegisterTestingT(t)
 	repository := "docker-registry3.mariadb.com/mariadb-operator/mariadb-operator"
 	tag := "v1.0.0"
@@ -374,7 +384,9 @@ func TestHelmConfigMap(t *testing.T) {
 			"config.exporterMaxscaleImage": "exporter-maxscale:1.0",
 		},
 	}
-	configMapData := helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/configmap.yaml"})
+	configMapData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/configmap.yaml"})
 	var configMap corev1.ConfigMap
 	helm.UnmarshalK8SYaml(t, configMapData, &configMap)
 	Expect(configMap.Name).To(Equal("mariadb-operator-env"))
@@ -387,7 +399,7 @@ func TestHelmConfigMap(t *testing.T) {
 	Expect(configMap.Data["RELATED_IMAGE_EXPORTER_MAXSCALE"]).To(Equal("exporter-maxscale:1.0"))
 }
 
-func TestHelmPprof(t *testing.T) {
+func TestOperatorHelmPprof(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
@@ -395,11 +407,13 @@ func TestHelmPprof(t *testing.T) {
 			"pprof.port":    `6060`,
 		},
 		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: testNamespace,
+			Namespace: operatorTestNamespace,
 		},
 	}
 
-	deploymentData := helm.RenderTemplate(t, opts, helmChartPath, helmReleaseName, []string{"templates/operator/deployment.yaml"})
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/deployment.yaml"})
 	var deployment appsv1.Deployment
 	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
 


### PR DESCRIPTION
The initial version of mariadb-cluster helm chart will be able to template:

 * 1 MariaDB
 * list of Database
 * list of User
 * list of Grant
 * list of Backup

Other resources might be included via prs in the future.

closes: https://github.com/mariadb-operator/mariadb-operator/issues/1273