### PR TITLE
Fixed Galera failover

### DIFF
--- a/internal/controller/mariadb_controller_update.go
+++ b/internal/controller/mariadb_controller_update.go
@@ -326,7 +326,7 @@ func (r *MariaDBReconciler) triggerSwitchover(ctx context.Context, mariadb *mari
 	}
 
 	fromIndex := mariadb.Status.CurrentPrimaryPodIndex
-	toIndex, err := health.HealthyMariaDBReplica(ctx, r.Client, mariadb)
+	toIndex, err := health.HealthyReplicationIndex(ctx, r.Client, mariadb)
 	if err != nil {
 		return fmt.Errorf("error getting healthy replica: %v", err)
 	}

--- a/internal/controller/pod_galera_controller.go
+++ b/internal/controller/pod_galera_controller.go
@@ -95,7 +95,7 @@ func (r *PodGaleraController) ReconcilePodNotReady(ctx context.Context, pod core
 	}
 
 	fromIndex := mariadb.Status.CurrentPrimaryPodIndex
-	toIndex, err := health.HealthyMariaDBReplica(ctx, r, mariadb)
+	toIndex, err := health.HealthyIndex(ctx, r, mariadb)
 	if err != nil {
 		return fmt.Errorf("error getting healthy replica: %v", err)
 	}

--- a/internal/controller/pod_replication_controller.go
+++ b/internal/controller/pod_replication_controller.go
@@ -113,7 +113,7 @@ func (r *PodReplicationController) ReconcilePodNotReady(ctx context.Context, pod
 	}
 
 	fromIndex := mariadb.Status.CurrentPrimaryPodIndex
-	toIndex, err := health.HealthyMariaDBReplica(ctx, r, mariadb)
+	toIndex, err := health.HealthyReplicationIndex(ctx, r, mariadb)
 	if err != nil {
 		return fmt.Errorf("error getting healthy replica: %v", err)
 	}


### PR DESCRIPTION
When Galera primary `Pod` goes down, the operator does not switch writes to a healthy `Pod`.

A regression has been introduced in https://github.com/mariadb-operator/mariadb-operator/pull/1287, fixed in the current PR.