### PR TITLE
Bump requeue interval defaults

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -125,12 +125,12 @@ func init() {
 	rootCmd.Flags().IntVar(&maxscaleMaxConcurrentReconciles, "maxscale-max-concurrent-reconciles", 10,
 		"Maximum number of concurrent reconciles per MaxScale.")
 
-	rootCmd.Flags().DurationVar(&requeueConnection, "requeue-connection", 30*time.Second, "The interval at which Connections are requeued.")
-	rootCmd.Flags().DurationVar(&requeueSql, "requeue-sql", 30*time.Second, "The interval at which SQL objects are requeued.")
-	rootCmd.Flags().DurationVar(&requeueSqlMaxOffset, "requeue-sql-max-offset", 0,
+	rootCmd.Flags().DurationVar(&requeueConnection, "requeue-connection", 1*time.Hour, "The interval at which Connections are requeued.")
+	rootCmd.Flags().DurationVar(&requeueSql, "requeue-sql", 10*time.Hour, "The interval at which SQL objects are requeued.")
+	rootCmd.Flags().DurationVar(&requeueSqlMaxOffset, "requeue-sql-max-offset", 1*time.Hour,
 		"Maximum offset added to the interval at which SQL objects are requeued.")
-	rootCmd.Flags().DurationVar(&requeueSqlJob, "requeue-sqljob", 5*time.Second, "The interval at which SqlJobs are requeued.")
-	rootCmd.Flags().DurationVar(&requeueMaxScale, "requeue-maxscale", 30*time.Second, "The interval at which MaxScales are requeued.")
+	rootCmd.Flags().DurationVar(&requeueSqlJob, "requeue-sqljob", 30*time.Second, "The interval at which SqlJobs are requeued.")
+	rootCmd.Flags().DurationVar(&requeueMaxScale, "requeue-maxscale", 1*time.Hour, "The interval at which MaxScales are requeued.")
 
 	rootCmd.Flags().DurationVar(&syncPeriod, "sync-period", 10*time.Hour, "The interval at which watched resources are reconciled.")
 

--- a/internal/controller/sqljob_controller_test.go
+++ b/internal/controller/sqljob_controller_test.go
@@ -2,14 +2,12 @@ package controller
 
 import (
 	"reflect"
-	"time"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -203,59 +201,6 @@ var _ = Describe("SqlJob", Label("basic"), func() {
 		}
 	})
 
-	It("should report unready status for non-existent dependencies", func() {
-		nonExistentDependency := "not-existing-job"
-		sqlJob := mariadbv1alpha1.SqlJob{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "sqljob-with-non-existent-dependency",
-				Namespace: testNamespace,
-			},
-			Spec: mariadbv1alpha1.SqlJobSpec{
-				DependsOn: []mariadbv1alpha1.LocalObjectReference{
-					{
-						Name: nonExistentDependency,
-					},
-				},
-				MariaDBRef: mariadbv1alpha1.MariaDBRef{
-					ObjectReference: mariadbv1alpha1.ObjectReference{
-						Name: testMdbkey.Name,
-					},
-					WaitForIt: true,
-				},
-				Username: testUser,
-				PasswordSecretKeyRef: mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: testPwdKey.Name,
-					},
-					Key: testPwdSecretKey,
-				},
-				Database: &testDatabase,
-			},
-		}
-
-		By("Creating SqlJob with non-existent dependency")
-		Expect(k8sClient.Create(testCtx, &sqlJob)).To(Succeed())
-		DeferCleanup(func() {
-			Expect(k8sClient.Delete(testCtx, &sqlJob)).To(Succeed())
-		})
-
-		By("Expecting SqlJob to report unready status")
-		Consistently(func() bool {
-			var updatedSqlJob mariadbv1alpha1.SqlJob
-			if err := k8sClient.Get(testCtx, client.ObjectKeyFromObject(&sqlJob), &updatedSqlJob); err != nil {
-				return false
-			}
-			return !updatedSqlJob.IsComplete()
-		}, 10*time.Second, testInterval).Should(BeTrue())
-
-		By("Expecting SqlJob to not create a Job")
-		Consistently(func() bool {
-			var job batchv1.Job
-			err := k8sClient.Get(testCtx, client.ObjectKeyFromObject(&sqlJob), &job)
-			return err != nil && apierrors.IsNotFound(err)
-		}, 10*time.Second, testInterval).Should(BeTrue())
-	})
-
 	DescribeTable("Creating an SqlJob",
 		func(
 			resourceName string,
@@ -276,7 +221,7 @@ var _ = Describe("SqlJob", Label("basic"), func() {
 		Entry(
 			"should reconcile a CronJob with history limits",
 			"sqljob-scheduled-with-history-limits",
-			applyDecoratorChain[mariadbv1alpha1.SqlJob](
+			applyDecoratorChain(
 				buildScheduledSqlJob,
 				decorateSqlJobWithHistoryLimits,
 			),
@@ -284,7 +229,7 @@ var _ = Describe("SqlJob", Label("basic"), func() {
 		Entry(
 			"should reconcile a CronJob with time zone setting",
 			"sqljob-scheduled-with-tz",
-			applyDecoratorChain[mariadbv1alpha1.SqlJob](
+			applyDecoratorChain(
 				buildScheduledSqlJob,
 				decorateSqlJobWithTimeZone,
 			),


### PR DESCRIPTION
Current requeue defaults are very aggresive, causing a higher memory, cpu and network usage in the controller. This PR bumps this defaults to mitigate this. Requeue intervals may be overriden at the resource level.

Related to:
- https://github.com/mariadb-operator/mariadb-operator/pull/1244