### PR TITLE
Fixing `PhysicalBackup` scheduling for Galera

### DIFF
--- a/api/v1alpha1/mariadb_replication_types.go
+++ b/api/v1alpha1/mariadb_replication_types.go
@@ -444,14 +444,15 @@ func (m *MariaDB) IsSwitchingPrimary() bool {
 	return meta.IsStatusConditionFalse(m.Status.Conditions, ConditionTypePrimarySwitched)
 }
 
-// IsSwitchoverRequired indicates that a primary switchover operation is required.
-func (m *MariaDB) IsSwitchoverRequired() bool {
-	if m.Status.CurrentPrimaryPodIndex == nil || m.IsMaxScaleEnabled() {
+// IsReplicationSwitchoverRequired indicates that a primary switchover operation is required.
+func (m *MariaDB) IsReplicationSwitchoverRequired() bool {
+	if m.IsMaxScaleEnabled() || !m.IsReplicationEnabled() {
 		return false
 	}
-	currentPodIndex := ptr.Deref(m.Status.CurrentPrimaryPodIndex, 0)
-	desiredPodIndex := ptr.Deref(ptr.Deref(m.Spec.Replication, Replication{}).Primary.PodIndex, 0)
-	return currentPodIndex != desiredPodIndex
+	if m.Status.CurrentPrimaryPodIndex == nil || m.Spec.Replication == nil || m.Spec.Replication.Primary.PodIndex == nil {
+		return false
+	}
+	return *m.Status.CurrentPrimaryPodIndex != *m.Spec.Replication.Primary.PodIndex
 }
 
 // ReplicationRole represents the observed replication roles.

--- a/internal/controller/mariadb_controller_replica_recovery.go
+++ b/internal/controller/mariadb_controller_replica_recovery.go
@@ -36,7 +36,7 @@ func shouldReconcileReplicaRecovery(mdb *mariadbv1alpha1.MariaDB) bool {
 	if !mdb.IsReplicationEnabled() || !mdb.HasConfiguredReplication() {
 		return false
 	}
-	if mdb.IsSwitchingPrimary() || mdb.IsSwitchoverRequired() || mdb.IsInitializing() || mdb.IsScalingOut() ||
+	if mdb.IsSwitchingPrimary() || mdb.IsReplicationSwitchoverRequired() || mdb.IsInitializing() || mdb.IsScalingOut() ||
 		mdb.IsRestoringBackup() || mdb.IsResizingStorage() || mdb.IsUpdating() {
 		return false
 	}

--- a/internal/controller/mariadb_controller_scale_out.go
+++ b/internal/controller/mariadb_controller_scale_out.go
@@ -33,7 +33,7 @@ func (r *MariaDBReconciler) reconcileScaleOut(ctx context.Context, mariadb *mari
 		return ctrl.Result{}, err
 	}
 
-	isScalingOut, err := r.isScalingOut(ctx, mariadb, &sts)
+	isScalingOut, err := r.isScalingOut(mariadb, &sts)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -95,11 +95,11 @@ func (r *MariaDBReconciler) reconcileScaleOut(ctx context.Context, mariadb *mari
 	return ctrl.Result{}, nil
 }
 
-func (r *MariaDBReconciler) isScalingOut(ctx context.Context, mdb *mariadbv1alpha1.MariaDB, sts *appsv1.StatefulSet) (bool, error) {
+func (r *MariaDBReconciler) isScalingOut(mdb *mariadbv1alpha1.MariaDB, sts *appsv1.StatefulSet) (bool, error) {
 	if !mdb.IsReplicationEnabled() || !mdb.HasConfiguredReplication() || sts.Status.Replicas == 0 {
 		return false, nil
 	}
-	if mdb.IsSwitchingPrimary() || mdb.IsSwitchoverRequired() || mdb.IsInitializing() || mdb.IsRecoveringReplicas() ||
+	if mdb.IsSwitchingPrimary() || mdb.IsReplicationSwitchoverRequired() || mdb.IsInitializing() || mdb.IsRecoveringReplicas() ||
 		mdb.IsRestoringBackup() || mdb.IsResizingStorage() || mdb.IsUpdating() {
 		return false, nil
 	}

--- a/internal/controller/physicalbackup_controller.go
+++ b/internal/controller/physicalbackup_controller.go
@@ -269,7 +269,7 @@ func shouldReconcilePhysicalBackup(mdb *mariadbv1alpha1.MariaDB, logger logr.Log
 		logger.Info("Initialization in progress, skipping PhysicalBackup schedule...")
 		return false
 	}
-	if mdb.IsSwitchingPrimary() || mdb.IsSwitchoverRequired() {
+	if mdb.IsSwitchingPrimary() || mdb.IsReplicationSwitchoverRequired() {
 		logger.Info("Switchover in progress, skipping PhysicalBackup schedule...")
 		return false
 	}

--- a/internal/controller/pod_replication_controller.go
+++ b/internal/controller/pod_replication_controller.go
@@ -149,7 +149,7 @@ func (r *PodReplicationController) ReconcilePodNotReady(ctx context.Context, pod
 }
 
 func shouldReconcile(mdb *mariadbv1alpha1.MariaDB) bool {
-	if mdb.IsMaxScaleEnabled() || mdb.IsSwitchingPrimary() || mdb.IsSwitchoverRequired() ||
+	if mdb.IsMaxScaleEnabled() || mdb.IsSwitchingPrimary() || mdb.IsReplicationSwitchoverRequired() ||
 		mdb.IsRestoringBackup() || mdb.IsResizingStorage() || mdb.IsSuspended() {
 		return false
 	}

--- a/pkg/controller/replication/controller.go
+++ b/pkg/controller/replication/controller.go
@@ -139,7 +139,7 @@ func (r *ReplicationReconciler) Reconcile(ctx context.Context, mdb *mariadbv1alp
 	}
 	defer req.Close()
 
-	if mdb.IsSwitchoverRequired() {
+	if mdb.IsReplicationSwitchoverRequired() {
 		return ctrl.Result{}, r.reconcileSwitchover(ctx, req, switchoverLogger)
 	}
 	if result, err := r.reconcileReplication(ctx, req, logger); !result.IsZero() || err != nil {
@@ -152,7 +152,7 @@ func (r *ReplicationReconciler) reconcileReplication(ctx context.Context, req *R
 	if result, err := r.shouldReconcileReplication(ctx, req, logger); !result.IsZero() || err != nil {
 		return result, err
 	}
-	for _, i := range r.replicationPodIndexes(ctx, req) {
+	for _, i := range r.replicationPodIndexes(req) {
 		if result, err := r.ReconcileReplicationInPod(ctx, req, i, logger); !result.IsZero() || err != nil {
 			return result, err
 		}
@@ -192,7 +192,7 @@ func (r *ReplicationReconciler) shouldReconcileReplication(ctx context.Context, 
 	return ctrl.Result{}, nil
 }
 
-func (r *ReplicationReconciler) replicationPodIndexes(ctx context.Context, req *ReconcileRequest) []int {
+func (r *ReplicationReconciler) replicationPodIndexes(req *ReconcileRequest) []int {
 	podIndexes := []int{
 		*req.mariadb.Status.CurrentPrimaryPodIndex,
 	}

--- a/pkg/controller/replication/switchover.go
+++ b/pkg/controller/replication/switchover.go
@@ -27,7 +27,7 @@ type switchoverPhase struct {
 }
 
 func isSwitchoverStale(mdb *mariadbv1alpha1.MariaDB) bool {
-	return mdb.IsSwitchingPrimary() && !mdb.IsSwitchoverRequired()
+	return mdb.IsSwitchingPrimary() && !mdb.IsReplicationSwitchoverRequired()
 }
 
 func shouldReconcileSwitchover(mdb *mariadbv1alpha1.MariaDB) bool {
@@ -37,7 +37,7 @@ func shouldReconcileSwitchover(mdb *mariadbv1alpha1.MariaDB) bool {
 	if !mdb.HasConfiguredReplica() {
 		return false
 	}
-	return mdb.IsSwitchoverRequired()
+	return mdb.IsReplicationSwitchoverRequired()
 }
 
 func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *ReconcileRequest, switchoverLogger logr.Logger) error {


### PR DESCRIPTION
Fixes https://github.com/mariadb-operator/mariadb-operator/issues/1568

This PR fixes a regression where Galera physical backups are not being scheduled whenever the primary is not the Pod `0`.  The `IsSwitchoverRequired` helper was not quite right, not accounting for other topologies and defaulting to the `0` index.

Additionally, if fixes some warnings in the related files.