### PR TITLE
Convert SyncBinlog to integer

### DIFF
--- a/api/v1alpha1/mariadb_replication_types.go
+++ b/api/v1alpha1/mariadb_replication_types.go
@@ -205,12 +205,12 @@ type ReplicationSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
 	Replica *ReplicaReplication `json:"replica,omitempty"`
-	// SyncBinlog indicates whether the binary log should be synchronized to the disk after every event.
-	// It trades off performance for consistency.
+	// SyncBinlog indicates after how many events the binary log is synchronized to the disk.
+	// The default is 1, in which case it trades off performance for consistency. .
 	// See: https://mariadb.com/kb/en/replication-and-binary-log-system-variables/#sync_binlog.
 	// +optional
-	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
-	SyncBinlog *bool `json:"syncBinlog,omitempty"`
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:number"}
+	SyncBinlog *int `json:"syncBinlog,omitempty"`
 	// ProbesEnabled indicates to use replication specific liveness and readiness probes.
 	// This probes check that the primary can receive queries and that the replica has the replication thread running.
 	// +optional
@@ -260,7 +260,7 @@ var (
 			ConnectionRetries: ptr.To(10),
 			SyncTimeout:       ptr.To(tenSeconds),
 		},
-		SyncBinlog:    ptr.To(true),
+		SyncBinlog:    ptr.To(1),
 		ProbesEnabled: ptr.To(false),
 	}
 )

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3744,7 +3744,7 @@ func (in *ReplicationSpec) DeepCopyInto(out *ReplicationSpec) {
 	}
 	if in.SyncBinlog != nil {
 		in, out := &in.SyncBinlog, &out.SyncBinlog
-		*out = new(bool)
+		*out = new(int)
 		**out = **in
 	}
 	if in.ProbesEnabled != nil {

--- a/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
+++ b/config/crd/bases/k8s.mariadb.com_mariadbs.yaml
@@ -4901,10 +4901,10 @@ spec:
                     type: object
                   syncBinlog:
                     description: |-
-                      SyncBinlog indicates whether the binary log should be synchronized to the disk after every event.
-                      It trades off performance for consistency.
+                      SyncBinlog indicates after how many events the binary log is synchronized to the disk.
+                      The default is 1, in which case it trades off performance for consistency. .
                       See: https://mariadb.com/kb/en/replication-and-binary-log-system-variables/#sync_binlog.
-                    type: boolean
+                    type: integer
                 type: object
               resources:
                 description: Resources describes the compute resource requirements.

--- a/deploy/charts/mariadb-operator-crds/templates/crds.yaml
+++ b/deploy/charts/mariadb-operator-crds/templates/crds.yaml
@@ -6629,10 +6629,10 @@ spec:
                     type: object
                   syncBinlog:
                     description: |-
-                      SyncBinlog indicates whether the binary log should be synchronized to the disk after every event.
-                      It trades off performance for consistency.
+                      SyncBinlog indicates after how many events the binary log is synchronized to the disk.
+                      The default is 1, in which case it trades off performance for consistency. .
                       See: https://mariadb.com/kb/en/replication-and-binary-log-system-variables/#sync_binlog.
-                    type: boolean
+                    type: integer
                 type: object
               resources:
                 description: Resources describes the compute resource requirements.

--- a/internal/controller/mariadb_controller_replication_test.go
+++ b/internal/controller/mariadb_controller_replication_test.go
@@ -60,7 +60,7 @@ var _ = Describe("MariaDB replication", Ordered, func() {
 							WaitPoint: func() *mariadbv1alpha1.WaitPoint { w := mariadbv1alpha1.WaitPointAfterSync; return &w }(),
 							Gtid:      func() *mariadbv1alpha1.Gtid { g := mariadbv1alpha1.GtidCurrentPos; return &g }(),
 						},
-						SyncBinlog: func() *bool { s := true; return &s }(),
+						SyncBinlog: func() *int { i := 1; return &i }(),
 					},
 					Enabled: true,
 				},

--- a/internal/webhook/v1alpha1/mariadb_webhook_test.go
+++ b/internal/webhook/v1alpha1/mariadb_webhook_test.go
@@ -107,7 +107,7 @@ var _ = Describe("v1alpha1.MariaDB webhook", func() {
 								Primary: &v1alpha1.PrimaryReplication{
 									PodIndex: func() *int { i := 0; return &i }(),
 								},
-								SyncBinlog: func() *bool { f := true; return &f }(),
+								SyncBinlog: func() *int { i := 1; return &i }(),
 							},
 							Enabled: true,
 						},
@@ -129,7 +129,7 @@ var _ = Describe("v1alpha1.MariaDB webhook", func() {
 								Primary: &v1alpha1.PrimaryReplication{
 									PodIndex: func() *int { i := 0; return &i }(),
 								},
-								SyncBinlog: func() *bool { f := true; return &f }(),
+								SyncBinlog: func() *int { i := 1; return &i }(),
 							},
 							Enabled: true,
 						},

--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -96,7 +96,7 @@ func (r *ReplicationConfig) ConfigureReplica(ctx context.Context, mariadb *maria
 func (r *ReplicationConfig) configurePrimaryVars(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB, client *sql.Client,
 	primaryPodIndex int) error {
 	kv := map[string]string{
-		"sync_binlog":                  binaryFromBool(mariadb.Replication().SyncBinlog),
+		"sync_binlog":                  fmt.Sprintf("%d", *mariadb.Replication().SyncBinlog),
 		"rpl_semi_sync_master_enabled": "ON",
 		"rpl_semi_sync_master_timeout": func() string {
 			return fmt.Sprint(mariadb.Replication().Replica.ConnectionTimeout.Milliseconds())
@@ -120,7 +120,7 @@ func (r *ReplicationConfig) configurePrimaryVars(ctx context.Context, mariadb *m
 func (r *ReplicationConfig) configureReplicaVars(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,
 	client *sql.Client, ordinal int) error {
 	kv := map[string]string{
-		"sync_binlog":                  binaryFromBool(mariadb.Replication().SyncBinlog),
+		"sync_binlog":                  fmt.Sprintf("%d", *mariadb.Replication().SyncBinlog),
 		"rpl_semi_sync_master_enabled": "OFF",
 		"rpl_semi_sync_slave_enabled":  "ON",
 		"server_id":                    serverId(ordinal),
@@ -296,13 +296,6 @@ func newReplPasswordRef(mariadb *mariadbv1alpha1.MariaDB) mariadbv1alpha1.Genera
 
 func serverId(index int) string {
 	return fmt.Sprint(10 + index)
-}
-
-func binaryFromBool(b *bool) string {
-	if b != nil && *b {
-		return "1"
-	}
-	return "0"
 }
 
 func formatAccountName(username, host string) string {


### PR DESCRIPTION
I have noticed that my custom `sync_binlog=1000` value from `.spec.myCnf` is not applied. It turned out the operator enforces either `1` or `0`. I think we should convert it to integer to allow proper configuration for those who want it.