### PR TITLE
feat: use MYSQL_PWD env instead of --password flag in backup commands

### DIFF
--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -30,8 +30,8 @@ const (
 	batchScriptsMountPath = "/opt"
 	batchScriptsSqlFile   = "job.sql"
 	batchBackupDirFull    = "full"
-	batchUserEnv     = "MARIADB_OPERATOR_USER"
-	batchPasswordEnv = "MYSQL_PWD"
+	batchUserEnv          = "MARIADB_OPERATOR_USER"
+	batchPasswordEnv      = "MYSQL_PWD"
 )
 
 var (

--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -30,8 +30,8 @@ const (
 	batchScriptsMountPath = "/opt"
 	batchScriptsSqlFile   = "job.sql"
 	batchBackupDirFull    = "full"
-	batchUserEnv          = "MARIADB_OPERATOR_USER"
-	batchPasswordEnv      = "MARIADB_OPERATOR_PASSWORD"
+	batchUserEnv     = "MARIADB_OPERATOR_USER"
+	batchPasswordEnv = "MYSQL_PWD"
 )
 
 var (

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -60,9 +60,8 @@ func ConnectionFlags(co *CommandOpts, mariadb interfaces.Connector,
 	}
 
 	flags := fmt.Sprintf(
-		"--user=${%s} --password=${%s} --host=%s --port=%d",
+		"--user=${%s} --host=%s --port=%d",
 		co.UserEnv,
-		co.PasswordEnv,
 		host(mariadb, opts),
 		mariadb.GetPort(),
 	)

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -47,7 +47,7 @@ func TestConnectionFlags(t *testing.T) {
 					Port: 3306,
 				},
 			},
-			want: "--user=${USER} --password=${PASS} --host=test.default.svc.cluster.local --port=3306",
+			want: "--user=${USER} --host=test.default.svc.cluster.local --port=3306",
 		},
 		{
 			name: "basic flags with Galera",
@@ -64,7 +64,7 @@ func TestConnectionFlags(t *testing.T) {
 					},
 				},
 			},
-			want: "--user=${USER} --password=${PASS} --host=test-primary.default.svc.cluster.local --port=3306",
+			want: "--user=${USER} --host=test-primary.default.svc.cluster.local --port=3306",
 		},
 		{
 			name: "with database",
@@ -81,7 +81,7 @@ func TestConnectionFlags(t *testing.T) {
 					},
 				},
 			},
-			want: "--user=${USER} --password=${PASS} --host=test-primary.default.svc.cluster.local --port=3306 --database=test",
+			want: "--user=${USER} --host=test-primary.default.svc.cluster.local --port=3306 --database=test",
 		},
 		{
 			name: "with host override",
@@ -99,7 +99,7 @@ func TestConnectionFlags(t *testing.T) {
 				},
 			},
 			flagOpts: []ConnectionFlagOpt{WithHostConnectionFlag("custom-host")},
-			want:     "--user=${USER} --password=${PASS} --host=custom-host --port=3306",
+			want:     "--user=${USER} --host=custom-host --port=3306",
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Remove `--password` flag from backup/restore commands
- Use `MYSQL_PWD` environment variable instead (MariaDB clients auto-read this)
- Improves security by preventing password exposure in process listings (`ps`)

## Changes

| File | Change |
|------|--------|
| `pkg/command/command.go` | Remove `--password` from `ConnectionFlags` |
| `pkg/builder/batch_builder.go` | Change `MARIADB_OPERATOR_PASSWORD` → `MYSQL_PWD` |
| `pkg/command/command_test.go` | Update test expectations |

## Before vs After

```bash
# Before (password visible in ps)
mariadb-dump --user=root --password=secret --host=...

# After (password hidden in env var)
MYSQL_PWD=secret mariadb-dump --user=root --host=...
```

## Test

```bash
go test ./pkg/command/... -v  # PASS
go test ./pkg/builder/... -v  # PASS
```

Closes #234