### PR TITLE
Improve secref handling in mariadb-cluster chart

### DIFF
--- a/deploy/charts/mariadb-cluster/README.md
+++ b/deploy/charts/mariadb-cluster/README.md
@@ -32,7 +32,8 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | databases | list | `[]` | The list of Database CRs. The `.mariaDbRef` keys will be ignored. The `.name` keys are required to generate distinct CR names. The `.namespace` keys are allowed to override `.Release.Namespace`. https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/api_reference.md#databasespec |
 | fullnameOverride | string | `""` |  |
 | grants | list | `[]` | The list of Grant CRs. The `.mariaDbRef` keys will be ignored. The `.name` keys are used to generate distinct CR names. The `.namespace` keys are allowed to override `.Release.Namespace`. https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/api_reference.md#grantspec |
-| mariadb | object | `{"galera":{"enabled":true},"replicas":3,"rootPasswordSecretKeyRef":{"key":"root-password","name":"mariadb"},"storage":{"size":"1Gi"}}` | MariaDB CR https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/api_reference.md#mariadbspec |
+| mariadb | object | `{"galera":{"enabled":true},"replicas":3,"rootPasswordSecretKeyRef":{"generate":true,"key":"root","name":""},"storage":{"size":"1Gi"}}` | MariaDB CR https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/api_reference.md#mariadbspec |
+| mariadb.rootPasswordSecretKeyRef.name | string | The chart will generate the Secret name e.g. `myrelease-mariadb-cluster-root` | The name of the Secret holding root password. |
 | nameOverride | string | `""` |  |
 | namespaceOverride | string | `""` |  |
 | physicalBackups | list | `[]` | The list of PhysicalBackup CRs. The `.mariaDbRef` keys will be ignored. The `.name` keys are used to generate distinct CR names. The `.namespace` keys are allowed to override `.Release.Namespace`. https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/api_reference.md#physicalbackup |

