### PR TITLE
Add appProtocol to mariadb service ports

### DIFF
--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -614,16 +614,21 @@ func (r *MariaDBReconciler) reconcileInternalService(ctx context.Context, mariad
 		agent := ptr.Deref(mariadb.Spec.Galera, mariadbv1alpha1.Galera{}).Agent
 		ports = append(ports, []corev1.ServicePort{
 			{
-				Name: galeraresources.GaleraClusterPortName,
-				Port: galeraresources.GaleraClusterPort,
+				// App protocol is a fix for istio to recognize protocol before attempting MariaDB Galera cluster Pod-to-Pod communication.
+				// See: https://github.com/istio/istio/issues/38655#issuecomment-1169819447
+				Name:        galeraresources.GaleraClusterPortName,
+				Port:        galeraresources.GaleraClusterPort,
+				AppProtocol: ptr.To[string](galeraresources.MysqlAppProtocol),
 			},
 			{
-				Name: galeraresources.GaleraISTPortName,
-				Port: galeraresources.GaleraISTPort,
+				Name:        galeraresources.GaleraISTPortName,
+				Port:        galeraresources.GaleraISTPort,
+				AppProtocol: ptr.To[string](galeraresources.MysqlAppProtocol),
 			},
 			{
-				Name: galeraresources.GaleraSSTPortName,
-				Port: galeraresources.GaleraSSTPort,
+				Name:        galeraresources.GaleraSSTPortName,
+				Port:        galeraresources.GaleraSSTPort,
+				AppProtocol: ptr.To[string](galeraresources.MysqlAppProtocol),
 			},
 			{
 				Name: galeraresources.AgentPortName,

--- a/pkg/controller/galera/resources/resources.go
+++ b/pkg/controller/galera/resources/resources.go
@@ -7,6 +7,8 @@ var (
 	AgentAuthVolume      = "agent-auth"
 	AgentAuthVolumeMount = "/var/run/secrets/mariadb-operator/agent"
 
+	MysqlAppProtocol = "mysql"
+
 	GaleraSSTPortName     = "sst"
 	GaleraSSTPort         = int32(4444)
 	GaleraClusterPortName = "cluster"


### PR DESCRIPTION
Fixing https://github.com/mariadb-operator/mariadb-operator/issues/1374

Turned out to be a very simple fix. I think no test changes are required, since no additional functionality is implemented.