### PR TITLE
[WIP] Add PrometheusRule to mariadb-cluster

### DIFF
--- a/deploy/charts/mariadb-cluster/prometheus/galera.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/galera.yaml
@@ -1,2 +1,36 @@
 # The rules are helm templated, so we must escape labels:
 # {{ $labels.target }} => {{"{{ $labels.target }}"}}
+- alert: MariaDBGaleraNotReady
+  expr: |
+    mysql_global_status_wsrep_ready{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} != 1
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB instance in a Galera cluster is not ready
+    description: |
+      MariaDB instance {{"`{{ $labels.target }}`"}} in a Galera cluster is not ready
+- alert: MariaDBGaleraOutOfSync
+  expr: |
+    mysql_global_status_wsrep_local_state{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} != 4
+    and
+    mysql_global_variables_wsrep_desync{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB instance in a Galera cluster is out of sync
+    description: |
+      MariaDB instance {{"`{{ $labels.target }}`"}} in a Galera cluster in out of sync
+- alert: MariaDBGaleraDonorFallingBehind
+  expr: |
+    mysql_global_status_wsrep_local_state{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 2
+    and
+    mysql_global_status_wsrep_local_recv_queue{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 100
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB instance in a Galera cluster is a donor falling behind
+    description: |
+      MariaDB instance {{"`{{ $labels.target }}`"}} in a Galera cluster is a donor falling behind

--- a/deploy/charts/mariadb-cluster/prometheus/galera.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/galera.yaml
@@ -1,0 +1,2 @@
+# The rules are helm templated, so we must escape labels:
+# {{ $labels.target }} => {{"{{ $labels.target }}"}}

--- a/deploy/charts/mariadb-cluster/prometheus/generic.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/generic.yaml
@@ -12,11 +12,8 @@
       MariaDB instance {{"`{{ $labels.target }}`"}} is down or cannot be scraped
 - alert: MariaDBTooManyConnections
   expr: |
-    (
-      max_over_time(mysql_global_status_threads_connected{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}[1m])
-      /
-      mysql_global_variables_max_connections{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
-    ) * 100 > 85
+    (100 * mysql_global_status_threads_connected{target=~"{{ include "mariadb-cluster.fullname" . }}.*"})
+    / mysql_global_variables_max_connections{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 85
   for: 3m
   labels:
     severity: warning
@@ -24,3 +21,13 @@
     summary: MariaDB instance has too many connections
     description: |
       MariaDB instance {{"`{{ $labels.target }}`"}} has too many connections
+- alert: MariaDBSlowQueries
+  expr: |
+    increase(mysql_global_status_slow_queries{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}[1m]) > 0
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: MariaDB instance has new recent slow queries
+    description: |
+      MariaDB instance {{"`{{ $labels.target }}`"}} has new recent slow queries

--- a/deploy/charts/mariadb-cluster/prometheus/generic.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/generic.yaml
@@ -1,0 +1,11 @@
+# The rules are helm templated, so we must escape labels:
+# {{ $labels.target }} => {{"{{ $labels.target }}"}}
+- alert: MariaDBDown
+  expr: mysql_up{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB instance is down
+    description: |
+      MariaDB instance {{"`{{ $labels.target }}`"}} is down

--- a/deploy/charts/mariadb-cluster/prometheus/generic.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/generic.yaml
@@ -1,11 +1,26 @@
 # The rules are helm templated, so we must escape labels:
 # {{ $labels.target }} => {{"{{ $labels.target }}"}}
 - alert: MariaDBDown
-  expr: mysql_up{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
+  expr: |
+    mysql_up{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
   for: 1m
   labels:
     severity: critical
   annotations:
-    summary: MariaDB instance is down
+    summary: MariaDB instance is down or cannot be scraped
     description: |
-      MariaDB instance {{"`{{ $labels.target }}`"}} is down
+      MariaDB instance {{"`{{ $labels.target }}`"}} is down or cannot be scraped
+- alert: MariaDBTooManyConnections
+  expr: |
+    (
+      max_over_time(mysql_global_status_threads_connected{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}[1m])
+      /
+      mysql_global_variables_max_connections{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
+    ) * 100 > 85
+  for: 3m
+  labels:
+    severity: warning
+  annotations:
+    summary: MariaDB instance has too many connections
+    description: |
+      MariaDB instance {{"`{{ $labels.target }}`"}} has too many connections

--- a/deploy/charts/mariadb-cluster/prometheus/generic.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/generic.yaml
@@ -2,7 +2,7 @@
 # {{ $labels.target }} => {{"{{ $labels.target }}"}}
 - alert: MariaDBDown
   expr: |
-    mysql_up{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
+    mysql_up{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} != 1
   for: 1m
   labels:
     severity: critical
@@ -10,17 +10,6 @@
     summary: MariaDB instance is down or cannot be scraped
     description: |
       MariaDB instance {{"`{{ $labels.target }}`"}} is down or cannot be scraped
-- alert: MariaDBTooManyConnections
-  expr: |
-    (100 * mysql_global_status_threads_connected{target=~"{{ include "mariadb-cluster.fullname" . }}.*"})
-    / mysql_global_variables_max_connections{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 85
-  for: 3m
-  labels:
-    severity: warning
-  annotations:
-    summary: MariaDB instance has too many connections
-    description: |
-      MariaDB instance {{"`{{ $labels.target }}`"}} has too many connections
 - alert: MariaDBSlowQueries
   expr: |
     increase(mysql_global_status_slow_queries{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}[1m]) > 0
@@ -28,6 +17,38 @@
   labels:
     severity: warning
   annotations:
-    summary: MariaDB instance has new recent slow queries
+    summary: MariaDB instance has continuous slow queries
     description: |
-      MariaDB instance {{"`{{ $labels.target }}`"}} has new recent slow queries
+      MariaDB instance {{"`{{ $labels.target }}`"}} has continuous slow queries
+- alert: MariaDBTooManyConnectionsWarning
+  expr: |
+    mysql_global_status_threads_connected{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
+    / mysql_global_variables_max_connections{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0.8
+  for: 1m
+  labels:
+    severity: warning
+  annotations:
+    summary: MariaDB instance has high connection utilization (>80%)
+    description: |
+      MariaDB instance {{"`{{ $labels.target }}`"}} has high connection utilization {{"`{{ humanizePercentage $value }}`"}}
+- alert: MariaDBTooManyConnectionsCritical
+  expr: |
+    mysql_global_status_threads_connected{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
+    / mysql_global_variables_max_connections{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0.9
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB instance has high connection utilization (>90%)
+    description: |
+      MariaDB instance {{"`{{ $labels.target }}`"}} has high connection utilization {{"`{{ humanizePercentage $value }}`"}}
+- alert: MariaDBConnectionError
+  expr: |
+    increase(mysql_global_status_connection_errors_total{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}[5m]) > 0
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB instance has connection errors
+    description: |
+      MariaDB instance {{"`{{ $labels.target }}`"}} has {{"`{{ $labels.error }}`"}} connection errors

--- a/deploy/charts/mariadb-cluster/prometheus/generic.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/generic.yaml
@@ -23,7 +23,7 @@
 - alert: MariaDBTooManyConnectionsWarning
   expr: |
     mysql_global_status_threads_connected{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
-    / mysql_global_variables_max_connections{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0.8
+    / mysql_global_variables_max_connections{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0.7
   for: 1m
   labels:
     severity: warning

--- a/deploy/charts/mariadb-cluster/prometheus/replication.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/replication.yaml
@@ -3,7 +3,8 @@
 - alert: MariaDBReplicationNotRunning
   expr: |
     mysql_slave_status_slave_sql_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
-    or mysql_slave_status_slave_io_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
+    or
+    mysql_slave_status_slave_io_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
   for: 1m
   labels:
     severity: critical

--- a/deploy/charts/mariadb-cluster/prometheus/replication.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/replication.yaml
@@ -1,58 +1,43 @@
 # The rules are helm templated, so we must escape labels:
 # {{ $labels.target }} => {{"{{ $labels.target }}"}}
-- alert: MariaDBReplicaSqlThreadNotRunning
+- alert: MariaDBReplicationNotRunning
   expr: |
-    (
-      mysql_slave_status_slave_sql_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
-      and on (target)
-      (mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0)
-    ) == 0
+    mysql_slave_status_slave_sql_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
+    or mysql_slave_status_slave_io_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
   for: 1m
   labels:
     severity: critical
   annotations:
-    summary: MariaDB replica does not have a running SQL replication thread
+    summary: Replication on MariaDB replica is not running
     description: |
-      MariaDB replica {{"`{{ $labels.target }}`"}} does not have a running SQL replication thread
-- alert: MariaDBReplicaIOThreadNotRunning
+      Replication on MariaDB replica {{"`{{ $labels.target }}`"}} is not running
+- alert: MariaDBReplicationLagWarning
   expr: |
-    (
-      mysql_slave_status_slave_io_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
-      and on (target)
-      (mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0)
-    ) == 0
-  for: 1m
-  labels:
-    severity: critical
-  annotations:
-    summary: MariaDB replica does not have a running IO replication thread
-    description: |
-      MariaDB replica {{"`{{ $labels.target }}`"}} does not have a running IO replication thread
-- alert: MariaDBReplicationLag
-  expr: |
-    (
-      (
-        mysql_slave_status_seconds_behind_master{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} - mysql_slave_status_sql_delay{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
-      )
-      and on (target)
-      (
-        mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0
-      )
-    ) > 30
+    mysql_slave_status_seconds_behind_master{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 30
   for: 1m
   labels:
     severity: warning
   annotations:
     summary: MariaDB replica is lagging behind the primary
     description: |
-      MariaDB replica {{"`{{ $labels.target }}`"}} is lagging behind the primary
-- alert: MariaDBReplicaNotConfigured
+      MariaDB replica {{"`{{ $labels.target }}`"}} is lagging {{"`{{ humanizeDuration $value }}`"}} behind the primary
+- alert: MariaDBReplicationLagCritical
   expr: |
-    count(mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}) != {{ sub .Values.mariadb.replicas 1 }}
-  for: 5m
+    mysql_slave_status_seconds_behind_master{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 300
+  for: 1m
   labels:
     severity: critical
   annotations:
-    summary: MariaDB cluster has instance(s) not configured as replicas
+    summary: MariaDB replica is lagging behind the primary
     description: |
-      MariaDB cluster `{{ include "mariadb-cluster.fullname" . }}` has instance(s) not configured as replicas
+      MariaDB replica {{"`{{ $labels.target }}`"}} is lagging {{"`{{ humanizeDuration $value }}`"}} behind the primary
+- alert: MariaDBReplicaMissing
+  expr: |
+    count(mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}) != {{ sub .Values.mariadb.replicas 1 }}
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB cluster is missing replica(s)
+    description: |
+      MariaDB cluster `{{ include "mariadb-cluster.fullname" . }}` is missing replica(s)

--- a/deploy/charts/mariadb-cluster/prometheus/replication.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/replication.yaml
@@ -4,7 +4,7 @@
   expr: |
     (
       mysql_slave_status_slave_sql_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
-      AND ON (target)
+      and on (target)
       (mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0)
     ) == 0
   for: 1m
@@ -18,7 +18,7 @@
   expr: |
     (
       mysql_slave_status_slave_io_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
-      AND ON (target)
+      and on (target)
       (mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0)
     ) == 0
   for: 1m
@@ -34,7 +34,7 @@
       (
         mysql_slave_status_seconds_behind_master{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} - mysql_slave_status_sql_delay{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
       )
-      AND ON (target)
+      and on (target)
       (
         mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0
       )
@@ -46,3 +46,13 @@
     summary: MariaDB replica is lagging behind the primary
     description: |
       MariaDB replica {{"`{{ $labels.target }}`"}} is lagging behind the primary
+- alert: MariaDBReplicaNotConfigured
+  expr: |
+    count(mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}) != {{ sub .Values.mariadb.replicas 1 }}
+  for: 5m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB cluster has instance(s) not configured as replicas
+    description: |
+      MariaDB cluster `{{ include "mariadb-cluster.fullname" . }}` has instance(s) not configured as replicas

--- a/deploy/charts/mariadb-cluster/prometheus/replication.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/replication.yaml
@@ -2,13 +2,47 @@
 # {{ $labels.target }} => {{"{{ $labels.target }}"}}
 - alert: MariaDBReplicaSqlThreadNotRunning
   expr: |
-    mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0
-    and
-    mysql_slave_status_slave_sql_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
+    (
+      mysql_slave_status_slave_sql_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
+      AND ON (target)
+      (mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0)
+    ) == 0
   for: 1m
   labels:
     severity: critical
   annotations:
-    summary: MariaDB replica SQL thread is not running
+    summary: MariaDB replica does not have a running SQL replication thread
     description: |
-      MariaDB replica SQL thread is not running on instance {{"`{{ $labels.target }}`"}}
+      MariaDB replica {{"`{{ $labels.target }}`"}} does not have a running SQL replication thread
+- alert: MariaDBReplicaIOThreadNotRunning
+  expr: |
+    (
+      mysql_slave_status_slave_io_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
+      AND ON (target)
+      (mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0)
+    ) == 0
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB replica does not have a running IO replication thread
+    description: |
+      MariaDB replica {{"`{{ $labels.target }}`"}} does not have a running IO replication thread
+- alert: MariaDBReplicationLag
+  expr: |
+    (
+      (
+        mysql_slave_status_seconds_behind_master{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} - mysql_slave_status_sql_delay{target=~"{{ include "mariadb-cluster.fullname" . }}.*"}
+      )
+      AND ON (target)
+      (
+        mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0
+      )
+    ) > 30
+  for: 1m
+  labels:
+    severity: warning
+  annotations:
+    summary: MariaDB replica is lagging behind the primary
+    description: |
+      MariaDB replica {{"`{{ $labels.target }}`"}} is lagging behind the primary

--- a/deploy/charts/mariadb-cluster/prometheus/replication.yaml
+++ b/deploy/charts/mariadb-cluster/prometheus/replication.yaml
@@ -1,0 +1,14 @@
+# The rules are helm templated, so we must escape labels:
+# {{ $labels.target }} => {{"{{ $labels.target }}"}}
+- alert: MariaDBReplicaSqlThreadNotRunning
+  expr: |
+    mysql_slave_status_master_server_id{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0
+    and
+    mysql_slave_status_slave_sql_running{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
+  for: 1m
+  labels:
+    severity: critical
+  annotations:
+    summary: MariaDB replica SQL thread is not running
+    description: |
+      MariaDB replica SQL thread is not running on instance {{"`{{ $labels.target }}`"}}

--- a/deploy/charts/mariadb-cluster/templates/prometheusrule.yaml
+++ b/deploy/charts/mariadb-cluster/templates/prometheusrule.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "mariadb-cluster.fullname" . }}
+  labels:
+    {{- include "mariadb-cluster.labels" . | nindent 4 }}
+  namespace: {{ default .Release.Namespace .Values.prometheusRule.namespace }}
+spec:
+  groups:
+    - name: {{ include "mariadb-cluster.fullname" . }}
+      rules:
+      {{- range $ruleName, $ruleCfg := .Values.prometheusRule.rules }}
+      {{- if $ruleCfg.enabled }}
+        - alert: {{ $ruleName }}
+        {{- tpl (toYaml $ruleCfg.rule) $ | nindent 10 }}
+      {{- end }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/mariadb-cluster/templates/prometheusrule.yaml
+++ b/deploy/charts/mariadb-cluster/templates/prometheusrule.yaml
@@ -8,12 +8,42 @@ metadata:
   namespace: {{ default .Release.Namespace .Values.prometheusRule.namespace }}
 spec:
   groups:
-    - name: {{ include "mariadb-cluster.fullname" . }}
+  {{- /* template bundled rules */ -}}
+  {{- range $ruleGroup := list "galera" "replication" "generic" }}
+  {{- if and (eq $ruleGroup "galera") (or (not $.Values.mariadb.galera) (not $.Values.mariadb.galera.enabled)) }}
+    {{- /* skip templating galera rules when galera is disabled */ -}}
+  {{- else if and (eq $ruleGroup "replication") (or (not $.Values.mariadb.replication) (not $.Values.mariadb.replication.enabled)) }}
+    {{- /* skip templating replication rules when replication is disabled */ -}}
+  {{- else }}
+    {{- $rulesFile := printf "prometheus/%s.yaml" $ruleGroup }}
+    {{- $rules := $.Files.Get $rulesFile | fromYamlArray }}
+    {{- $rulesToTemplate := list }}
+    {{- range $rule := $rules }}
+      {{- $ruleName := $rule.alert }}
+      {{- $ruleOverrides := get $.Values.prometheusRule.overrides $ruleName }}
+      {{- if $ruleOverrides }}
+        {{- if not $ruleOverrides.disabled }}
+          {{- $ruleWithOverrides := mergeOverwrite $rule $ruleOverrides }}
+          {{- $rulesToTemplate = append $rulesToTemplate $ruleWithOverrides }}
+        {{- end }}
+      {{- else }}
+        {{- $rulesToTemplate = append $rulesToTemplate $rule }}
+      {{- end }}
+    {{- end }}
+    {{- if gt (len $rulesToTemplate) 0 }}
+    - name: {{ include "mariadb-cluster.fullname" $ }}-{{ $ruleGroup }}
       rules:
-      {{- range $ruleName, $ruleCfg := .Values.prometheusRule.rules }}
-      {{- if $ruleCfg.enabled }}
+        {{- tpl (toYaml $rulesToTemplate | nindent 8) $ }}
+    {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- /* template custom rules */ -}}
+  {{- if .Values.prometheusRule.custom }}
+    - name: {{ include "mariadb-cluster.fullname" $ }}-custom
+      rules:
+      {{- range $ruleName, $ruleConfig := .Values.prometheusRule.custom }}
         - alert: {{ $ruleName }}
-        {{- tpl (toYaml $ruleCfg.rule) $ | nindent 10 }}
+          {{- tpl (toYaml $ruleConfig | nindent 10) $ }}
       {{- end }}
-      {{- end }}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/mariadb-cluster/templates/prometheusrule.yaml
+++ b/deploy/charts/mariadb-cluster/templates/prometheusrule.yaml
@@ -39,11 +39,8 @@ spec:
   {{- end }}
   {{- /* template custom rules */ -}}
   {{- if .Values.prometheusRule.custom }}
-    - name: {{ include "mariadb-cluster.fullname" $ }}-custom
+    - name: {{ include "mariadb-cluster.fullname" . }}-custom
       rules:
-      {{- range $ruleName, $ruleConfig := .Values.prometheusRule.custom }}
-        - alert: {{ $ruleName }}
-          {{- tpl (toYaml $ruleConfig | nindent 10) $ }}
-      {{- end }}
+        {{- tpl (toYaml .Values.prometheusRule.custom | nindent 8) . }}
   {{- end }}
 {{- end }}

--- a/deploy/charts/mariadb-cluster/values.yaml
+++ b/deploy/charts/mariadb-cluster/values.yaml
@@ -112,3 +112,19 @@ physicalBackups: []
   #         caSecretKeyRef:
   #           name: minio-ca
   #           key: ca.crt
+# -- PrometheusRule configuration. Escape `{{ $labels }}` to avoid incorrect templating.
+prometheusRule:
+  enabled: false
+  namespace: ""
+  rules:
+    MariaDBDown:
+      enabled: true
+      rule:
+        expr: mysql_up{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: MariaDB instance is down
+          description: |
+            MariaDB instance {{"`{{ $labels.target }}`"}} is down

--- a/deploy/charts/mariadb-cluster/values.yaml
+++ b/deploy/charts/mariadb-cluster/values.yaml
@@ -112,19 +112,26 @@ physicalBackups: []
   #         caSecretKeyRef:
   #           name: minio-ca
   #           key: ca.crt
-# -- PrometheusRule configuration. Escape `{{ $labels }}` to avoid incorrect templating.
+# -- PrometheusRule configuration.
 prometheusRule:
   enabled: false
   namespace: ""
-  rules:
-    MariaDBDown:
-      enabled: true
-      rule:
-        expr: mysql_up{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} == 0
-        for: 1m
-        labels:
-          severity: critical
-        annotations:
-          summary: MariaDB instance is down
-          description: |
-            MariaDB instance {{"`{{ $labels.target }}`"}} is down
+  # -- Disable or tune bundled alerts.
+  overrides: {}
+    # MariaDBDown:
+    #   disabled: true
+    # MariaDBDown:
+    #   for: 3m
+    #   labels:
+    #     severity: warning
+  # -- Declare your own custom alerts.
+  custom: {}
+    # MariaDBNotOk:
+    #   expr: mysql_arbitrary_metric{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0
+    #   for: 5m
+    #   labels:
+    #     severity: warning
+    #   annotations:
+    #     summary: MariaDB instance is not ok
+    #     description: |
+    #       MariaDB instance {{"`{{ $labels.target }}`"}} is not ok

--- a/deploy/charts/mariadb-cluster/values.yaml
+++ b/deploy/charts/mariadb-cluster/values.yaml
@@ -125,8 +125,8 @@ prometheusRule:
     #   labels:
     #     severity: warning
   # -- Declare your own custom alerts.
-  custom: {}
-    # MariaDBNotOk:
+  custom: []
+    # - alert: MariaDBNotOk
     #   expr: mysql_arbitrary_metric{target=~"{{ include "mariadb-cluster.fullname" . }}.*"} > 0
     #   for: 5m
     #   labels:

--- a/deploy/charts/mariadb-cluster/values.yaml
+++ b/deploy/charts/mariadb-cluster/values.yaml
@@ -120,10 +120,10 @@ prometheusRule:
   overrides: {}
     # MariaDBDown:
     #   disabled: true
-    # MariaDBDown:
+    # MariaDBSlowQueries:
     #   for: 3m
     #   labels:
-    #     severity: warning
+    #     severity: critical
   # -- Declare your own custom alerts.
   custom: []
     # - alert: MariaDBNotOk


### PR DESCRIPTION
I believe it will be convenient to have several basic fully customizable cluster-scoped prometheus alerts in `mariadb-cluster` with an easy way to add custom ones. 

**TO DO:**
- [x] create templating for bundled rules with optional overrides
- [x] create templating for custom rules
- [ ] find good useful alerts (generic, replication and galera)
- [ ] add tests