### PR TITLE
feat: overwrite tolerations and nodeSelector in the restore job when using bootstrapFrom

### DIFF
--- a/api/v1alpha1/base_types.go
+++ b/api/v1alpha1/base_types.go
@@ -187,6 +187,14 @@ type Job struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	Affinity *AffinityConfig `json:"affinity,omitempty"`
+	// NodeSelector to be used in the Pod.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	// Tolerations to be used in the Pod.
+	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
 	// Resources describes the compute resource requirements.
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:resourceRequirements"}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -1534,6 +1534,20 @@ func (in *Job) DeepCopyInto(out *Job) {
 		*out = new(AffinityConfig)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.NodeSelector != nil {
+		in, out := &in.NodeSelector, &out.NodeSelector
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Tolerations != nil {
+		in, out := &in.Tolerations, &out.Tolerations
+		*out = make([]corev1.Toleration, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	if in.Resources != nil {
 		in, out := &in.Resources, &out.Resources
 		*out = new(ResourceRequirements)

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -565,6 +565,11 @@ spec:
                             description: Labels to be added to children resources.
                             type: object
                         type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector to be used in the Pod.
+                        type: object
                       resources:
                         description: Resources describes the compute resource requirements.
                         properties:
@@ -589,6 +594,45 @@ spec:
                               quantity) pairs.
                             type: object
                         type: object
+                      tolerations:
+                        description: Tolerations to be used in the Pod.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     type: object
                   s3:
                     description: S3 defines the configuration to restore backups from

--- a/deploy/charts/mariadb-operator-crds/templates/crds.yaml
+++ b/deploy/charts/mariadb-operator-crds/templates/crds.yaml
@@ -2293,6 +2293,11 @@ spec:
                             description: Labels to be added to children resources.
                             type: object
                         type: object
+                      nodeSelector:
+                        additionalProperties:
+                          type: string
+                        description: NodeSelector to be used in the Pod.
+                        type: object
                       resources:
                         description: Resources describes the compute resource requirements.
                         properties:
@@ -2317,6 +2322,45 @@ spec:
                               quantity) pairs.
                             type: object
                         type: object
+                      tolerations:
+                        description: Tolerations to be used in the Pod.
+                        items:
+                          description: |-
+                            The pod this Toleration is attached to tolerates any taint that matches
+                            the triple <key,value,effect> using the matching operator <operator>.
+                          properties:
+                            effect:
+                              description: |-
+                                Effect indicates the taint effect to match. Empty means match all taint effects.
+                                When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                              type: string
+                            key:
+                              description: |-
+                                Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                              type: string
+                            operator:
+                              description: |-
+                                Operator represents a key's relationship to the value.
+                                Valid operators are Exists and Equal. Defaults to Equal.
+                                Exists is equivalent to wildcard for value, so that a pod can
+                                tolerate all taints of a particular category.
+                              type: string
+                            tolerationSeconds:
+                              description: |-
+                                TolerationSeconds represents the period of time the toleration (which must be
+                                of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                negative values will be treated as 0 (evict immediately) by the system.
+                              format: int64
+                              type: integer
+                            value:
+                              description: |-
+                                Value is the taint value the toleration matches to.
+                                If the operator is Exists, the value should be empty, otherwise just a regular string.
+                              type: string
+                          type: object
+                        type: array
                     type: object
                   s3:
                     description: S3 defines the configuration to restore backups from

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -980,6 +980,8 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `metadata` _[Metadata](#metadata)_ | Refer to Kubernetes API documentation for fields of `metadata`. |  |  |
 | `affinity` _[AffinityConfig](#affinityconfig)_ | Affinity to be used in the Pod. |  |  |
+| `nodeSelector` _object (keys:string, values:string)_ | NodeSelector to be used in the Pod. |  |  |
+| `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#toleration-v1-core) array_ | Tolerations to be used in the Pod. |  |  |
 | `resources` _[ResourceRequirements](#resourcerequirements)_ | Resouces describes the compute resource requirements. |  |  |
 | `args` _string array_ | Args to be used in the Container. |  |  |
 

--- a/pkg/builder/restore_builder.go
+++ b/pkg/builder/restore_builder.go
@@ -26,6 +26,15 @@ func (b *Builder) BuildRestore(mariadb *mariadbv1alpha1.MariaDB, key types.Names
 		restoreJob.Metadata,
 	)
 
+	// Allow the restoreJob to overwrite tolerations and node selector to ensure we allow the restore job to run
+	// differently than the mariadb pods.
+	if restoreJob.NodeSelector != nil {
+		podTpl.NodeSelector = restoreJob.NodeSelector
+	}
+	if restoreJob.Tolerations != nil {
+		podTpl.Tolerations = restoreJob.Tolerations
+	}
+
 	containerTpl := mariadbv1alpha1.JobContainerTemplate{}
 	containerTpl.FromContainerTemplate(mariadb.Spec.ContainerTemplate.DeepCopy())
 	containerTpl.Resources = restoreJob.Resources

--- a/pkg/builder/restore_builder_test.go
+++ b/pkg/builder/restore_builder_test.go
@@ -196,7 +196,7 @@ func TestBuildRestore(t *testing.T) {
 	if restore.Spec.JobPodTemplate.Affinity == nil {
 		t.Error("expected affinity to have been set")
 	}
-	if restore.Spec.NodeSelector == nil || len(restore.Spec.NodeSelector) <= 0 {
+	if len(restore.Spec.NodeSelector) <= 0 {
 		t.Error("expected nodeSelector to have been set")
 	}
 	if restore.Spec.Tolerations == nil {

--- a/pkg/builder/restore_builder_test.go
+++ b/pkg/builder/restore_builder_test.go
@@ -170,6 +170,10 @@ func TestBuildRestore(t *testing.T) {
 						AntiAffinityEnabled: ptr.To(true),
 						Affinity:            mariadbv1alpha1.Affinity{},
 					},
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": "compute-0",
+					},
+					Tolerations: []corev1.Toleration{},
 					Resources: &mariadbv1alpha1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							"cpu": resource.MustParse("100m"),
@@ -191,6 +195,12 @@ func TestBuildRestore(t *testing.T) {
 
 	if restore.Spec.JobPodTemplate.Affinity == nil {
 		t.Error("expected affinity to have been set")
+	}
+	if restore.Spec.NodeSelector == nil || len(restore.Spec.NodeSelector) <= 0 {
+		t.Error("expected nodeSelector to have been set")
+	}
+	if restore.Spec.Tolerations == nil {
+		t.Error("expected Tolerations to have been set")
 	}
 	if restore.Spec.JobContainerTemplate.Resources == nil {
 		t.Error("expected resources to have been set")


### PR DESCRIPTION
Builds on #1192, specifically, when using the `bootstrapFrom` mechanism when using `hostPath` backups. In that case, you want to ensure the restore job is ran from the correct node that contains the backups.

P.S. In the meantime you could set the `nodeSelector` on the mariadb spec as the recovery job "inherits" the node selector (and tolerations).