### PR TITLE
fix: accept compressed backup files in logical restore

### DIFF
--- a/pkg/backup/processor.go
+++ b/pkg/backup/processor.go
@@ -83,7 +83,9 @@ func (p *LogicalBackupProcessor) GetOldBackupFiles(backupFileNames []string, max
 
 // IsValidBackupFile determines whether a backup file name is valid.
 func (p *LogicalBackupProcessor) IsValidBackupFile(fileName string) bool {
-	if !strings.HasPrefix(fileName, "backup.") || !strings.HasSuffix(fileName, ".sql") {
+	// Must start with "backup." and contain ".sql" either as suffix (uncompressed)
+	// or before the compression extension (e.g. ".sql.gz", ".sql.bz2").
+	if !strings.HasPrefix(fileName, "backup.") || !strings.Contains(fileName, ".sql") {
 		return false
 	}
 	_, err := p.ParseCompressionAlgorithm(fileName)

--- a/pkg/backup/processor_test.go
+++ b/pkg/backup/processor_test.go
@@ -330,8 +330,18 @@ func TestLogicalIsValidBackupFile(t *testing.T) {
 			wantValid:  true,
 		},
 		{
-			name:       "valid with compression",
+			name:       "valid with legacy compression",
 			backupFile: "backup.2023-12-18T16:14:00Z.bzip2.sql",
+			wantValid:  true,
+		},
+		{
+			name:       "valid with gzip compression",
+			backupFile: "backup.2023-12-18T16:14:00Z.sql.gz",
+			wantValid:  true,
+		},
+		{
+			name:       "valid with bzip2 compression",
+			backupFile: "backup.2023-12-18T16:14:00Z.sql.bz2",
 			wantValid:  true,
 		},
 	}


### PR DESCRIPTION
## Summary
- `LogicalBackupProcessor.IsValidBackupFile()` rejected new-format compressed backups (`.sql.gz`, `.sql.bz2`) because it required files to end with `.sql`
- This was a regression from commit 4f538471 which changed compression format from `backup.{ts}.{algo}.sql` to `backup.{ts}.sql.{ext}`
- Changed `HasSuffix` to `Contains` so both compressed and uncompressed files pass the initial filter; the subsequent `ParseCompressionAlgorithm` and `parseDateInBackupFile` checks validate the full structure

## Test plan
- [x] Added test cases for new-format gzip (`.sql.gz`) and bzip2 (`.sql.bz2`) compressed files
- [x] All existing tests pass (31 suites)
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)