### PR TITLE
feat: use source command instead of shell redirection in SQL jobs

### DIFF
--- a/pkg/command/sql.go
+++ b/pkg/command/sql.go
@@ -63,7 +63,7 @@ func (s *SqlCommand) ExecCommand(mariadb interfaces.Connector) (*Command, error)
 		"set -euo pipefail",
 		"echo '⚙️ Executing SQL script'",
 		fmt.Sprintf(
-			"mariadb %s < %s",
+			"mariadb %s -e 'source %s'",
 			sqlFlags,
 			s.SqlFile,
 		),


### PR DESCRIPTION
## Summary

- Replaces `mariadb %s < %s` with `mariadb %s -e 'source %s'` in SQL job execution
- More native and robust approach as suggested in the issue

Closes #235

---

**Note:** I noticed `pkg/command/backup.go` also uses the same shell redirection pattern. Should I update that file as well for consistency?