### PR TITLE
Optimize locking for `VolumeSnapshots`

### DIFF
--- a/examples/manifests/mariadb.yaml
+++ b/examples/manifests/mariadb.yaml
@@ -32,15 +32,15 @@ spec:
     default_storage_engine=InnoDB
     binlog_format=row
     innodb_autoinc_lock_mode=2
-    innodb_buffer_pool_size=1024M
+    innodb_buffer_pool_size=1600M
     max_allowed_packet=256M
 
   resources:
     requests:
-      cpu: 100m
+      cpu: 300m
       memory: 128Mi
     limits:
-      memory: 1Gi
+      memory: 2Gi
 
   metrics:
     enabled: true

--- a/hack/manifests/sysbench/standalone/sql/user.yaml
+++ b/hack/manifests/sysbench/standalone/sql/user.yaml
@@ -8,7 +8,5 @@ spec:
   passwordSecretKeyRef:
     name: mariadb
     key: password
-  require:
-    x509: true
   host: "%"
   maxUserConnections: 1000000000

--- a/hack/manifests/sysbench/standalone/sysbench-prepare_job.yaml
+++ b/hack/manifests/sysbench/standalone/sysbench-prepare_job.yaml
@@ -8,7 +8,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: sysbench-prepare
-        image: zyclonite/sysbench:1.0.21
+        image: severalnines/sysbench
         command:
           - sysbench
           - oltp_read_write
@@ -19,13 +19,7 @@ spec:
           - --mysql-user=sbtest
           - --mysql-password=MariaDB11!
           - --mysql-db=sbtest
-          - --mysql-ssl=on
-          - --mysql-ssl-cipher=AES256
           - prepare
-        volumeMounts:
-          - name: pki
-            mountPath: /etc/pki
-            readOnly: true
         workingDir: /etc/pki
         resources:
           requests:
@@ -33,19 +27,3 @@ spec:
             memory: 128Mi
           limits:
             memory: 512Mi
-      volumes:
-        - name: pki
-          projected:
-            sources:
-              - secret:
-                  name: mariadb-ca-bundle
-                  items:
-                    - key: ca.crt
-                      path: cacert.pem
-              - secret:
-                  name: mariadb-client-cert
-                  items:
-                    - key: tls.crt
-                      path: client-cert.pem
-                    - key: tls.key
-                      path: client-key.pem

--- a/hack/manifests/sysbench/standalone/sysbench_cronjob.yaml
+++ b/hack/manifests/sysbench/standalone/sysbench_cronjob.yaml
@@ -12,7 +12,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: sysbench-prepare
-            image: zyclonite/sysbench:1.0.21
+            image: severalnines/sysbench
             command:
               - sysbench
               - oltp_read_write
@@ -23,16 +23,10 @@ spec:
               - --mysql-user=sbtest
               - --mysql-password=MariaDB11!
               - --mysql-db=sbtest
-              - --mysql-ssl=on
-              - --mysql-ssl-cipher=AES256
               - --time=300 
               - --threads=64
               - --report-interval=1
               - run
-            volumeMounts:
-              - name: pki
-                mountPath: /etc/pki
-                readOnly: true
             workingDir: /etc/pki
             resources:
               requests:
@@ -40,19 +34,3 @@ spec:
                 memory: 128Mi
               limits:
                 memory: 512Mi
-          volumes:
-            - name: pki
-              projected:
-                sources:
-                  - secret:
-                      name: mariadb-ca-bundle
-                      items:
-                        - key: ca.crt
-                          path: cacert.pem
-                  - secret:
-                      name: mariadb-client-cert
-                      items:
-                        - key: tls.crt
-                          path: client-cert.pem
-                        - key: tls.key
-                          path: client-key.pem

--- a/internal/controller/physicalbackup_controller_snapshot.go
+++ b/internal/controller/physicalbackup_controller_snapshot.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/metadata"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/predicate"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/sql"
-	"github.com/mariadb-operator/mariadb-operator/v25/pkg/volumesnapshot"
 	mdbsnapshot "github.com/mariadb-operator/mariadb-operator/v25/pkg/volumesnapshot"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/wait"
 	"github.com/robfig/cron/v3"
@@ -137,7 +136,7 @@ func (r *PhysicalBackupReconciler) reconcileSnapshotStatus(ctx context.Context, 
 				logger.Info("error patching status", "err", err)
 			}
 			return nil
-		} else if volumesnapshot.IsVolumeSnapshotReady(&snapshot) {
+		} else if mdbsnapshot.IsVolumeSnapshotReady(&snapshot) {
 			numReady++
 		}
 	}

