### PR TITLE
Add --sync-period opt to manager

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -79,6 +79,8 @@ var (
 
 	requeueSqlMaxOffset time.Duration
 
+	syncPeriod time.Duration
+
 	webhookEnabled bool
 	webhookPort    int
 	webhookCertDir string
@@ -122,6 +124,8 @@ func init() {
 		"Maximum offset added to the interval at which SQL objects are requeued.")
 	rootCmd.Flags().DurationVar(&requeueSqlJob, "requeue-sqljob", 5*time.Second, "The interval at which SqlJobs are requeued.")
 	rootCmd.Flags().DurationVar(&requeueMaxScale, "requeue-maxscale", 30*time.Second, "The interval at which MaxScales are requeued.")
+
+	rootCmd.Flags().DurationVar(&syncPeriod, "sync-period", 10*time.Hour, "The interval at which watched resources are reconciled.")
 
 	rootCmd.Flags().BoolVar(&webhookEnabled, "webhook", false, "Enable the webhook server.")
 	rootCmd.Flags().IntVar(&webhookPort, "webhook-port", 9443, "Port to be used by the webhook server."+
@@ -174,6 +178,9 @@ var rootCmd = &cobra.Command{
 			LeaderElectionID:       "mariadb-operator.mariadb.com",
 			Controller: config.Controller{
 				MaxConcurrentReconciles: maxConcurrentReconciles,
+			},
+			Cache: cache.Options{
+				SyncPeriod: &syncPeriod,
 			},
 		}
 		if webhookEnabled {


### PR DESCRIPTION
When having 10k+ db/user/grant resources, and requeueSql set to 0 I still notice periodic bulk reconciles every 10h that create 10k queue for ~7 minutes. Of course, one could raise maxConcurrentReconciles to lower the spike duration, but having an option to disable or tune informer sync would be nicer. 

The solution is taken from: https://github.com/kubernetes-sigs/controller-runtime/issues/521

By defaulting it to 10h https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.4/pkg/cache#Options we do not modify the default behavior for regular not hardcore users.

> Defaults to 10 hours if unset.


