### PR TITLE
Refactor/async replication refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
+  pull_request: {}
 
 env:
   GOLANGCI_VERSION: "v2.4.0"

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ pprof.out
 
 # Nvim config
 .nvim.lua
+
+.envrc

--- a/api/v1alpha1/mariadb_keys.go
+++ b/api/v1alpha1/mariadb_keys.go
@@ -248,13 +248,26 @@ func (m *MariaDB) MetricsConfigSecretKeyRef() GeneratedSecretKeyRef {
 	}
 }
 
-// ConfigMapKeySelector defines the key selector for the ConfigMap used for replication healthchecks.
+// ReplConfigMapKeyRef defines the key selector for the ConfigMap used for replication healthchecks.
 func (m *MariaDB) ReplConfigMapKeyRef() ConfigMapKeySelector {
 	return ConfigMapKeySelector{
 		LocalObjectReference: LocalObjectReference{
 			Name: fmt.Sprintf("%s-probes", m.Name),
 		},
 		Key: "replication.sh",
+	}
+}
+
+// ReplPasswordSecretKeyRef defines the key selector for for the password to be used by the replication "repl" user
+func (m *MariaDB) ReplPasswordSecretKeyRef() *GeneratedSecretKeyRef {
+	return &GeneratedSecretKeyRef{
+		SecretKeySelector: SecretKeySelector{
+			LocalObjectReference: LocalObjectReference{
+				Name: fmt.Sprintf("repl-password-%s", m.Name),
+			},
+			Key: "password",
+		},
+		Generate: true,
 	}
 }
 

--- a/api/v1alpha1/mariadb_keys.go
+++ b/api/v1alpha1/mariadb_keys.go
@@ -314,6 +314,22 @@ func (m *MariaDB) MariadbSysGrantKey() types.NamespacedName {
 	}
 }
 
