### PR TITLE
Lower grant reconcile time

### DIFF
--- a/internal/controller/grant_controller.go
+++ b/internal/controller/grant_controller.go
@@ -116,10 +116,12 @@ func (wr *wrappedGrantReconciler) Reconcile(ctx context.Context, mdbClient *sqlC
 		return fmt.Errorf("error granting privileges in MariaDB: %v", err)
 	}
 
-	if err := wr.patchStatusWithFunc(ctx, func(status *mariadbv1alpha1.GrantStatus) {
-		wr.grant.Status.CurrentPrivileges = wr.grant.Spec.Privileges
-	}); err != nil {
-		return fmt.Errorf("error patching current privileges: %v", err)
+	if !slices.Equal(wr.grant.Status.CurrentPrivileges, wr.grant.Spec.Privileges) {
+		if err := wr.patchStatusWithFunc(ctx, func(status *mariadbv1alpha1.GrantStatus) {
+			wr.grant.Status.CurrentPrivileges = wr.grant.Spec.Privileges
+		}); err != nil {
+			return fmt.Errorf("error patching current privileges: %v", err)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
I believe the changes introduced in https://github.com/mariadb-operator/mariadb-operator/pull/1326 inadvertently negatively affected Grant reconcile time.

<img width="1808" height="728" alt="image" src="https://github.com/user-attachments/assets/96fec3f3-b851-4fda-826f-f98ae9e95ad1" />

I think it is due to unconditional patching of the status. Perhaps if we skip patch when it is not required, we can avoid extra api requests and latency undesirable at scale. 