### PR TITLE
fix: Install golangci-lint as recommended.

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -80,7 +80,7 @@ $(GINKGO): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(LOCALBIN) $(GOLANGCI_LINT_VERSION)
 
 .PHONY: goreleaser
 goreleaser: $(GORELEASER) ## Download goreleaser locally if necessary.


### PR DESCRIPTION
Official docs: https://golangci-lint.run/docs/welcome/install/#local-installation

Before we were installing it with go install, which respects what is present in the `go.mod` of the target project, hence building golangci-lint with 1.24.5, which results in:

❯ make lint
GOBIN=/home/martin/go/src/github.com/mariadb-operator/mariadb-operator/bin go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.4.0 /home/martin/go/src/github.com/mariadb-operator/mariadb-operator/bin/golangci-lint run Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.1) The command is terminated due to an error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.1) make: *** [make/dev.mk:67: lint] Error 3

Difference in installation:
❯ /home/stef/projects/mariadb-operator/bin/golangci-lint version golangci-lint has version 2.4.0 built with go1.24.5 from (unknown, modified: ?, mod sum: "h1:qz6O6vr7kVzXJqyvHjHSz5fA3D+PM8v96QU5gxZCNWM=") on (unknown) mariadb-operator git:main
❯ golangci-lint version
golangci-lint has version 2.4.0 built with go1.25.0 from 43d03392 on 2025-08-13T23:36:29Z