### PR TITLE
test: Added int tests for sql resources with external mariadb deletion

### DIFF
--- a/internal/controller/external_mariadb_controller_test.go
+++ b/internal/controller/external_mariadb_controller_test.go
@@ -5,8 +5,12 @@ import (
 	"time"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v25/api/v1alpha1"
+	"github.com/mariadb-operator/mariadb-operator/v25/pkg/refresolver"
+	"github.com/mariadb-operator/mariadb-operator/v25/pkg/sql"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -164,6 +168,244 @@ var _ = Describe("External MariaDB spec", func() {
 		}, testTimeout, testInterval).Should(BeTrue())
 	})
 
+	It("should delete sql resources", func() {
+		By("Waiting for MariaDB to be ready")
+		expectMariadbReady(testCtx, k8sClient, testEmulateExternalMdbkey)
+
+		By("Creating External MariaDB")
+		emdbKey := types.NamespacedName{
+			Name:      "test-external-mariadb-default",
+			Namespace: testNamespace,
+		}
+		emdb := mariadbv1alpha1.ExternalMariaDB{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      emdbKey.Name,
+				Namespace: emdbKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.ExternalMariaDBSpec{
+				Host:     testEmulateExternalMdbHost,
+				Username: ptr.To("root"),
+				PasswordSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: testEmulatedExternalPwdKey.Name,
+					},
+					Key: testPwdSecretKey,
+				},
+				InheritMetadata: &mariadbv1alpha1.Metadata{
+					Labels: map[string]string{
+						"k8s.mariadb.com/test": "test",
+					},
+					Annotations: map[string]string{
+						"k8s.mariadb.com/test": "test",
+					},
+				},
+				TLS: &mariadbv1alpha1.ExternalTLS{
+					TLS: mariadbv1alpha1.TLS{
+						Enabled:  true,
+						Required: ptr.To(false),
+						ServerCASecretRef: &mariadbv1alpha1.LocalObjectReference{
+							Name: "mdb-emulate-external-test-ca",
+						},
+						ClientCertSecretRef: &mariadbv1alpha1.LocalObjectReference{
+							Name: "mdb-emulate-external-test-client-cert",
+						},
+						ServerCertSecretRef: &mariadbv1alpha1.LocalObjectReference{
+							Name: "mdb-emulate-external-test-server-cert",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &emdb)).To(Succeed())
+		DeferCleanup(func() {
+			deleteExternalMariadb(emdbKey, true)
+		})
+
+		By("Expecting ExternalMariaDB to be ready eventually")
+		Eventually(func(g Gomega) bool {
+			var mdb mariadbv1alpha1.ExternalMariaDB
+			g.Expect(k8sClient.Get(testCtx, emdbKey, &mdb)).To(Succeed())
+			return mdb.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Creating Database")
+		dbKey := types.NamespacedName{
+			Name:      "test-db-finalize",
+			Namespace: testNamespace,
+		}
+
+		db := mariadbv1alpha1.Database{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      dbKey.Name,
+				Namespace: dbKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.DatabaseSpec{
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{
+						Name: emdbKey.Name,
+					},
+					Kind:      mariadbv1alpha1.ExternalMariaDBKind,
+					WaitForIt: true,
+				},
+				CharacterSet: "utf8",
+				Collate:      "utf8_general_ci",
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &db)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(testCtx, &db))).To(Succeed())
+		})
+
+		By("Expecting Database to be ready eventually")
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(testCtx, dbKey, &db)).To(Succeed())
+			return db.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Creating User")
+		userKey := types.NamespacedName{
+			Name:      "test-user-finalize",
+			Namespace: testNamespace,
+		}
+		passwordSecretKey := types.NamespacedName{
+			Name:      "test-user-password-finalize",
+			Namespace: testNamespace,
+		}
+		passwordSecret := corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      passwordSecretKey.Name,
+				Namespace: passwordSecretKey.Namespace,
+			},
+			StringData: map[string]string{
+				"password": "test-password",
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &passwordSecret)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(testCtx, &passwordSecret)).To(Succeed())
+		})
+
+		user := mariadbv1alpha1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      userKey.Name,
+				Namespace: userKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.UserSpec{
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{
+						Name: emdbKey.Name,
+					},
+					Kind:      mariadbv1alpha1.ExternalMariaDBKind,
+					WaitForIt: true,
+				},
+				PasswordSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: passwordSecretKey.Name,
+					},
+					Key: "password",
+				},
+				MaxUserConnections: 20,
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &user)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(testCtx, &user))).To(Succeed())
+		})
+
+		By("Expecting User to be ready eventually")
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(testCtx, userKey, &user)).To(Succeed())
+			return user.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Creating Grant")
+		grantKey := types.NamespacedName{
+			Name:      "test-grant-finalize",
+			Namespace: testNamespace,
+		}
+		grant := mariadbv1alpha1.Grant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      grantKey.Name,
+				Namespace: grantKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.GrantSpec{
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{
+						Name: emdbKey.Name,
+					},
+					Kind:      mariadbv1alpha1.ExternalMariaDBKind,
+					WaitForIt: true,
+				},
+				Privileges: []string{
+					"SELECT",
+					"INSERT",
+					"UPDATE",
+				},
+				Database: dbKey.Name,
+				Table:    "*",
+				Username: userKey.Name,
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &grant)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(testCtx, &grant))).To(Succeed())
+		})
+
+		By("Expecting Grant to be ready eventually")
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(testCtx, grantKey, &grant)).To(Succeed())
+			return grant.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Deleting User")
+		Expect(k8sClient.Delete(testCtx, &user)).To(Succeed())
+
+		By("Deleting Grant")
+		Expect(k8sClient.Delete(testCtx, &grant)).To(Succeed())
+
+		By("Deleting Database")
+		Expect(k8sClient.Delete(testCtx, &db)).To(Succeed())
+
+		By("Expecting User to be deleted eventually")
+		Eventually(func() bool {
+			err := k8sClient.Get(testCtx, userKey, &mariadbv1alpha1.User{})
+			return apierrors.IsNotFound(err)
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Expecting Grant to be deleted eventually")
+		Eventually(func() bool {
+			err := k8sClient.Get(testCtx, grantKey, &mariadbv1alpha1.Grant{})
+			return apierrors.IsNotFound(err)
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Expecting Database to be deleted eventually")
+		Eventually(func() bool {
+			err := k8sClient.Get(testCtx, dbKey, &mariadbv1alpha1.Database{})
+			return apierrors.IsNotFound(err)
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Expecting User and Database to be deleted from MariaDB")
+		var emulatedMdb mariadbv1alpha1.MariaDB
+		Expect(k8sClient.Get(testCtx, testEmulateExternalMdbkey, &emulatedMdb)).To(Succeed())
+		refResolver := refresolver.New(k8sClient)
+		sqlClient, err := sql.NewClientWithMariaDB(testCtx, &emulatedMdb, refResolver)
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() {
+			sqlClient.Close()
+		})
+
+		Eventually(func(g Gomega) {
+			dbExists, err := sqlClient.Exists(testCtx, "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = ?;", dbKey.Name)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(dbExists).To(BeFalse())
+		}, testTimeout, testInterval).Should(Succeed())
+
+		Eventually(func(g Gomega) {
+			userExists, err := sqlClient.UserExists(testCtx, userKey.Name, "%")
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(userExists).To(BeFalse())
+		}, testTimeout, testInterval).Should(Succeed())
+	})
 })
 
 func TestGetVersion(t *testing.T) {


### PR DESCRIPTION
This is a continuation of PR #1606 to add INT tests