### PR TITLE
Fix `PhysicalBackups` based on `VolumeSnapshots` to be synchronous and consistent

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -71,9 +71,10 @@ var (
 	kubeApiQps   float32
 	kubeApiBurst int
 
-	maxConcurrentReconciles         int
-	mariadbMaxConcurrentReconciles  int
-	maxscaleMaxConcurrentReconciles int
+	maxConcurrentReconciles               int
+	mariadbMaxConcurrentReconciles        int
+	maxscaleMaxConcurrentReconciles       int
+	physicalBackupMaxConcurrentReconciles int
 
 	requeueConnection time.Duration
 	requeueSql        time.Duration
@@ -124,6 +125,8 @@ func init() {
 		"Maximum number of concurrent reconciles per MariaDB.")
 	rootCmd.Flags().IntVar(&maxscaleMaxConcurrentReconciles, "maxscale-max-concurrent-reconciles", 10,
 		"Maximum number of concurrent reconciles per MaxScale.")
+	rootCmd.Flags().IntVar(&physicalBackupMaxConcurrentReconciles, "physicalbackup-max-concurrent-reconciles", 10,
+		"Maximum number of concurrent reconciles per PhysicalBackups.")
 
 	rootCmd.Flags().DurationVar(&requeueConnection, "requeue-connection", 1*time.Hour, "The interval at which Connections are requeued.")
 	rootCmd.Flags().DurationVar(&requeueSql, "requeue-sql", 10*time.Hour, "The interval at which SQL objects are requeued.")
@@ -408,7 +411,7 @@ var rootCmd = &cobra.Command{
 			RBACReconciler:    rbacReconciler,
 			PVCReconciler:     pvcReconciler,
 			BackupProcessor:   backupProcessor,
-		}).SetupWithManager(ctx, mgr); err != nil {
+		}).SetupWithManager(ctx, mgr, ctrlcontroller.Options{MaxConcurrentReconciles: physicalBackupMaxConcurrentReconciles}); err != nil {
 			setupLog.Error(err, "Unable to create controller", "controller", "PhysicalBackup")
 			os.Exit(1)
 		}

--- a/docs/physical_backup.md
+++ b/docs/physical_backup.md
@@ -414,10 +414,10 @@ The operator is capable of creating [`VolumeSnapshot` resources](https://kuberne
 Most of the fields described in this documentation apply to `VolumeSnapshots`, including scheduling, retention policy, and compression. The main difference with the `mariadb-backup` based backups is that the operator will not create a `Job` to perform the backup, but instead it will create a `VolumeSnapshot` resource directly.
 
 In order to create consistent, point-in-time snapshots of the `MariaDB` data, the operator will perform the following steps:
-1. Temporarily pause the `MariaDB` writes by executing a `FLUSH TABLES WITH READ LOCK` command on the `MariaDB` primary `Pod`.
+1. Temporarily pause the `MariaDB` writes by executing a `FLUSH TABLES WITH READ LOCK` command in one of the secondary `Pods`.
 2. Create a `VolumeSnapshot` resource of the data PVC mounted by the `MariaDB` primary `Pod`.
 3. Wait until the `VolumeSnapshot` resources becomes ready. When timing out, the operator will delete the `VolumeSnapshot` resource and retry the operation.
-4. Release the `MariaDB` writes by executing an `UNLOCK TABLES` command on the `MariaDB` primary `Pod`.
+4. Issue a `UNLOCK TABLE` statement.
 
 ## Important considerations and limitations
 

--- a/internal/controller/mariadb_controller_update.go
+++ b/internal/controller/mariadb_controller_update.go
@@ -326,7 +326,7 @@ func (r *MariaDBReconciler) triggerSwitchover(ctx context.Context, mariadb *mari
 	}
 
 	fromIndex := mariadb.Status.CurrentPrimaryPodIndex
-	toIndex, err := health.HealthyReplicationIndex(ctx, r.Client, mariadb)
+	toIndex, err := health.ReplicaPodHealthyIndex(ctx, r.Client, mariadb)
 	if err != nil {
 		return fmt.Errorf("error getting healthy replica: %v", err)
 	}

--- a/internal/controller/physicalbackup_controller.go
+++ b/internal/controller/physicalbackup_controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 )
 
 // PhysicalBackupReconciler reconciles a PhysicalBackup object
@@ -176,12 +177,13 @@ func (r *PhysicalBackupReconciler) patchStatus(ctx context.Context, backup *mari
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *PhysicalBackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) error {
+func (r *PhysicalBackupReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, opts controller.Options) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&mariadbv1alpha1.PhysicalBackup{}).
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.ServiceAccount{}).
-		Owns(&corev1.PersistentVolumeClaim{})
+		Owns(&corev1.PersistentVolumeClaim{}).
+		WithOptions(opts)
 	if err := r.indexJobs(ctx, mgr); err != nil {
 		return fmt.Errorf("error indexing PhysicalBackup Jobs: %v", err)
 	}