+// MariadbReplUserKey defines the key for the 'repl' User resource.
+func (m *MariaDB) MariadbReplUserKey() types.NamespacedName {
+	return types.NamespacedName{
+		Name:      fmt.Sprintf("%s-mariadb-repl", m.Name),
+		Namespace: m.Namespace,
+	}
+}
+
+// MariadbReplGrantKey defines the key for the 'repl' Grant resource.
+func (m *MariaDB) MariadbReplGrantKey() types.NamespacedName {
+	return types.NamespacedName{
+		Name:      fmt.Sprintf("%s-mariadb-repl-replication", m.Name),
+		Namespace: m.Namespace,
+	}
+}
+
 // MariadbDatabaseKey defines the key for the initial database
 func (m *MariaDB) MariadbDatabaseKey() types.NamespacedName {
 	return types.NamespacedName{

--- a/api/v1alpha1/mariadb_replication_types.go
+++ b/api/v1alpha1/mariadb_replication_types.go
@@ -94,9 +94,9 @@ type PrimaryReplication struct {
 	AutomaticFailoverDelay *metav1.Duration `json:"automaticFailoverDelay,omitempty"`
 }
 
-// FillWithDefaults fills the current PrimaryReplication object with DefaultReplicationSpec.
+// SetDefaults fills the current PrimaryReplication object with DefaultReplicationSpec.
 // This enables having minimal PrimaryReplication objects and provides sensible defaults.
-func (r *PrimaryReplication) FillWithDefaults() {
+func (r *PrimaryReplication) SetDefaults() {
 	if r.PodIndex == nil {
 		index := *DefaultReplicationSpec.Primary.PodIndex
 		r.PodIndex = &index
@@ -144,9 +144,9 @@ type ReplicaReplication struct {
 	SyncTimeout *metav1.Duration `json:"syncTimeout,omitempty"`
 }
 
-// FillWithDefaults fills the current ReplicaReplication object with DefaultReplicationSpec.
+// SetDefaults fills the current ReplicaReplication object with DefaultReplicationSpec.
 // This enables having minimal ReplicaReplication objects and provides sensible defaults.
-func (r *ReplicaReplication) FillWithDefaults() {
+func (r *ReplicaReplication) SetDefaults() {
 	if r.WaitPoint == nil {
 		waitPoint := *DefaultReplicationSpec.Replica.WaitPoint
 		r.WaitPoint = &waitPoint
@@ -217,20 +217,20 @@ type ReplicationSpec struct {
 	ProbesEnabled *bool `json:"probesEnabled,omitempty"`
 }
 
-// FillWithDefaults fills the current ReplicationSpec object with DefaultReplicationSpec.
-// This enables having minimal ReplicationSpec objects and provides sensible defaults.
-func (r *ReplicationSpec) FillWithDefaults() {
+// SetDefaults fills the current Replication object with DefaultReplicationSpec.
+// This enables having minimal Replication objects and provides sensible defaults.
+func (r *Replication) SetDefaults() error {
 	if r.Primary == nil {
 		primary := *DefaultReplicationSpec.Primary
 		r.Primary = &primary
 	} else {
-		r.Primary.FillWithDefaults()
+		r.Primary.SetDefaults()
 	}
 	if r.Replica == nil {
 		replica := *DefaultReplicationSpec.Replica
 		r.Replica = &replica
 	} else {
-		r.Replica.FillWithDefaults()
+		r.Replica.SetDefaults()
 	}
 	if r.SyncBinlog == nil {
 		syncBinlog := *DefaultReplicationSpec.SyncBinlog
@@ -240,6 +240,8 @@ func (r *ReplicationSpec) FillWithDefaults() {
 		probesEnabled := *DefaultReplicationSpec.ProbesEnabled
 		r.ProbesEnabled = &probesEnabled
 	}
+
+	return nil
 }
 
 var (

--- a/api/v1alpha1/mariadb_replication_types.go
+++ b/api/v1alpha1/mariadb_replication_types.go
@@ -126,6 +126,7 @@ type ReplicaReplication struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	Gtid *Gtid `json:"gtid,omitempty"`
 	// ReplPasswordSecretKeyRef provides a reference to the Secret to use as password for the replication user.
+	// If one isn't provided, a password will be generated for you as a secret with name "repl-password-MARIADB_NAME"
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ReplPasswordSecretKeyRef *GeneratedSecretKeyRef `json:"replPasswordSecretKeyRef,omitempty"`
@@ -146,7 +147,7 @@ type ReplicaReplication struct {
 
 // SetDefaults fills the current ReplicaReplication object with DefaultReplicationSpec.
 // This enables having minimal ReplicaReplication objects and provides sensible defaults.
-func (r *ReplicaReplication) SetDefaults() {
+func (r *ReplicaReplication) SetDefaults(mariadb *MariaDB) {
 	if r.WaitPoint == nil {
 		waitPoint := *DefaultReplicationSpec.Replica.WaitPoint
 		r.WaitPoint = &waitPoint
@@ -166,6 +167,10 @@ func (r *ReplicaReplication) SetDefaults() {
 	if r.SyncTimeout == nil {
 		timeout := *DefaultReplicationSpec.Replica.SyncTimeout
 		r.SyncTimeout = &timeout
+	}
+
+	if r.ReplPasswordSecretKeyRef == nil {
+		r.ReplPasswordSecretKeyRef = mariadb.ReplPasswordSecretKeyRef()
 	}
 }
 
@@ -219,7 +224,7 @@ type ReplicationSpec struct {
 
 // SetDefaults fills the current Replication object with DefaultReplicationSpec.
 // This enables having minimal Replication objects and provides sensible defaults.
-func (r *Replication) SetDefaults() error {
+func (r *Replication) SetDefaults(mariadb *MariaDB) error {
 	if r.Primary == nil {
 		primary := *DefaultReplicationSpec.Primary
 		r.Primary = &primary
@@ -230,7 +235,7 @@ func (r *Replication) SetDefaults() error {
 		replica := *DefaultReplicationSpec.Replica
 		r.Replica = &replica
 	} else {
-		r.Replica.SetDefaults()
+		r.Replica.SetDefaults(mariadb)
 	}
 	if r.SyncBinlog == nil {
 		syncBinlog := *DefaultReplicationSpec.SyncBinlog

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -849,6 +849,12 @@ func (m *MariaDB) SetDefaults(env *environment.OperatorEnv) error {
 		m.Spec.UpdateStrategy.SetDefaults()
 	}
 
+	if m.IsReplicationEnabled() {
+		if err := m.Spec.Replication.SetDefaults(); err != nil {
+			return fmt.Errorf("error setting Replication defaults: %v", err)
+		}
+	}
+
 	m.Spec.Storage.SetDefaults()
 	m.Spec.SetDefaults(m.ObjectMeta)
 
@@ -857,16 +863,17 @@ func (m *MariaDB) SetDefaults(env *environment.OperatorEnv) error {
 
 // Replication with defaulting accessor
 func (m *MariaDB) Replication() Replication {
-	if m.Spec.Replication == nil {
-		m.Spec.Replication = &Replication{}
-	}
-	m.Spec.Replication.FillWithDefaults()
 	return *m.Spec.Replication
 }
 
-// IsHAEnabled indicates whether the MariaDB instance has Galera enabled
+// IsGaleraEnabled indicates whether the MariaDB instance has Galera enabled
 func (m *MariaDB) IsGaleraEnabled() bool {
 	return ptr.Deref(m.Spec.Galera, Galera{}).Enabled
+}
+
+// IsReplicationEnabled indicates whether the MariaDB instance has replication enabled
+func (m *MariaDB) IsReplicationEnabled() bool {
+	return ptr.Deref(m.Spec.Replication, Replication{}).Enabled
 }
 
 // IsHAEnabled indicates whether the MariaDB instance has HA enabled
@@ -948,7 +955,7 @@ func (m *MariaDB) IsResizingStorage() bool {
 	return meta.IsStatusConditionFalse(m.Status.Conditions, ConditionTypeStorageResized)
 }
 
-// IsResizingStorage indicates whether the MariaDB instance is waiting for storage resize
+// IsWaitingForStorageResize indicates whether the MariaDB instance is waiting for storage resize
 func (m *MariaDB) IsWaitingForStorageResize() bool {
 	condition := meta.FindStatusCondition(m.Status.Conditions, ConditionTypeStorageResized)
 	if condition == nil {

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -878,7 +878,7 @@ func (m *MariaDB) IsReplicationEnabled() bool {
 
 // IsHAEnabled indicates whether the MariaDB instance has HA enabled
 func (m *MariaDB) IsHAEnabled() bool {
-	return m.Replication().Enabled || m.IsGaleraEnabled()
+	return m.IsReplicationEnabled() || m.IsGaleraEnabled()
 }
 
 // IsMaxScaleEnabled indicates that a MaxScale instance is forwarding traffic to this MariaDB instance

--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -850,7 +850,7 @@ func (m *MariaDB) SetDefaults(env *environment.OperatorEnv) error {
 	}
 
 	if m.IsReplicationEnabled() {
-		if err := m.Spec.Replication.SetDefaults(); err != nil {
+		if err := m.Spec.Replication.SetDefaults(m); err != nil {
 			return fmt.Errorf("error setting Replication defaults: %v", err)
 		}
 	}

--- a/api/v1alpha1/maxscale_types.go
+++ b/api/v1alpha1/maxscale_types.go
@@ -537,7 +537,7 @@ func (m *MaxScaleTLS) SetDefaults(mdb *MariaDB) {
 		return
 	}
 
-	if mdb.Replication().Enabled && m.ReplicationSSLEnabled == nil {
+	if mdb.IsReplicationEnabled() && m.ReplicationSSLEnabled == nil {
 		m.ReplicationSSLEnabled = ptr.To(true)
 	}
 	if m.ServerCASecretRef == nil {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -277,7 +277,7 @@ var rootCmd = &cobra.Command{
 		certReconciler := certctrl.NewCertReconciler(client, scheme, mgr.GetEventRecorderFor("cert"), discovery, builder)
 
 		mxsReconciler := maxscale.NewMaxScaleReconciler(client, builder, env)
-		replConfig := replication.NewReplicationConfig(client, builder, secretReconciler, env)
+		replConfig := replication.NewReplicationConfig(client, builder, secretReconciler, authReconciler, env)
 		replicationReconciler, err := replication.NewReplicationReconciler(
 			client,
 			replRecorder,

--- a/internal/controller/mariadb_controller.go
+++ b/internal/controller/mariadb_controller.go
@@ -335,7 +335,7 @@ func (r *MariaDBReconciler) reconcileConfigMap(ctx context.Context, mariadb *mar
 		}
 	}
 
-	if mariadb.Replication().Enabled && ptr.Deref(mariadb.Replication().ProbesEnabled, false) {
+	if mariadb.IsReplicationEnabled() && ptr.Deref(mariadb.Replication().ProbesEnabled, false) {
 		configMapKeyRef := mariadb.ReplConfigMapKeyRef()
 		if err := r.ReplicationReconciler.ReconcileProbeConfigMap(ctx, configMapKeyRef, mariadb); err != nil {
 			return ctrl.Result{}, err

--- a/internal/controller/mariadb_controller_status.go
+++ b/internal/controller/mariadb_controller_status.go
@@ -83,7 +83,7 @@ func (r *MariaDBReconciler) reconcileStatus(ctx context.Context, mdb *mariadbv1a
 
 func (r *MariaDBReconciler) getReplicationStatus(ctx context.Context,
 	mdb *mariadbv1alpha1.MariaDB) (mariadbv1alpha1.ReplicationStatus, error) {
-	if !mdb.Replication().Enabled {
+	if !mdb.IsReplicationEnabled() {
 		return nil, nil
 	}
 
@@ -228,7 +228,7 @@ func defaultPrimary(mdb *mariadbv1alpha1.MariaDB) {
 		galera := ptr.Deref(mdb.Spec.Galera, mariadbv1alpha1.Galera{})
 		podIndex = ptr.Deref(galera.Primary.PodIndex, 0)
 	}
-	if mdb.Replication().Enabled {
+	if mdb.IsReplicationEnabled() {
 		primaryReplication := ptr.Deref(mdb.Replication().Primary, mariadbv1alpha1.PrimaryReplication{})
 		podIndex = ptr.Deref(primaryReplication.PodIndex, 0)
 	}

--- a/internal/controller/mariadb_controller_update.go
+++ b/internal/controller/mariadb_controller_update.go
@@ -195,7 +195,7 @@ func (r *MariaDBReconciler) waitForReadyStatus(ctx context.Context, mdb *mariadb
 }
 
 func (r *MariaDBReconciler) waitForConfiguredReplica(mdb *mariadbv1alpha1.MariaDB, logger logr.Logger) error {
-	if !mdb.Replication().Enabled {
+	if !mdb.IsReplicationEnabled() {
 		return nil
 	}
 
@@ -350,5 +350,5 @@ func shouldTriggerSwitchover(mariadb *mariadbv1alpha1.MariaDB) bool {
 		return false
 	}
 	primaryRepl := ptr.Deref(mariadb.Replication().Primary, mariadbv1alpha1.PrimaryReplication{})
-	return mariadb.Replication().Enabled && *primaryRepl.AutomaticFailover && mariadb.HasConfiguredReplica()
+	return mariadb.IsReplicationEnabled() && *primaryRepl.AutomaticFailover && mariadb.HasConfiguredReplica()
 }

--- a/internal/controller/pod_replication_controller.go
+++ b/internal/controller/pod_replication_controller.go
@@ -146,7 +146,7 @@ func shouldReconcile(mariadb *mariadbv1alpha1.MariaDB) bool {
 		return false
 	}
 	primaryRepl := ptr.Deref(mariadb.Replication().Primary, mariadbv1alpha1.PrimaryReplication{})
-	return mariadb.Replication().Enabled && *primaryRepl.AutomaticFailover && mariadb.HasConfiguredReplica()
+	return mariadb.IsReplicationEnabled() && *primaryRepl.AutomaticFailover && mariadb.HasConfiguredReplica()
 }
 
 func (r *PodReplicationController) patch(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -150,7 +150,7 @@ var _ = BeforeSuite(func() {
 	certReconciler := certctrl.NewCertReconciler(client, scheme, k8sManager.GetEventRecorderFor("cert"), disc, builder)
 
 	mxsReconciler := maxscale.NewMaxScaleReconciler(client, builder, env)
-	replConfig := replication.NewReplicationConfig(client, builder, secretReconciler, env)
+	replConfig := replication.NewReplicationConfig(client, builder, secretReconciler, authReconciler, env)
 	replicationReconciler, err := replication.NewReplicationReconciler(
 		client,
 		replRecorder,

--- a/internal/webhook/v1alpha1/mariadb_webhook.go
+++ b/internal/webhook/v1alpha1/mariadb_webhook.go
@@ -44,10 +44,9 @@ func (d *MariaDBCustomDefaulter) Default(ctx context.Context, obj runtime.Object
 	}
 	mariadblog.V(1).Info("Defaulting for MariaDB", "name", mariadb.GetName())
 
-	if mariadb.Spec.Replication != nil && mariadb.Spec.Replication.Enabled {
+	if mariadb.IsReplicationEnabled() {
 		mariadblog.V(1).Info("Defaulting spec.replication", "mariadb", mariadb.Name)
-		mariadb.Spec.Replication.SetDefaults()
-		return nil
+		return mariadb.Spec.Replication.SetDefaults()
 	}
 	return nil
 }

--- a/internal/webhook/v1alpha1/mariadb_webhook.go
+++ b/internal/webhook/v1alpha1/mariadb_webhook.go
@@ -46,7 +46,7 @@ func (d *MariaDBCustomDefaulter) Default(ctx context.Context, obj runtime.Object
 
 	if mariadb.Spec.Replication != nil && mariadb.Spec.Replication.Enabled {
 		mariadblog.V(1).Info("Defaulting spec.replication", "mariadb", mariadb.Name)
-		mariadb.Spec.Replication.FillWithDefaults()
+		mariadb.Spec.Replication.SetDefaults()
 		return nil
 	}
 	return nil

--- a/internal/webhook/v1alpha1/mariadb_webhook.go
+++ b/internal/webhook/v1alpha1/mariadb_webhook.go
@@ -46,7 +46,7 @@ func (d *MariaDBCustomDefaulter) Default(ctx context.Context, obj runtime.Object
 
 	if mariadb.IsReplicationEnabled() {
 		mariadblog.V(1).Info("Defaulting spec.replication", "mariadb", mariadb.Name)
-		return mariadb.Spec.Replication.SetDefaults()
+		return mariadb.Spec.Replication.SetDefaults(mariadb)
 	}
 	return nil
 }

--- a/internal/webhook/v1alpha1/mariadb_webhook.go
+++ b/internal/webhook/v1alpha1/mariadb_webhook.go
@@ -130,7 +130,7 @@ func (v *MariaDBCustomValidator) ValidateDelete(ctx context.Context, obj runtime
 }
 
 func validateHA(mariadb *v1alpha1.MariaDB) error {
-	if mariadb.Replication().Enabled && mariadb.IsGaleraEnabled() {
+	if mariadb.IsHAEnabled() {
 		return errors.New("you may only enable one HA method at a time, either 'spec.replication' or 'spec.galera'")
 	}
 	if !mariadb.IsHAEnabled() && mariadb.Spec.Replicas > 1 {
@@ -226,7 +226,7 @@ func validateGalera(mariadb *v1alpha1.MariaDB) error {
 }
 
 func validateReplication(mariadb *v1alpha1.MariaDB) error {
-	if !mariadb.Replication().Enabled {
+	if !mariadb.IsReplicationEnabled() {
 		return nil
 	}
 	if *mariadb.Replication().Primary.PodIndex < 0 || *mariadb.Replication().Primary.PodIndex >= int(mariadb.Spec.Replicas) {
@@ -247,7 +247,7 @@ func validateReplication(mariadb *v1alpha1.MariaDB) error {
 }
 
 func validatePrimarySwitchover(mariadb, old *v1alpha1.MariaDB) error {
-	if old.Replication().Enabled && old.IsSwitchingPrimary() {
+	if old.IsReplicationEnabled() && old.IsSwitchingPrimary() {
 		if *old.Replication().Primary.PodIndex != *mariadb.Replication().Primary.PodIndex {
 			return field.Invalid(
 				field.NewPath("spec").Child("replication").Child("primary").Child("podIndex"),

--- a/make/pki.mk
+++ b/make/pki.mk
@@ -102,7 +102,7 @@ CERT_ALT_NAMES ?=
 cert-leaf: ## Generates leaf certificate keypair.
 	@mkdir -p $(PKI_DIR)
 	@openssl ecparam -genkey -name $(EC_PARAM) -noout -out $(KEY)
-	@openssl req -new -key $(KEY) $(EC_HASH) -sha256 -days 365 \
+	@openssl req -new -key $(KEY) $(EC_HASH) -days 365 \
 		-CA $(CA_CERT) -CAkey $(CA_KEY) \
 		-out $(CERT) -subj $(CERT_SUBJECT) -addext $(CERT_ALT_NAMES)
 

--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -328,7 +328,7 @@ func (b *Builder) buildContainer(mdb *mariadbv1alpha1.MariaDB, mdbContainer *mar
 
 func mariadbArgs(mariadb *mariadbv1alpha1.MariaDB) []string {
 	var mariadbArgs []string
-	if mariadb.Replication().Enabled {
+	if mariadb.IsReplicationEnabled() {
 		mariadbArgs = append(mariadbArgs, []string{
 			"--log-bin",
 			fmt.Sprintf("--log-basename=%s", mariadb.Name)}...)
@@ -499,7 +499,7 @@ func mariadbVolumeMounts(mariadb *mariadbv1alpha1.MariaDB, opts ...mariadbPodOpt
 
 	volumeMounts = append(volumeMounts, mariadbStorageVolumeMount(mariadb))
 
-	if mariadb.Replication().Enabled && ptr.Deref(mariadb.Replication().ProbesEnabled, false) {
+	if mariadb.IsReplicationEnabled() && ptr.Deref(mariadb.Replication().ProbesEnabled, false) {
 		volumeMounts = append(volumeMounts, corev1.VolumeMount{
 			Name:      ProbesVolume,
 			MountPath: ProbesMountPath,
@@ -625,7 +625,7 @@ func mariadbReadinessProbe(mariadb *mariadbv1alpha1.MariaDB) *corev1.Probe {
 }
 
 func mariadbProbe(mariadb *mariadbv1alpha1.MariaDB, probe *mariadbv1alpha1.Probe) *corev1.Probe {
-	if mariadb.Replication().Enabled && ptr.Deref(mariadb.Replication().ProbesEnabled, false) {
+	if mariadb.IsReplicationEnabled() && ptr.Deref(mariadb.Replication().ProbesEnabled, false) {
 		replProbe := mariadbReplProbe(mariadb, probe)
 		if probe != nil {
 			setProbeThresholds(replProbe, ptr.To(probe.ToKubernetesType()))

--- a/pkg/builder/pod_builder.go
+++ b/pkg/builder/pod_builder.go
@@ -312,7 +312,7 @@ func mariadbVolumes(mariadb *mariadbv1alpha1.MariaDB, opts ...mariadbPodOpt) []c
 		tlsVolumes, _ := mariadbTLSVolumes(mariadb)
 		volumes = append(volumes, tlsVolumes...)
 	}
-	if mariadb.Replication().Enabled && ptr.Deref(mariadb.Replication().ProbesEnabled, false) {
+	if mariadb.IsReplicationEnabled() && ptr.Deref(mariadb.Replication().ProbesEnabled, false) {
 		volumes = append(volumes, corev1.Volume{
 			Name: ProbesVolume,
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -237,7 +237,7 @@ func mariadbHAAnnotations(mariadb *mariadbv1alpha1.MariaDB) map[string]string {
 		annotations = map[string]string{
 			annotation.MariadbAnnotation: mariadb.Name,
 		}
-		if mariadb.Replication().Enabled {
+		if mariadb.IsReplicationEnabled() {
 			annotations[annotation.ReplicationAnnotation] = ""
 		}
 		if mariadb.IsGaleraEnabled() {

--- a/pkg/controller/auth/controller.go
+++ b/pkg/controller/auth/controller.go
@@ -35,6 +35,8 @@ type GrantOpts struct {
 	Key types.NamespacedName
 }
 
+// ReconcileUserGrant will reconcile a user and a grant. This involves multiple requeues
+// @WARN: We may want to add an option to wait for the grant too.
 func (r *AuthReconciler) ReconcileUserGrant(ctx context.Context, key types.NamespacedName, owner metav1.Object,
 	userOpts builder.UserOpts, grantOpts ...GrantOpts) (ctrl.Result, error) {
 	if err := r.ReconcileUser(ctx, key, owner, userOpts); err != nil {
@@ -59,6 +61,7 @@ func (r *AuthReconciler) ReconcileUser(ctx context.Context, key types.Namespaced
 	err := r.Get(ctx, key, &user)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("Creating User", "key", key, "owner", owner, "opts", userOpts)
 			return r.createUser(ctx, key, owner, userOpts)
 		}
 		return err
@@ -76,6 +79,7 @@ func (r *AuthReconciler) ReconcileGrant(ctx context.Context, key, userKey types.
 	var grant mariadbv1alpha1.Grant
 	if err := r.Get(ctx, key, &grant); err != nil {
 		if apierrors.IsNotFound(err) {
+			log.FromContext(ctx).V(1).Info("Creating User Grant", "key", key, "owner", owner, "opts", grantOpts)
 			return r.createGrant(ctx, key, owner, grantOpts)
 		}
 		return err

--- a/pkg/controller/replication/clientset.go
+++ b/pkg/controller/replication/clientset.go
@@ -16,7 +16,7 @@ type ReplicationClientSet struct {
 }
 
 func NewReplicationClientSet(mariadb *mariadbv1alpha1.MariaDB, refResolver *refresolver.RefResolver) (*ReplicationClientSet, error) {
-	if !mariadb.Replication().Enabled {
+	if !mariadb.IsReplicationEnabled() {
 		return nil, errors.New("'mariadb.spec.replication' is required to create a replicationClientSet")
 	}
 	return &ReplicationClientSet{

--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -62,6 +62,7 @@ func (r *ReplicationConfig) ConfigurePrimary(ctx context.Context, mariadb *maria
 	if err := client.DisableReadOnly(ctx); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error disabling read_only: %v", err)
 	}
+	// @TODO: This should probably be a functionality of the AuthReconciler. If it does not exist and Generate is true, we can create it
 	if err := r.reconcileReplUserPassword(ctx, mariadb); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error while creating password for replication user: %v", err)
 	}

--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -3,18 +3,20 @@ package replication
 import (
 	"context"
 	"fmt"
+	"time"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v25/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/builder"
 	builderpki "github.com/mariadb-operator/mariadb-operator/v25/pkg/builder/pki"
+	"github.com/mariadb-operator/mariadb-operator/v25/pkg/controller/auth"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/controller/secret"
 	env "github.com/mariadb-operator/mariadb-operator/v25/pkg/environment"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/refresolver"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/sql"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/statefulset"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/version"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -29,41 +31,52 @@ type ReplicationConfig struct {
 	builder          *builder.Builder
 	refResolver      *refresolver.RefResolver
 	secretReconciler *secret.SecretReconciler
+	authReconciler   *auth.AuthReconciler
 	env              *env.OperatorEnv
 }
 
 func NewReplicationConfig(client client.Client, builder *builder.Builder, secretReconciler *secret.SecretReconciler,
-	env *env.OperatorEnv) *ReplicationConfig {
+	authReconciler *auth.AuthReconciler, env *env.OperatorEnv) *ReplicationConfig {
 	return &ReplicationConfig{
 		Client:           client,
 		builder:          builder,
 		refResolver:      refresolver.New(client),
 		secretReconciler: secretReconciler,
+		authReconciler:   authReconciler,
 		env:              env,
 	}
 }
 
+// ConfigurePrimary will configure a primary replica given the pod's index
 func (r *ReplicationConfig) ConfigurePrimary(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB, client *sql.Client,
-	podIndex int) error {
+	podIndex int) (ctrl.Result, error) {
 	if err := client.StopAllSlaves(ctx); err != nil {
-		return fmt.Errorf("error stopping slaves: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error stopping slaves: %v", err)
 	}
 	if err := client.ResetAllSlaves(ctx); err != nil {
-		return fmt.Errorf("error resetting slave: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error resetting slave: %v", err)
 	}
 	if err := client.ResetSlavePos(ctx); err != nil {
-		return fmt.Errorf("error resetting slave position: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error resetting slave position: %v", err)
 	}
 	if err := client.DisableReadOnly(ctx); err != nil {
-		return fmt.Errorf("error disabling read_only: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error disabling read_only: %v", err)
 	}
-	if err := r.reconcilePrimarySql(ctx, mariadb, client); err != nil {
-		return fmt.Errorf("error reconciling primary SQL: %v", err)
+	if result, err := r.reconcileSQL(ctx, mariadb, client); !result.IsZero() || err != nil {
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("error reconciling primary SQL: %v", err)
+		}
+
+		return result, err
 	}
-	if err := r.configurePrimaryVars(ctx, mariadb, client, podIndex); err != nil {
-		return fmt.Errorf("error configuring replication variables: %v", err)
+	if result, err := r.configurePrimaryVars(ctx, mariadb, client, podIndex); !result.IsZero() || err != nil {
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("error configuring replication variables: %v", err)
+		}
+
+		return result, err
 	}
-	return nil
+	return ctrl.Result{}, nil
 }
 
 func (r *ReplicationConfig) ConfigureReplica(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB, client *sql.Client,
@@ -95,7 +108,8 @@ func (r *ReplicationConfig) ConfigureReplica(ctx context.Context, mariadb *maria
 }
 
 func (r *ReplicationConfig) configurePrimaryVars(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB, client *sql.Client,
-	primaryPodIndex int) error {
+	primaryPodIndex int) (ctrl.Result, error) {
+	log.FromContext(ctx).Info("Configuring Primary Vars", "primaryPodIndex", primaryPodIndex)
 	kv := map[string]string{
 		"sync_binlog":                  fmt.Sprintf("%d", ptr.Deref(mariadb.Replication().SyncBinlog, 1)),
 		"rpl_semi_sync_master_enabled": "ON",
@@ -108,18 +122,19 @@ func (r *ReplicationConfig) configurePrimaryVars(ctx context.Context, mariadb *m
 	if mariadb.Replication().Replica.WaitPoint != nil {
 		waitPoint, err := mariadb.Replication().Replica.WaitPoint.MariaDBFormat()
 		if err != nil {
-			return fmt.Errorf("error getting wait point: %v", err)
+			return ctrl.Result{}, fmt.Errorf("error getting wait point: %v", err)
 		}
 		kv["rpl_semi_sync_master_wait_point"] = waitPoint
 	}
 	if err := client.SetSystemVariables(ctx, kv); err != nil {
-		return fmt.Errorf("error setting replication vars: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error setting replication vars: %v", err)
 	}
-	return nil
+	return ctrl.Result{}, nil
 }
 
 func (r *ReplicationConfig) configureReplicaVars(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,
 	client *sql.Client, ordinal int) error {
+	log.FromContext(ctx).Info("Configuring Replica Vars", "ordinal", ordinal)
 	kv := map[string]string{
 		"sync_binlog":                  fmt.Sprintf("%d", ptr.Deref(mariadb.Replication().SyncBinlog, 1)),
 		"rpl_semi_sync_master_enabled": "OFF",
@@ -216,68 +231,63 @@ func (r *ReplicationConfig) getChangeMasterHost(ctx context.Context, mariadb *ma
 	), nil
 }
 
-func (r *ReplicationConfig) reconcilePrimarySql(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB, client *sql.Client) error {
-	opts := userSqlOpts{
-		username:   replUser,
-		host:       replUserHost,
-		privileges: []string{"REPLICATION REPLICA"},
-	}
-	if err := r.reconcileUserSql(ctx, mariadb, client, &opts); err != nil {
-		return fmt.Errorf("error reconciling '%s' SQL user: %v", replUser, err)
-	}
-	return nil
-}
+// Creates a `User` and `Grant` resources with minimum required permissions for replication.
+func (r *ReplicationConfig) reconcileSQL(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,
+	client *sql.Client) (ctrl.Result, error) {
+	replUserKey := mariadb.MariadbReplUserKey()
+	replGrantKey := mariadb.MariadbReplGrantKey()
 
-type userSqlOpts struct {
-	username   string
-	host       string
-	privileges []string
-}
-
-func (r *ReplicationConfig) reconcileUserSql(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB, client *sql.Client,
-	opts *userSqlOpts) error {
-	replPasswordRef := newReplPasswordRef(mariadb)
-	var replPassword string
-
-	req := secret.PasswordRequest{
-		Owner:    mariadb,
-		Metadata: mariadb.Spec.InheritMetadata,
-		Key: types.NamespacedName{
-			Name:      replPasswordRef.Name,
-			Namespace: mariadb.Namespace,
+	userOpts := builder.UserOpts{
+		MariaDBRef: mariadbv1alpha1.MariaDBRef{
+			ObjectReference: mariadbv1alpha1.ObjectReference{
+				Name:      mariadb.Name,
+				Namespace: mariadb.Namespace,
+			},
 		},
-		SecretKey: replPasswordRef.Key,
-		Generate:  replPasswordRef.Generate,
-	}
-	replPassword, err := r.secretReconciler.ReconcilePassword(ctx, req)
-	if err != nil {
-		return fmt.Errorf("error reconciling replication password: %v", err)
+		Metadata:             mariadb.Spec.InheritMetadata,
+		MaxUserConnections:   20,
+		Name:                 replUser,
+		Host:                 replUserHost,
+		PasswordSecretKeyRef: nil,
+		CleanupPolicy:        ptr.To(mariadbv1alpha1.CleanupPolicySkip),
 	}
 
-	accountName := formatAccountName(opts.username, opts.host)
-	exists, err := client.UserExists(ctx, opts.username, opts.host)
-	if err != nil {
-		return fmt.Errorf("error checking if replication user exists: %v", err)
+	grantOpts := auth.GrantOpts{
+		Key: replGrantKey,
+		GrantOpts: builder.GrantOpts{
+			MariaDBRef: mariadbv1alpha1.MariaDBRef{
+				ObjectReference: mariadbv1alpha1.ObjectReference{
+					Name:      mariadb.Name,
+					Namespace: mariadb.Namespace,
+				},
+			},
+			Metadata:      mariadb.Spec.InheritMetadata,
+			Privileges:    []string{"REPLICATION SLAVE"},
+			Database:      "*",
+			Table:         "*",
+			Username:      replUser,
+			Host:          replUserHost,
+			CleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
+		},
 	}
-	if exists {
-		if err := client.AlterUser(ctx, accountName, sql.WithIdentifiedBy(replPassword)); err != nil {
-			return fmt.Errorf("error altering replication user: %v", err)
+
+	if result, err := r.authReconciler.ReconcileUserGrant(ctx, replUserKey, mariadb, userOpts, grantOpts); !result.IsZero() || err != nil {
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("error reconciling %s user auth: %v", replUser, err)
 		}
-	} else {
-		if err := client.CreateUser(ctx, accountName, sql.WithIdentifiedBy(replPassword)); err != nil {
-			return fmt.Errorf("error creating replication user: %v", err)
-		}
+		return result, err
 	}
-	if err := client.Grant(
-		ctx,
-		opts.privileges,
-		"*",
-		"*",
-		accountName,
-	); err != nil {
-		return fmt.Errorf("error creating grant: %v", err)
+
+	var replGrant mariadbv1alpha1.Grant
+	if err := r.Get(ctx, replGrantKey, &replGrant); err != nil {
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
 	}
-	return nil
+	if !replGrant.IsReady() {
+		log.FromContext(ctx).V(1).Info("Grant not ready. Requeuing...", "user", replUser)
+		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func newReplPasswordRef(mariadb *mariadbv1alpha1.MariaDB) mariadbv1alpha1.GeneratedSecretKeyRef {
@@ -297,8 +307,4 @@ func newReplPasswordRef(mariadb *mariadbv1alpha1.MariaDB) mariadbv1alpha1.Genera
 
 func serverId(index int) string {
 	return fmt.Sprint(10 + index)
-}
-
-func formatAccountName(username, host string) string {
-	return fmt.Sprintf("'%s'@'%s'", username, host)
 }

--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -262,7 +262,7 @@ func (r *ReplicationConfig) reconcileSQL(ctx context.Context, mariadb *mariadbv1
 				},
 			},
 			Metadata:      mariadb.Spec.InheritMetadata,
-			Privileges:    []string{"REPLICATION SLAVE"},
+			Privileges:    []string{"REPLICATION REPLICA"},
 			Database:      "*",
 			Table:         "*",
 			Username:      replUser,

--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -3,7 +3,6 @@ package replication
 import (
 	"context"
 	"fmt"
-	"time"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v25/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/builder"
@@ -15,6 +14,7 @@ import (
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/sql"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/statefulset"
 	"github.com/mariadb-operator/mariadb-operator/v25/pkg/version"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,6 +62,10 @@ func (r *ReplicationConfig) ConfigurePrimary(ctx context.Context, mariadb *maria
 	if err := client.DisableReadOnly(ctx); err != nil {
 		return ctrl.Result{}, fmt.Errorf("error disabling read_only: %v", err)
 	}
+	if err := r.reconcileReplUserPassword(ctx, mariadb); err != nil {
+		return ctrl.Result{}, fmt.Errorf("error while creating password for replication user: %v", err)
+	}
+
 	if result, err := r.reconcileSQL(ctx, mariadb, client); !result.IsZero() || err != nil {
 		if err != nil {
 			return ctrl.Result{}, fmt.Errorf("error reconciling primary SQL: %v", err)
@@ -149,8 +153,7 @@ func (r *ReplicationConfig) configureReplicaVars(ctx context.Context, mariadb *m
 
 func (r *ReplicationConfig) changeMaster(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB, client *sql.Client,
 	primaryPodIndex int) error {
-	replPasswordRef := newReplPasswordRef(mariadb)
-
+	replPasswordRef := mariadb.Spec.Replication.Replica.ReplPasswordSecretKeyRef
 	password, err := r.refResolver.SecretKeyRef(ctx, replPasswordRef.SecretKeySelector, mariadb.Namespace)
 	if err != nil {
 		return fmt.Errorf("error getting replication password: %v", err)
@@ -248,7 +251,7 @@ func (r *ReplicationConfig) reconcileSQL(ctx context.Context, mariadb *mariadbv1
 		MaxUserConnections:   20,
 		Name:                 replUser,
 		Host:                 replUserHost,
-		PasswordSecretKeyRef: nil,
+		PasswordSecretKeyRef: &mariadb.Spec.Replication.Replica.ReplPasswordSecretKeyRef.SecretKeySelector,
 		CleanupPolicy:        ptr.To(mariadbv1alpha1.CleanupPolicySkip),
 	}
 
@@ -278,31 +281,31 @@ func (r *ReplicationConfig) reconcileSQL(ctx context.Context, mariadb *mariadbv1
 		return result, err
 	}
 
-	var replGrant mariadbv1alpha1.Grant
-	if err := r.Get(ctx, replGrantKey, &replGrant); err != nil {
-		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
-	}
-	if !replGrant.IsReady() {
-		log.FromContext(ctx).V(1).Info("Grant not ready. Requeuing...", "user", replUser)
-		return ctrl.Result{RequeueAfter: 1 * time.Second}, nil
+	if result, err := r.authReconciler.WaitForGrant(ctx, replGrantKey); !result.IsZero() || err != nil {
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("error waiting for grant: %v", err)
+		}
+		return result, err
 	}
 
 	return ctrl.Result{}, nil
 }
 
-func newReplPasswordRef(mariadb *mariadbv1alpha1.MariaDB) mariadbv1alpha1.GeneratedSecretKeyRef {
-	if mariadb.Replication().Enabled && mariadb.Replication().Replica.ReplPasswordSecretKeyRef != nil {
-		return *mariadb.Replication().Replica.ReplPasswordSecretKeyRef
-	}
-	return mariadbv1alpha1.GeneratedSecretKeyRef{
-		SecretKeySelector: mariadbv1alpha1.SecretKeySelector{
-			LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-				Name: fmt.Sprintf("repl-password-%s", mariadb.Name),
-			},
-			Key: "password",
+// reconcileReplUserPassword will create a new secret with repl user password if it does not already exists
+func (r *ReplicationConfig) reconcileReplUserPassword(ctx context.Context, mdb *mariadbv1alpha1.MariaDB) error {
+	secretKeyRef := mdb.Spec.Replication.Replica.ReplPasswordSecretKeyRef
+	req := secret.PasswordRequest{
+		Metadata: mdb.Spec.InheritMetadata,
+		Owner:    mdb,
+		Key: types.NamespacedName{
+			Name:      secretKeyRef.Name,
+			Namespace: mdb.Namespace,
 		},
-		Generate: true,
+		SecretKey: secretKeyRef.Key,
+		Generate:  secretKeyRef.Generate,
 	}
+	_, err := r.secretReconciler.ReconcilePassword(ctx, req)
+	return err
 }
 
 func serverId(index int) string {

--- a/pkg/controller/replication/controller.go
+++ b/pkg/controller/replication/controller.go
@@ -89,7 +89,7 @@ type reconcileRequest struct {
 }
 
 func (r *ReplicationReconciler) Reconcile(ctx context.Context, mdb *mariadbv1alpha1.MariaDB) (ctrl.Result, error) {
-	if !mdb.Replication().Enabled {
+	if !mdb.IsReplicationEnabled() {
 		return ctrl.Result{}, nil
 	}
 	logger := log.FromContext(ctx).WithName("replication")
@@ -145,7 +145,7 @@ func (r *ReplicationReconciler) Reconcile(ctx context.Context, mdb *mariadbv1alp
 // nolint:lll
 func (r *ReplicationReconciler) ReconcileProbeConfigMap(ctx context.Context, configMapKeyRef mariadbv1alpha1.ConfigMapKeySelector,
 	mdb *mariadbv1alpha1.MariaDB) error {
-	if !mdb.Replication().Enabled {
+	if !mdb.IsReplicationEnabled() {
 		return nil
 	}
 	req := configmap.ReconcileRequest{

--- a/pkg/controller/replication/controller.go
+++ b/pkg/controller/replication/controller.go
@@ -107,7 +107,7 @@ func (r *ReplicationReconciler) Reconcile(ctx context.Context, mdb *mariadbv1alp
 			key:       client.ObjectKeyFromObject(mdb),
 			clientSet: clientSet,
 		}
-		return ctrl.Result{}, r.reconcileSwitchover(ctx, &req, switchoverLogger)
+		return r.reconcileSwitchover(ctx, &req, switchoverLogger)
 	}
 	healthy, err := health.IsStatefulSetHealthy(
 		ctx,
@@ -138,7 +138,8 @@ func (r *ReplicationReconciler) Reconcile(ctx context.Context, mdb *mariadbv1alp
 	if result, err := r.reconcileReplication(ctx, &req, logger); !result.IsZero() || err != nil {
 		return result, err
 	}
-	return ctrl.Result{}, r.reconcileSwitchover(ctx, &req, switchoverLogger)
+
+	return r.reconcileSwitchover(ctx, &req, switchoverLogger)
 }
 
 // nolint:lll
@@ -180,30 +181,40 @@ func (r *ReplicationReconciler) reconcileReplication(ctx context.Context, req *r
 		pod := statefulset.PodName(req.mariadb.ObjectMeta, i)
 
 		if req.mariadb.Status.ReplicationStatus == nil {
-			if err := r.reconcileReplicationInPod(ctx, req, logger, i); err != nil {
-				return ctrl.Result{}, fmt.Errorf("error configuring replication in Pod '%s': %v", pod, err)
+			if result, err := r.reconcileReplicationInPod(ctx, req, logger, i); !result.IsZero() || err != nil {
+				if err != nil {
+					return ctrl.Result{}, fmt.Errorf("error configuring replication in Pod '%s': %v", pod, err)
+				}
+
+				return result, err
 			}
 		}
 
 		state, ok := req.mariadb.Status.ReplicationStatus[pod]
 		if !ok || state == mariadbv1alpha1.ReplicationStateNotConfigured {
-			if err := r.reconcileReplicationInPod(ctx, req, logger, i); err != nil {
-				return ctrl.Result{}, fmt.Errorf("error configuring replication in Pod '%s': %v", pod, err)
+			if result, err := r.reconcileReplicationInPod(ctx, req, logger, i); !result.IsZero() || err != nil {
+				if err != nil {
+					return ctrl.Result{}, fmt.Errorf("error configuring replication in Pod '%s': %v", pod, err)
+				}
+
+				return result, err
 			}
 		}
 	}
 	return ctrl.Result{}, nil
 }
 
-func (r *ReplicationReconciler) reconcileReplicationInPod(ctx context.Context, req *reconcileRequest, logger logr.Logger, index int) error {
+func (r *ReplicationReconciler) reconcileReplicationInPod(ctx context.Context, req *reconcileRequest, logger logr.Logger,
+	index int) (ctrl.Result, error) {
 	pod := statefulset.PodName(req.mariadb.ObjectMeta, index)
 	primaryPodIndex := *req.mariadb.Status.CurrentPrimaryPodIndex
 
+	logger.V(1).Info("Reconciling replication in pod", "primaryPodIndex", primaryPodIndex, "index", index)
 	if primaryPodIndex == index {
 		logger.Info("Configuring primary", "pod", pod)
 		client, err := req.clientSet.currentPrimaryClient(ctx)
 		if err != nil {
-			return fmt.Errorf("error getting current primary client: %v", err)
+			return ctrl.Result{}, fmt.Errorf("error getting current primary client: %v", err)
 		}
 		return r.replConfig.ConfigurePrimary(ctx, req.mariadb, client, index)
 	}
@@ -211,9 +222,9 @@ func (r *ReplicationReconciler) reconcileReplicationInPod(ctx context.Context, r
 	logger.Info("Configuring replica", "pod", pod)
 	client, err := req.clientSet.clientForIndex(ctx, index)
 	if err != nil {
-		return fmt.Errorf("error getting replica client: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error getting replica client: %v", err)
 	}
-	return r.replConfig.ConfigureReplica(ctx, req.mariadb, client, index, primaryPodIndex, false)
+	return ctrl.Result{}, r.replConfig.ConfigureReplica(ctx, req.mariadb, client, index, primaryPodIndex, false)
 }
 
 func (r *ReplicationReconciler) patchStatus(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,

--- a/pkg/controller/replication/switchover.go
+++ b/pkg/controller/replication/switchover.go
@@ -17,11 +17,15 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
+
+type switchoverPhaseReconcileFuncNoResult func(context.Context, *mariadbv1alpha1.MariaDB, *ReplicationClientSet, logr.Logger) error
+type switchoverPhaseReconcileFunc func(context.Context, *mariadbv1alpha1.MariaDB, *ReplicationClientSet, logr.Logger) (ctrl.Result, error)
 
 type switchoverPhase struct {
 	name      string
-	reconcile func(context.Context, *mariadbv1alpha1.MariaDB, *ReplicationClientSet, logr.Logger) error
+	reconcile switchoverPhaseReconcileFunc
 }
 
 func shouldReconcileSwitchover(mdb *mariadbv1alpha1.MariaDB) bool {
@@ -39,9 +43,10 @@ func shouldReconcileSwitchover(mdb *mariadbv1alpha1.MariaDB) bool {
 	return currentPodIndex != desiredPodIndex
 }
 
-func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *reconcileRequest, switchoverLogger logr.Logger) error {
+func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *reconcileRequest,
+	switchoverLogger logr.Logger) (ctrl.Result, error) {
 	if !shouldReconcileSwitchover(req.mariadb) {
-		return nil
+		return ctrl.Result{}, nil
 	}
 
 	fromIndex := req.mariadb.Status.CurrentPrimaryPodIndex
@@ -51,21 +56,21 @@ func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *re
 	if err := r.patchStatus(ctx, req.mariadb, func(status *mariadbv1alpha1.MariaDBStatus) {
 		condition.SetPrimarySwitching(&req.mariadb.Status, req.mariadb)
 	}); err != nil {
-		return fmt.Errorf("error patching MariaDB status: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error patching MariaDB status: %v", err)
 	}
 
 	phases := []switchoverPhase{
 		{
 			name:      "Lock primary with read lock",
-			reconcile: r.lockPrimaryWithReadLock,
+			reconcile: r.zeroReconcileResult(r.lockPrimaryWithReadLock),
 		},
 		{
 			name:      "Set read_only in primary",
-			reconcile: r.setPrimaryReadOnly,
+			reconcile: r.zeroReconcileResult(r.setPrimaryReadOnly),
 		},
 		{
 			name:      "Wait for replica sync",
-			reconcile: r.waitForReplicaSync,
+			reconcile: r.zeroReconcileResult(r.waitForReplicaSync),
 		},
 		{
 			name:      "Configure new primary",
@@ -73,20 +78,24 @@ func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *re
 		},
 		{
 			name:      "Connect replicas to new primary",
-			reconcile: r.connectReplicasToNewPrimary,
+			reconcile: r.zeroReconcileResult(r.connectReplicasToNewPrimary),
 		},
 		{
 			name:      "Change primary to replica",
-			reconcile: r.changePrimaryToReplica,
+			reconcile: r.zeroReconcileResult(r.changePrimaryToReplica),
 		},
 	}
 
 	for _, p := range phases {
-		if err := p.reconcile(ctx, req.mariadb, req.clientSet, logger); err != nil {
+		if result, err := p.reconcile(ctx, req.mariadb, req.clientSet, logger); !result.IsZero() || err != nil {
 			if apierrors.IsNotFound(err) {
-				return err
+				return ctrl.Result{}, err
 			}
-			return fmt.Errorf("error in '%s' switchover reconcile phase: %v", p.name, err)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("error in '%s' switchover reconcile phase: %v", p.name, err)
+			}
+
+			return result, err
 		}
 	}
 
@@ -94,13 +103,13 @@ func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *re
 		status.UpdateCurrentPrimary(req.mariadb, toIndex)
 		condition.SetPrimarySwitched(&req.mariadb.Status)
 	}); err != nil {
-		return fmt.Errorf("error patching MariaDB status: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error patching MariaDB status: %v", err)
 	}
 
 	logger.Info("Primary switched")
 	r.recorder.Eventf(req.mariadb, corev1.EventTypeNormal, mariadbv1alpha1.ReasonPrimarySwitched,
 		"Primary switched from index '%d' to index '%d'", *fromIndex, toIndex)
-	return nil
+	return ctrl.Result{}, nil
 }
 
 func (r *ReplicationReconciler) lockPrimaryWithReadLock(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,
@@ -235,10 +244,10 @@ func (r *ReplicationReconciler) waitForReplicaSync(ctx context.Context, mariadb 
 }
 
 func (r *ReplicationReconciler) configureNewPrimary(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,
-	clientSet *ReplicationClientSet, logger logr.Logger) error {
+	clientSet *ReplicationClientSet, logger logr.Logger) (ctrl.Result, error) {
 	client, err := clientSet.newPrimaryClient(ctx)
 	if err != nil {
-		return fmt.Errorf("error getting new primary client: %v", err)
+		return ctrl.Result{}, fmt.Errorf("error getting new primary client: %v", err)
 	}
 
 	podIndex := *mariadb.Replication().Primary.PodIndex
@@ -246,10 +255,14 @@ func (r *ReplicationReconciler) configureNewPrimary(ctx context.Context, mariadb
 	r.recorder.Eventf(mariadb, corev1.EventTypeNormal, mariadbv1alpha1.ReasonReplicationPrimaryNew,
 		"Configuring new primary at index '%d'", podIndex)
 
-	if err := r.replConfig.ConfigurePrimary(ctx, mariadb, client, podIndex); err != nil {
-		return fmt.Errorf("error confguring new primary vars: %v", err)
+	if result, err := r.replConfig.ConfigurePrimary(ctx, mariadb, client, podIndex); !result.IsZero() || err != nil {
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("error confguring new primary vars: %v", err)
+		}
+
+		return result, err
 	}
-	return nil
+	return ctrl.Result{}, nil
 }
 
 func (r *ReplicationReconciler) connectReplicasToNewPrimary(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB,
@@ -381,4 +394,13 @@ func (r *ReplicationReconciler) currentPrimaryReady(ctx context.Context, mariadb
 		return false, err
 	}
 	return mariadbpod.PodReady(&pod), nil
+}
+
+// zeroReconcileResult will take a reconcileFunc as expected inside `reconcileSwitchover` and return an empty result.
+// We are preserving errors, so we can send them upstream.
+// This is needed as some reconcile actions don't need to return a result, while others do, to perform short sleeps for example
+func (r *ReplicationReconciler) zeroReconcileResult(reconcileFunc switchoverPhaseReconcileFuncNoResult) switchoverPhaseReconcileFunc {
+	return func(ctx context.Context, md *mariadbv1alpha1.MariaDB, rcs *ReplicationClientSet, l logr.Logger) (ctrl.Result, error) {
+		return ctrl.Result{}, reconcileFunc(ctx, md, rcs, l)
+	}
 }


### PR DESCRIPTION
- Work on AuthService to introduce and expose WaitForGrant and WaitForUser methods
- [ ] Further work on AuthService to add capabilities to actually create the users
- SetDefaults strategy for Replication obj
- Bug in e12769e2cf47cca963cb37ff8b415fe706f95e3d in the `cert-leaf` make target has been addressed.
- Replication logic now uses same methodology when creating a user as Galera