### PR TITLE
Allow tweaking kube api client ratelimiter

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -68,6 +68,9 @@ var (
 	logMaxScale    bool
 	logSql         bool
 
+	kubeApiQps   float32
+	kubeApiBurst int
+
 	maxConcurrentReconciles         int
 	mariadbMaxConcurrentReconciles  int
 	maxscaleMaxConcurrentReconciles int
@@ -110,6 +113,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&logDev, "log-dev", false, "Enable development logs.")
 	rootCmd.Flags().BoolVar(&logMaxScale, "log-maxscale", false, "Enable MaxScale API request logs.")
 	rootCmd.Flags().BoolVar(&logSql, "log-sql", false, "Enable SQL resource logs.")
+
+	rootCmd.Flags().Float32Var(&kubeApiQps, "kube-api-qps", 20.0,
+		"QPS limit for requests to Kubernetes API server (set to `-1` to disable client-side ratelimit).")
+	rootCmd.Flags().IntVar(&kubeApiBurst, "kube-api-burst", 30, "Burst limit for requests to Kubernetes API server.")
 
 	rootCmd.Flags().IntVar(&maxConcurrentReconciles, "max-concurrent-reconciles", 1,
 		"Global maximum number of concurrent reconciles per resource.")
@@ -162,6 +169,9 @@ var rootCmd = &cobra.Command{
 			setupLog.Error(err, "Unable to get config")
 			os.Exit(1)
 		}
+		restConfig.QPS = kubeApiQps
+		restConfig.Burst = kubeApiBurst
+
 		env, err := environment.GetOperatorEnv(ctx)
 		if err != nil {
 			setupLog.Error(err, "Error getting environment")


### PR DESCRIPTION
The latest controller-runtime decided to disable client-side ratelimit: https://github.com/kubernetes-sigs/controller-runtime/commit/ab40409635dc0c91781f575a87c64a579680be95

That is opinionated, so we can allow the end user to decide what is best. Let's use the values from the controller-runtime we are using https://github.com/kubernetes-sigs/controller-runtime/blob/v0.20.4/pkg/client/config/config.go#L101-L106

And if/when we upgrade, we can just change the defaults if need be.