--- a/internal/controller/pod_galera_controller.go
+++ b/internal/controller/pod_galera_controller.go
@@ -95,7 +95,7 @@ func (r *PodGaleraController) ReconcilePodNotReady(ctx context.Context, pod core
 	}
 
 	fromIndex := mariadb.Status.CurrentPrimaryPodIndex
-	toIndex, err := health.HealthyIndex(ctx, r, mariadb)
+	toIndex, err := health.SecondaryPodHealthyIndex(ctx, r, mariadb)
 	if err != nil {
 		return fmt.Errorf("error getting healthy replica: %v", err)
 	}

--- a/internal/controller/pod_replication_controller.go
+++ b/internal/controller/pod_replication_controller.go
@@ -113,7 +113,7 @@ func (r *PodReplicationController) ReconcilePodNotReady(ctx context.Context, pod
 	}
 
 	fromIndex := mariadb.Status.CurrentPrimaryPodIndex
-	toIndex, err := health.HealthyReplicationIndex(ctx, r, mariadb)
+	toIndex, err := health.ReplicaPodHealthyIndex(ctx, r, mariadb)
 	if err != nil {
 		return fmt.Errorf("error getting healthy replica: %v", err)
 	}

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -277,7 +277,7 @@ var _ = BeforeSuite(func() {
 		RBACReconciler:    rbacReconciler,
 		PVCReconciler:     pvcReconciler,
 		BackupProcessor:   backupProcessor,
-	}).SetupWithManager(testCtx, k8sManager)
+	}).SetupWithManager(testCtx, k8sManager, ctrlcontroller.Options{MaxConcurrentReconciles: 10})
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&RestoreReconciler{

--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -182,7 +182,7 @@ func (b *Builder) BuildPhysicalBackupJob(key types.NamespacedName, backup *maria
 	if err != nil {
 		return nil, fmt.Errorf("error building backup command: %v", err)
 	}
-	backupCmd, err := cmd.MariadbBackup(mariadb, backupFilepath)
+	backupCmd, err := cmd.MariadbBackup(mariadb, backupFilepath, *podIndex)
 	if err != nil {
 		return nil, fmt.Errorf("error getting mariadb-backup command: %v", err)
 	}

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -34,7 +34,23 @@ func NewBashCommand(args []string) *Command {
 	}
 }
 
-func ConnectionFlags(co *CommandOpts, mariadb *mariadbv1alpha1.MariaDB) (string, error) {
+type ConnectionFlagsOpts struct {
+	Host string
+}
+
+type ConnectionFlagOpt func(*ConnectionFlagsOpts)
+
+func WithHostConnectionFlag(host string) ConnectionFlagOpt {
+	return func(o *ConnectionFlagsOpts) {
+		o.Host = host
+	}
+}
+
+func ConnectionFlags(co *CommandOpts, mariadb *mariadbv1alpha1.MariaDB, connectionFlagOpts ...ConnectionFlagOpt) (string, error) {
+	opts := &ConnectionFlagsOpts{}
+	for _, setOpt := range connectionFlagOpts {
+		setOpt(opts)
+	}
 	if co.UserEnv == "" {
 		return "", errors.New("UserEnv must be set")
 	}
@@ -46,7 +62,7 @@ func ConnectionFlags(co *CommandOpts, mariadb *mariadbv1alpha1.MariaDB) (string,
 		"--user=${%s} --password=${%s} --host=%s --port=%d",
 		co.UserEnv,
 		co.PasswordEnv,
-		host(mariadb),
+		host(mariadb, opts),
 		mariadb.Spec.Port,
 	)
 	if co.Database != nil {
@@ -55,7 +71,10 @@ func ConnectionFlags(co *CommandOpts, mariadb *mariadbv1alpha1.MariaDB) (string,
 	return flags, nil
 }
 
-func host(mariadb *mariadbv1alpha1.MariaDB) string {
+func host(mariadb *mariadbv1alpha1.MariaDB, opts *ConnectionFlagsOpts) string {
+	if opts.Host != "" {
+		return opts.Host
+	}
 	if mariadb.IsHAEnabled() {
 		return statefulset.ServiceFQDNWithService(
 			mariadb.ObjectMeta,

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -1,0 +1,123 @@
+package command
+
+import (
+	"errors"
+	"testing"
+
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v25/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestConnectionFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		opts     *CommandOpts
+		mariadb  *mariadbv1alpha1.MariaDB
+		flagOpts []ConnectionFlagOpt
+		want     string
+		wantErr  error
+	}{
+		{
+			name:    "missing UserEnv",
+			opts:    &CommandOpts{PasswordEnv: "PASS"},
+			mariadb: &mariadbv1alpha1.MariaDB{},
+			wantErr: errors.New("UserEnv must be set"),
+		},
+		{
+			name: "missing PasswordEnv",
+			opts: &CommandOpts{UserEnv: "USER"},
+			mariadb: &mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+			},
+			wantErr: errors.New("PasswordEnv must be set"),
+		},
+		{
+			name: "basic flags with standalone",
+			opts: &CommandOpts{UserEnv: "USER", PasswordEnv: "PASS"},
+			mariadb: &mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+				},
+			},
+			want: "--user=${USER} --password=${PASS} --host=test.default.svc.cluster.local --port=3306",
+		},
+		{
+			name: "basic flags with Galera",
+			opts: &CommandOpts{UserEnv: "USER", PasswordEnv: "PASS"},
+			mariadb: &mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+					Galera: &mariadbv1alpha1.Galera{
+						Enabled: true,
+					},
+				},
+			},
+			want: "--user=${USER} --password=${PASS} --host=test-primary.default.svc.cluster.local --port=3306",
+		},
+		{
+			name: "with database",
+			opts: &CommandOpts{UserEnv: "USER", PasswordEnv: "PASS", Database: ptr.To("test")},
+			mariadb: &mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+					Galera: &mariadbv1alpha1.Galera{
+						Enabled: true,
+					},
+				},
+			},
+			want: "--user=${USER} --password=${PASS} --host=test-primary.default.svc.cluster.local --port=3306 --database=test",
+		},
+		{
+			name: "with host override",
+			opts: &CommandOpts{UserEnv: "USER", PasswordEnv: "PASS"},
+			mariadb: &mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+					Galera: &mariadbv1alpha1.Galera{
+						Enabled: true,
+					},
+				},
+			},
+			flagOpts: []ConnectionFlagOpt{WithHostConnectionFlag("custom-host")},
+			want:     "--user=${USER} --password=${PASS} --host=custom-host --port=3306",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ConnectionFlags(tt.opts, tt.mariadb, tt.flagOpts...)
+			if tt.wantErr != nil {
+				if err == nil || err.Error() != tt.wantErr.Error() {
+					t.Errorf("expected error %v, got %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -120,19 +120,19 @@ func IsStatefulSetHealthy(ctx context.Context, client ctrlclient.Client, service
 	return false, nil
 }
 
-func HealthyIndex(ctx context.Context, client ctrlclient.Client, mariadb *mariadbv1alpha1.MariaDB) (*int, error) {
-	return healthyPodIndex(ctx, client, mariadb, func(p *corev1.Pod) bool {
+func SecondaryPodHealthyIndex(ctx context.Context, client ctrlclient.Client, mariadb *mariadbv1alpha1.MariaDB) (*int, error) {
+	return secondaryPodHealthyIndex(ctx, client, mariadb, func(p *corev1.Pod) bool {
 		return pod.PodReady(p)
 	})
 }
 
-func HealthyReplicationIndex(ctx context.Context, client ctrlclient.Client, mariadb *mariadbv1alpha1.MariaDB) (*int, error) {
-	return healthyPodIndex(ctx, client, mariadb, func(p *corev1.Pod) bool {
+func ReplicaPodHealthyIndex(ctx context.Context, client ctrlclient.Client, mariadb *mariadbv1alpha1.MariaDB) (*int, error) {
+	return secondaryPodHealthyIndex(ctx, client, mariadb, func(p *corev1.Pod) bool {
 		return pod.PodReady(p) && mariadb.IsConfiguredReplica(p.Name)
 	})
 }
 
-func healthyPodIndex(ctx context.Context, client ctrlclient.Client, mariadb *mariadbv1alpha1.MariaDB,
+func secondaryPodHealthyIndex(ctx context.Context, client ctrlclient.Client, mariadb *mariadbv1alpha1.MariaDB,
 	isHealthy func(*corev1.Pod) bool) (*int, error) {
 	if mariadb.Status.CurrentPrimaryPodIndex == nil {
 		return nil, errors.New("'status.currentPrimaryPodIndex' must be set")


### PR DESCRIPTION
Currently, when a `PhysicalBackup` based on `VolumeSnapshots` is scheduled, the following steps are followed:
1. Lock database for consistency reasons
2. Create a `VolumeSnapshot` object (fire and forget)
3. Unlock the database

The approach to create the snapshot is fire and forget, not waiting for the CSI driver to complete the snapshot, therefore this could lead to inconsistencies as the database is processing transactions while the `VolumeSnapshot` is in progress. We should introduce a step between 2. and 3. to wait for the `VolumeSnapshot` to be finished.