### PR TITLE
Add explicit ns in mariadb-cluster chart

### DIFF
--- a/deploy/charts/mariadb-cluster/templates/_helpers.tpl
+++ b/deploy/charts/mariadb-cluster/templates/_helpers.tpl
@@ -51,6 +51,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Determine target namespace
+*/}}
+{{- define "mariadb-cluster.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride }}
+{{- end }}
+
+{{/*
 Render an object as YAML omitting specified keys and indent it.
 Usage:
   {{ include "mariadb-cluster.omitKeys" (dict "object" . "keys" (list "name" "mariaDbRef") "nindent" 2) }}

--- a/deploy/charts/mariadb-cluster/templates/backup.yaml
+++ b/deploy/charts/mariadb-cluster/templates/backup.yaml
@@ -5,12 +5,12 @@ apiVersion: k8s.mariadb.com/v1alpha1
 kind: Backup
 metadata:
   name: {{ include "mariadb-cluster.fullname" $ }}-{{ .name }}
-  namespace: {{ default $.Release.Namespace .namespace }}
+  namespace: {{ .namespace | default (include "mariadb-cluster.namespace" $) }}
   labels:
     {{- include "mariadb-cluster.labels" $ | nindent 4 }}
 spec:
   mariaDbRef:
     name: {{ include "mariadb-cluster.fullname" $ }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "mariadb-cluster.namespace" $ }}
   {{- include "mariadb-cluster.omitKeys" (dict "object" . "keys" (list "name" "namespace" "mariaDbRef") "nindent" 2) }}
 {{- end }}

--- a/deploy/charts/mariadb-cluster/templates/database.yaml
+++ b/deploy/charts/mariadb-cluster/templates/database.yaml
@@ -5,12 +5,12 @@ apiVersion: k8s.mariadb.com/v1alpha1
 kind: Database
 metadata:
   name: {{ include "mariadb-cluster.fullname" $ }}-{{ .name }}
-  namespace: {{ default $.Release.Namespace .namespace }}
+  namespace: {{ .namespace | default (include "mariadb-cluster.namespace" $) }}
   labels:
     {{- include "mariadb-cluster.labels" $ | nindent 4 }}
 spec:
   mariaDbRef:
     name: {{ include "mariadb-cluster.fullname" $ }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "mariadb-cluster.namespace" $ }}
   {{- include "mariadb-cluster.omitKeys" (dict "object" . "keys" (list "namespace" "mariaDbRef") "nindent" 2) }}
 {{- end }}

--- a/deploy/charts/mariadb-cluster/templates/grant.yaml
+++ b/deploy/charts/mariadb-cluster/templates/grant.yaml
@@ -5,12 +5,12 @@ apiVersion: k8s.mariadb.com/v1alpha1
 kind: Grant
 metadata:
   name: {{ include "mariadb-cluster.fullname" $ }}-{{ .name }}
-  namespace: {{ default $.Release.Namespace .namespace }}
+  namespace: {{ .namespace | default (include "mariadb-cluster.namespace" $) }}
   labels:
     {{- include "mariadb-cluster.labels" $ | nindent 4 }}
 spec:
   mariaDbRef:
     name: {{ include "mariadb-cluster.fullname" $ }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "mariadb-cluster.namespace" $ }}
   {{- include "mariadb-cluster.omitKeys" (dict "object" . "keys" (list "name" "namespace" "mariaDbRef") "nindent" 2) }}
 {{- end }}

--- a/deploy/charts/mariadb-cluster/templates/mariadb.yaml
+++ b/deploy/charts/mariadb-cluster/templates/mariadb.yaml
@@ -2,6 +2,7 @@ apiVersion: k8s.mariadb.com/v1alpha1
 kind: MariaDB
 metadata:
   name: {{ include "mariadb-cluster.fullname" . }}
+  namespace: {{ include "mariadb-cluster.namespace" . }}
   labels:
     {{- include "mariadb-cluster.labels" . | nindent 4 }}
 spec:

--- a/deploy/charts/mariadb-cluster/templates/physicalbackup.yaml
+++ b/deploy/charts/mariadb-cluster/templates/physicalbackup.yaml
@@ -5,12 +5,12 @@ apiVersion: k8s.mariadb.com/v1alpha1
 kind: PhysicalBackup
 metadata:
   name: {{ include "mariadb-cluster.fullname" $ }}-{{ .name }}
-  namespace: {{ default $.Release.Namespace .namespace }}
+  namespace: {{ .namespace | default (include "mariadb-cluster.namespace" $) }}
   labels:
     {{- include "mariadb-cluster.labels" $ | nindent 4 }}
 spec:
   mariaDbRef:
     name: {{ include "mariadb-cluster.fullname" $ }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "mariadb-cluster.namespace" $ }}
   {{- include "mariadb-cluster.omitKeys" (dict "object" . "keys" (list "name" "namespace" "mariaDbRef") "nindent" 2) }}
 {{- end }}

--- a/deploy/charts/mariadb-cluster/templates/user.yaml
+++ b/deploy/charts/mariadb-cluster/templates/user.yaml
@@ -5,12 +5,12 @@ apiVersion: k8s.mariadb.com/v1alpha1
 kind: User
 metadata:
   name: {{ include "mariadb-cluster.fullname" $ }}-{{ .name }}
-  namespace: {{ default $.Release.Namespace .namespace }}
+  namespace: {{ .namespace | default (include "mariadb-cluster.namespace" $) }}
   labels:
     {{- include "mariadb-cluster.labels" $ | nindent 4 }}
 spec:
   mariaDbRef:
     name: {{ include "mariadb-cluster.fullname" $ }}
-    namespace: {{ $.Release.Namespace }}
+    namespace: {{ include "mariadb-cluster.namespace" $ }}
   {{- include "mariadb-cluster.omitKeys" (dict "object" . "keys" (list "namespace" "mariaDbRef") "nindent" 2) }}
 {{- end }}

--- a/internal/helmtest/mariadb_cluster_test.go
+++ b/internal/helmtest/mariadb_cluster_test.go
@@ -47,6 +47,8 @@ func TestClusterHelmMariaDB(t *testing.T) {
 	var mariadb v1alpha1.MariaDB
 	helm.UnmarshalK8SYaml(t, renderedData, &mariadb)
 
+	Expect(mariadb.Name).To(Equal(clusterHelmReleaseName))
+	Expect(mariadb.Namespace).To(Equal(kubectlopts.Namespace))
 	Expect(mariadb.Spec.Galera.Enabled).To(BeTrue())
 	Expect(mariadb.Spec.Metrics.Enabled).To(BeTrue())
 	Expect(mariadb.Spec.Replicas).To(Equal(int32(replicas)))


### PR DESCRIPTION
This should make templating predictable: https://github.com/helm/helm/issues/3553

P.S. I don't need this feature for mariadb-operator chart, thus this pr is scoped to mariadb-cluster chart only. But you are welcome to port it if need be. 