### PR TITLE
[Replication] Add verbosity to skipped switchover steps

### DIFF
--- a/pkg/controller/replication/switchover.go
+++ b/pkg/controller/replication/switchover.go
@@ -110,6 +110,7 @@ func (r *ReplicationReconciler) lockPrimaryWithReadLock(ctx context.Context, mar
 		return fmt.Errorf("error getting current primary readiness: %v", err)
 	}
 	if !ready {
+		logger.Info("Skipped locking primary with read lock due primary's non ready status")
 		return nil
 	}
 	client, err := clientSet.currentPrimaryClient(ctx)
@@ -130,6 +131,7 @@ func (r *ReplicationReconciler) setPrimaryReadOnly(ctx context.Context, mariadb 
 		return fmt.Errorf("error getting current primary readiness: %v", err)
 	}
 	if !ready {
+		logger.Info("Skipped enabling readonly mode in primary due to its non ready status")
 		return nil
 	}
 	client, err := clientSet.currentPrimaryClient(ctx)
@@ -153,6 +155,7 @@ func (r *ReplicationReconciler) waitForReplicaSync(ctx context.Context, mariadb 
 		return fmt.Errorf("error getting current primary readiness: %v", err)
 	}
 	if !ready {
+		logger.Info("Skipped waiting for replicas to be synced with primary due to its non ready status")
 		return nil
 	}
 	client, err := clientSet.currentPrimaryClient(ctx)
@@ -324,6 +327,7 @@ func (r *ReplicationReconciler) changePrimaryToReplica(ctx context.Context, mari
 		return fmt.Errorf("error getting current primary readiness: %v", err)
 	}
 	if !ready {
+		logger.Info("Skipped changing primary to be a replica due to primary's non ready status")
 		return nil
 	}
 	currentPrimaryClient, err := clientSet.currentPrimaryClient(ctx)


### PR DESCRIPTION
This should make it a bit easier to investigate botched failovers. 

For example, when my node is flapping for a few seconds (rke2 agent restart), with 2 replica cluster with automatic failover, I see that in 50% of cases the cluster ends up with 2 masters: the new one and the old one because `changePrimaryToReplica()` sees the master is not ready and skips this step. And a few seconds later, the restarted kubelet gets hold of things, and the old master pod becomes ready. 

I figured it out only by noticing the absence of `Change primary to be a replica` log entry. With the suggested change, it would be much easier to understand what happened. 