--- a/pkg/volumesnapshot/volumesnapshot.go
+++ b/pkg/volumesnapshot/volumesnapshot.go
@@ -48,8 +48,22 @@ func ListReadyVolumeSnapshots(ctx context.Context, client ctrlclient.Client,
 	}, nil
 }
 
+// IsVolumeSnapshotProvisioned determines whether a VolumeSnapshot has been provisioned by the storage system
+func IsVolumeSnapshotProvisioned(snapshot *volumesnapshotv1.VolumeSnapshot) bool {
+	status := ptr.Deref(snapshot.Status, volumesnapshotv1.VolumeSnapshotStatus{})
+	boundVolumeSnapshotContentName := ptr.Deref(status.BoundVolumeSnapshotContentName, "")
+
+	if boundVolumeSnapshotContentName == "" {
+		return false
+	}
+	return status.CreationTime != nil && status.Error == nil
+}
+
 // IsVolumeSnapshotReady determines whether a VolumeSnapshot is ready.
 func IsVolumeSnapshotReady(snapshot *volumesnapshotv1.VolumeSnapshot) bool {
+	if !IsVolumeSnapshotProvisioned(snapshot) {
+		return false
+	}
 	status := ptr.Deref(snapshot.Status, volumesnapshotv1.VolumeSnapshotStatus{})
 	ready := ptr.Deref(status.ReadyToUse, false)
 

--- a/pkg/volumesnapshot/volumesnapshot_test.go
+++ b/pkg/volumesnapshot/volumesnapshot_test.go
@@ -1,0 +1,129 @@
+package volumesnapshot
+
+import (
+	"testing"
+	"time"
+
+	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestIsVolumeSnapshotProvisioned(t *testing.T) {
+	now := metav1.Time{Time: time.Now()}
+	cases := []struct {
+		name string
+		snap *volumesnapshotv1.VolumeSnapshot
+		want bool
+	}{
+		{
+			name: "nil status",
+			snap: &volumesnapshotv1.VolumeSnapshot{},
+			want: false,
+		},
+		{
+			name: "bound empty",
+			snap: &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{},
+			},
+			want: false,
+		},
+		{
+			name: "bound present but creationTime nil",
+			snap: &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
+					BoundVolumeSnapshotContentName: ptr.To("bvs-1"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "bound and creationTime present, no error",
+			snap: &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
+					BoundVolumeSnapshotContentName: ptr.To("bvs-2"),
+					CreationTime:                   &now,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "bound and creationTime present, but error present",
+			snap: &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
+					BoundVolumeSnapshotContentName: ptr.To("bvs-3"),
+					CreationTime:                   &now,
+					Error:                          &volumesnapshotv1.VolumeSnapshotError{Message: ptr.To("boom")},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := IsVolumeSnapshotProvisioned(c.snap)
+			if got != c.want {
+				t.Fatalf("IsVolumeSnapshotProvisioned(%s) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}
+
+func TestIsVolumeSnapshotReady(t *testing.T) {
+	now := metav1.Time{Time: time.Now()}
+	cases := []struct {
+		name string
+		snap *volumesnapshotv1.VolumeSnapshot
+		want bool
+	}{
+		{
+			name: "not provisioned",
+			snap: &volumesnapshotv1.VolumeSnapshot{},
+			want: false,
+		},
+		{
+			name: "provisioned but not ready",
+			snap: &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
+					BoundVolumeSnapshotContentName: ptr.To("bvs-4"),
+					CreationTime:                   &now,
+					ReadyToUse:                     ptr.To(false),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "provisioned and ready",
+			snap: &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
+					BoundVolumeSnapshotContentName: ptr.To("bvs-5"),
+					CreationTime:                   &now,
+					ReadyToUse:                     ptr.To(true),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "provisioned and ready but error present",
+			snap: &volumesnapshotv1.VolumeSnapshot{
+				Status: &volumesnapshotv1.VolumeSnapshotStatus{
+					BoundVolumeSnapshotContentName: ptr.To("bvs-6"),
+					CreationTime:                   &now,
+					ReadyToUse:                     ptr.To(true),
+					Error:                          &volumesnapshotv1.VolumeSnapshotError{Message: ptr.To("err")},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := IsVolumeSnapshotReady(c.snap)
+			if got != c.want {
+				t.Fatalf("IsVolumeSnapshotReady(%s) = %v, want %v", c.name, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently, when performing a volume snapshot, the operator waits until the `VolumeSnapshot` is fully replicated to the backing storage. In this case, the lock can be removed just after the `VolumeSnapshot` has been provisioned by the storage system, and there is no need to wait until the whole data gets asynchronously replicated, as it could take a long time and therefore lead to contention.

When bootstrapping a new cluster from a `VolumeSnapshot`, we should wait until the data is replicated i.e. `VolumeSnapshot` ready to use, as the PVCs will not be able to be provisioned.