### PR TITLE
[Replication] Do not trigger automatic failover when suspended

### DIFF
--- a/internal/controller/pod_replication_controller.go
+++ b/internal/controller/pod_replication_controller.go
@@ -91,7 +91,7 @@ func (r *PodReplicationController) ReconcilePodNotReady(ctx context.Context, pod
 }
 
 func shouldReconcile(mariadb *mariadbv1alpha1.MariaDB) bool {
-	if mariadb.IsMaxScaleEnabled() || mariadb.IsRestoringBackup() {
+	if mariadb.IsMaxScaleEnabled() || mariadb.IsRestoringBackup() || mariadb.IsSuspended() {
 		return false
 	}
 	primaryRepl := ptr.Deref(mariadb.Replication().Primary, mariadbv1alpha1.PrimaryReplication{})


### PR DESCRIPTION
Currently, when mariadb is suspended and automatic failover is enabled, the operator updates the desired master index, but not actually performs the failover until unsuspended. Since for now there is no automated way to cancel pending switchover, we should not initiate it at all when the resource is suspended.