### PR TITLE
Set storage  mount subPath in `PhysicalBackup`

### DIFF
--- a/pkg/builder/batch_container_builder.go
+++ b/pkg/builder/batch_container_builder.go
@@ -97,10 +97,7 @@ func jobPhysicalBackupVolumes(storageVolume mariadbv1alpha1.StorageVolumeSource,
 			},
 		},
 	})
-	volumeMounts = append(volumeMounts, corev1.VolumeMount{
-		Name:      StorageVolume,
-		MountPath: MariadbStorageMountPath,
-	})
+	volumeMounts = append(volumeMounts, mariadbStorageVolumeMount(mariadb))
 
 	return volumes, volumeMounts
 }

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -490,13 +490,14 @@ func mariadbVolumeMounts(mariadb *mariadbv1alpha1.MariaDB, opts ...mariadbPodOpt
 			Name:      ConfigVolume,
 			MountPath: MariadbConfigMountPath,
 		},
-		mariadbStorageVolumeMount(mariadb),
 	}
 
 	if mariadb.IsTLSEnabled() {
 		_, tlsVolumeMounts := mariadbTLSVolumes(mariadb)
 		volumeMounts = append(volumeMounts, tlsVolumeMounts...)
 	}
+
+	volumeMounts = append(volumeMounts, mariadbStorageVolumeMount(mariadb))
 
 	if mariadb.Replication().Enabled && ptr.Deref(mariadb.Replication().ProbesEnabled, false) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{


### PR DESCRIPTION
Close https://github.com/mariadb-operator/mariadb-operator/issues/1386

When setting `galera.config.reuseStorageVolume=true` in Galera, the `volumeMount.subPath` is not properly set in the recently introduced `PhysicalBackup` storage volume, resulting in the `mariadb-backup` failing, as it is mapping `/var/lib/mysql` to an empty folder.

This PR addresses this issue by abstracting the storage volume mount in a single function, shared between the `MariaDB` and `PhysicalBackup` CRs.
