### PR TITLE
chore: Bump to latest go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.5-alpine3.21 AS builder
+FROM golang:1.25.7-alpine3.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mariadb-operator/mariadb-operator/v25
 
-go 1.25.5
+go 1.25.7
 
 require (
 	github.com/cert-manager/cert-manager v1.18.2


### PR DESCRIPTION
This fixes: CVE-2025-68121