--- a/deploy/charts/mariadb-cluster/templates/_helpers.tpl
+++ b/deploy/charts/mariadb-cluster/templates/_helpers.tpl
@@ -124,3 +124,14 @@ Validate PhysicalBackup CRs
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Generate names for Secret references
+*/}}
+{{- define "mariadb-cluster.generateSecretRefNames" -}}
+{{- range list .Values.mariadb.rootPasswordSecretKeyRef .Values.mariadb.passwordSecretKeyRef .Values.mariadb.passwordHashSecretKeyRef }}
+{{- if and . (not .name) }}
+{{- $_ := set . "name" (printf "%s-%s" (include "mariadb-cluster.fullname" $) .key) -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/mariadb-cluster/templates/mariadb.yaml
+++ b/deploy/charts/mariadb-cluster/templates/mariadb.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     {{- include "mariadb-cluster.labels" . | nindent 4 }}
 spec:
+  {{- include "mariadb-cluster.generateSecretRefNames" . -}}
   {{- toYaml .Values.mariadb | nindent 2 }}

--- a/deploy/charts/mariadb-cluster/values.yaml
+++ b/deploy/charts/mariadb-cluster/values.yaml
@@ -5,8 +5,11 @@ namespaceOverride: ""
 # https://github.com/mariadb-operator/mariadb-operator/blob/main/docs/api_reference.md#mariadbspec
 mariadb:
   rootPasswordSecretKeyRef:
-    name: mariadb
-    key: root-password
+    # -- The name of the Secret holding root password.
+    # @default -- The chart will generate the Secret name e.g. `myrelease-mariadb-cluster-root`
+    name: ""
+    key: root
+    generate: true
   storage:
     size: 1Gi
   replicas: 3

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -158,10 +158,12 @@ This helm chart simplifies the deployment of a `MariaDB` cluster and its associa
 For example, by using the following `values.yaml` file to install the helm chart:
 
 ```yaml
+# In the following example the referenced secrets are managed externally.
 mariadb:
   rootPasswordSecretKeyRef:
     name: mariadb
     key: root-password
+    generate: false
   storage:
     size: 1Gi
   replicas: 3

--- a/internal/helmtest/mariadb_cluster_test.go
+++ b/internal/helmtest/mariadb_cluster_test.go
@@ -28,8 +28,8 @@ func TestClusterHelmMariaDB(t *testing.T) {
 
 	replicas := 3
 	storageSize := "1Gi"
-	rootPasswordSecretKeyRefKey := "mariadb"
-	rootPasswordSecretKeyRefName := "root-password"
+	rootPasswordSecretKeyRefKey := "root"
+	rootPasswordSecretKeyRefName := "mariadb"
 
 	opts := &helm.Options{
 		SetValues: map[string]string{
@@ -55,6 +55,34 @@ func TestClusterHelmMariaDB(t *testing.T) {
 	Expect(mariadb.Spec.Storage.Size.String()).To(Equal(storageSize))
 	Expect(mariadb.Spec.RootPasswordSecretKeyRef.Key).To(Equal(rootPasswordSecretKeyRefKey))
 	Expect(mariadb.Spec.RootPasswordSecretKeyRef.Name).To(Equal(rootPasswordSecretKeyRefName))
+}
+
+func TestClusterHelmMariaDBNoSecretKeyRefName(t *testing.T) {
+	RegisterTestingT(t)
+
+	rootPasswordSecretKeyRefKey := "root"
+	passwordSecretKeyRefKey := "mariadb-1"
+	passwordHashSecretKeyRefKey := "mariadb-2"
+
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"mariadb.rootPasswordSecretKeyRef.key":  rootPasswordSecretKeyRefKey,
+			"mariadb.rootPasswordSecretKeyRef.name": "",
+			"mariadb.passwordSecretKeyRef.key":      passwordSecretKeyRefKey,
+			"mariadb.passwordSecretKeyRef.name":     "",
+			"mariadb.passwordHashSecretKeyRef.key":  passwordHashSecretKeyRefKey,
+			"mariadb.passwordHashSecretKeyRef.name": "",
+		},
+		KubectlOptions: kubectlopts,
+	}
+
+	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/mariadb.yaml"})
+	var mariadb v1alpha1.MariaDB
+	helm.UnmarshalK8SYaml(t, renderedData, &mariadb)
+
+	Expect(mariadb.Spec.RootPasswordSecretKeyRef.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, rootPasswordSecretKeyRefKey)))
+	Expect(mariadb.Spec.PasswordSecretKeyRef.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, passwordSecretKeyRefKey)))
+	Expect(mariadb.Spec.PasswordHashSecretKeyRef.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, passwordHashSecretKeyRefKey)))
 }
 
 func TestClusterHelmDatabase(t *testing.T) {
@@ -116,8 +144,8 @@ func TestClusterHelmUser(t *testing.T) {
 	cleanupPolicy := "Delete"
 	host := "%"
 	maxUserConnections := 100
-	passwordSecretKeyRefKey := "mariadb"
-	passwordSecretKeyRefName := "password"
+	passwordSecretKeyRefKey := "root"
+	passwordSecretKeyRefName := "mariadb"
 	requeueInterval := "10h"
 	retryInterval := "30s"
 
@@ -240,10 +268,10 @@ func TestClusterHelmBackup(t *testing.T) {
 	endpoint := "minio.minio.svc.cluster.local:9000"
 	region := "us-east-1"
 	prefix := "mariadb-cluster"
-	accessKeyIdSecretKeyRefKey := "minio"
-	accessKeyIdSecretKeyRefName := "access-key-id"
-	secretAccessKeySecretKeyRefKey := "minio"
-	secretAccessKeySecretKeyRefName := "secret-access-key"
+	accessKeyIdSecretKeyRefKey := "access-key-id"
+	accessKeyIdSecretKeyRefName := "minio"
+	secretAccessKeySecretKeyRefKey := "secret-access-key"
+	secretAccessKeySecretKeyRefName := "minio"
 	cron := "0 0 * * *"
 
 	durationMaxRetention, _ := time.ParseDuration(maxRetention)
@@ -315,10 +343,10 @@ func TestClusterHelmPhysicalBackup(t *testing.T) {
 	endpoint := "minio.minio.svc.cluster.local:9000"
 	region := "us-east-1"
 	prefix := "mariadb-cluster"
-	accessKeyIdSecretKeyRefKey := "minio"
-	accessKeyIdSecretKeyRefName := "access-key-id"
-	secretAccessKeySecretKeyRefKey := "minio"
-	secretAccessKeySecretKeyRefName := "secret-access-key"
+	accessKeyIdSecretKeyRefKey := "access-key-id"
+	accessKeyIdSecretKeyRefName := "minio"
+	secretAccessKeySecretKeyRefKey := "secret-access-key"
+	secretAccessKeySecretKeyRefName := "minio"
 	cron := "0 0 * * *"
 
 	durationMaxRetention, _ := time.ParseDuration(maxRetention)


### PR DESCRIPTION
Fixes https://github.com/mariadb-operator/mariadb-operator/issues/1566

**Note:** this adds `generate: true` to the root secret reference to simplify testing for the newcomers. Thus, this change should be mentioned in the upgrade notes to allow old consumers to set it to false.