### PR TITLE
add support to generate secret names

### DIFF
--- a/deploy/charts/mariadb-cluster/templates/_helpers.tpl
+++ b/deploy/charts/mariadb-cluster/templates/_helpers.tpl
@@ -71,6 +71,19 @@ Usage:
 {{- end }}
 
 {{/*
+Generate a passwordSecretKeyRef.
+*/}}
+{{- define "mariadb-cluster.generatePasswordSecretKeyRef" -}}
+{{- if and .secretKeyRef.generate (not .secretKeyRef.name) }}
+  name: {{ include "mariadb-cluster.fullname" .global }}-{{ .name }}
+{{- else }}
+  name: {{ .secretKeyRef.name }}
+{{- end }}
+  generate: {{ .secretKeyRef.generate }}
+  key: {{ .secretKeyRef.key }}
+{{- end }}
+
+{{/*
 Validate Database CRs
 */}}
 {{- define "mariadb-cluster.validateDatabases" -}}

--- a/deploy/charts/mariadb-cluster/templates/mariadb.yaml
+++ b/deploy/charts/mariadb-cluster/templates/mariadb.yaml
@@ -6,4 +6,16 @@ metadata:
   labels:
     {{- include "mariadb-cluster.labels" . | nindent 4 }}
 spec:
-  {{- toYaml .Values.mariadb | nindent 2 }}
+  {{- if .Values.mariadb.rootPasswordSecretKeyRef }}
+  rootPasswordSecretKeyRef:
+    {{- include "mariadb-cluster.generatePasswordSecretKeyRef" (dict "secretKeyRef" .Values.mariadb.rootPasswordSecretKeyRef "global" $ "name" "root") | nindent 2 }}
+  {{- end }}
+  {{- if .Values.mariadb.passwordSecretKeyRef }}
+  passwordSecretKeyRef:
+    {{- include "mariadb-cluster.generatePasswordSecretKeyRef" (dict "secretKeyRef" .Values.mariadb.passwordSecretKeyRef "global" $ "name" .Values.mariadb.username) | nindent 2 }}
+  {{- end }}
+  {{- if .Values.mariadb.passwordHashSecretKeyRef }}
+  passwordHashSecretKeyRef:
+    {{- include "mariadb-cluster.generatePasswordSecretKeyRef" (dict "secretKeyRef" .Values.mariadb.passwordHashSecretKeyRef "global" $ "name" .Values.mariadb.username) | nindent 2 }}
+  {{- end }}
+  {{- include "mariadb-cluster.omitKeys" (dict "object" .Values.mariadb "keys" (list "rootPasswordSecretKeyRef" "passwordSecretKeyRef" "passwordHashSecretKeyRef") "nindent" 2) }}

--- a/deploy/charts/mariadb-cluster/values.yaml
+++ b/deploy/charts/mariadb-cluster/values.yaml
@@ -5,6 +5,7 @@ namespaceOverride: ""
 # https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/api_reference.md#mariadbspec
 mariadb:
   rootPasswordSecretKeyRef:
+    # If name is set to null and generate is true then secret key name will also be generated
     name: mariadb
     key: root-password
   storage:


### PR DESCRIPTION
Fixes #1566 and partially #1265 (because UserSpec.passwordSecretKeyRef takes in `SecretKeySelector` instead of `GeneratedSecretKeyRef`