### PR TITLE
fix: guard bootstrapFrom defaulting to not overwrite immutable fields

### DIFF
--- a/api/v1alpha1/mariadb_types.go
+++ b/api/v1alpha1/mariadb_types.go
@@ -317,7 +317,9 @@ func (b *BootstrapFrom) validateMutuallyExclusive() error {
 func (b *BootstrapFrom) SetDefaults(mariadb *MariaDB) {
 	if b.PointInTimeRecoveryRef != nil {
 		stagingStorage := ptr.Deref(b.StagingStorage, StagingStorage{})
-		b.Volume = ptr.To(stagingStorage.VolumeOrEmptyDir(mariadb.BootstrapFromStagingPVCKey()))
+		if b.Volume == nil {
+			b.Volume = ptr.To(stagingStorage.VolumeOrEmptyDir(mariadb.BootstrapFromStagingPVCKey()))
+		}
 		return
 	}
 
@@ -337,7 +339,9 @@ func (b *BootstrapFrom) SetDefaults(mariadb *MariaDB) {
 	}
 	if b.BackupContentType == BackupContentTypePhysical && (b.S3 != nil || b.AzureBlob != nil) {
 		stagingStorage := ptr.Deref(b.StagingStorage, StagingStorage{})
-		b.Volume = ptr.To(stagingStorage.VolumeOrEmptyDir(mariadb.BootstrapFromStagingPVCKey()))
+		if b.Volume == nil {
+			b.Volume = ptr.To(stagingStorage.VolumeOrEmptyDir(mariadb.BootstrapFromStagingPVCKey()))
+		}
 	}
 }
 
@@ -346,18 +350,26 @@ func (b *BootstrapFrom) SetDefaultsWithPhysicalBackup(physicalBackup *PhysicalBa
 	if physicalBackup.Spec.Storage.VolumeSnapshot != nil {
 		return nil
 	}
-	volume, err := physicalBackup.Volume()
-	if err != nil {
-		return fmt.Errorf("error getting BackupSource volume: %v", err)
+	if b.Volume == nil {
+		volume, err := physicalBackup.Volume()
+		if err != nil {
+			return fmt.Errorf("error getting BackupSource volume: %v", err)
+		}
+		b.Volume = &volume
 	}
-	b.Volume = &volume
-	b.S3 = physicalBackup.Spec.Storage.S3
-	b.AzureBlob = physicalBackup.Spec.Storage.AzureBlob
+	if b.S3 == nil {
+		b.S3 = physicalBackup.Spec.Storage.S3
+	}
+	if b.AzureBlob == nil {
+		b.AzureBlob = physicalBackup.Spec.Storage.AzureBlob
+	}
 	return nil
 }
 
 func (b *BootstrapFrom) SetDefaultsWithVolumeSnapshotRef(ref *LocalObjectReference) {
-	b.VolumeSnapshotRef = ref
+	if b.VolumeSnapshotRef == nil {
+		b.VolumeSnapshotRef = ref
+	}
 }
 
 func (b *BootstrapFrom) TargetRecoveryTimeOrDefault() time.Time {


### PR DESCRIPTION
## Description

### Problem

After upgrading mariadb-operator, existing MariaDB CRs that have `bootstrapFrom` with `stagingStorage` drop to `Ready: False` without any user-initiated changes to the CR spec:

```
Error reconciling Spec: admission webhook "vmariadb-v1alpha1.kb.io" denied the request:
MariaDB.k8s.mariadb.com "mariadb-galera" is invalid:
  spec.bootstrapFrom.volume: Invalid value: {"persistentVolumeClaim":{"claimName":"mariadb-galera-bootstrap-staging"}}:
  'spec.bootstrapFrom.volume' field is immutable
```

CRs without `bootstrapFrom` (e.g. ones created without S3/backup restore) are unaffected.

### Root Cause

`BootstrapFrom.SetDefaults()` unconditionally recomputes derived fields (`volume`, `s3`, `azureBlob`, `volumeSnapshotRef`) on every reconciliation. The validating webhook correctly treats `spec.bootstrapFrom.volume` as immutable via `inmutableinit`. The controller is blocked by its own webhook.

**This bug was latent since the `inmutableinit` validation was introduced**, but was masked because the recomputed PVC name always matched the persisted value — `DeepEqual` passed, and the webhook had nothing to reject.

**The trigger** was commit [46538a5d](https://github.com/mariadb-operator/mariadb-operator/commit/46538a5d) which renamed the staging PVC key function from `PhysicalBackupStagingPVCKey()` (suffix `-pb-staging`) to `BootstrapFromStagingPVCKey()` (suffix `-bootstrap-staging`). After upgrade, the recomputed value diverges from the persisted one, exposing the latent immutability violation:

```
# Persisted in CR (set by old operator version):
bootstrapFrom:
  volume:
    persistentVolumeClaim:
      claimName: mariadb-galera-pb-staging

# Recomputed by new operator version:
bootstrapFrom:
  volume:
    persistentVolumeClaim:
      claimName: mariadb-galera-bootstrap-staging
```
### Analysis

All fields in the `BootstrapFrom` struct tagged with `webhook:"inmutableinit"` are listed below, along with whether they are overwritten by defaulting logic and whether this fix adds a nil guard.

| Field | `inmutableinit` | Overwritten by defaulting? | Nil guard added? | Notes |
|-------|:-:|:-:|:-:|-------|
| `backupRef` | ✅ | ❌ | ❌ | User-provided, never set by defaulting |
| `volumeSnapshotRef` | ✅ | ✅ `SetDefaultsWithVolumeSnapshotRef()` | ✅ | |
| `backupContentType` | ✅ | ✅ `SetDefaults()` | ❌ (not needed) | Already protected by `== ""` empty checks — won't overwrite existing value |
| `s3` | ✅ | ✅ `SetDefaultsWithPhysicalBackup()` | ✅ | |
| `azureBlob` | ✅ | ✅ `SetDefaultsWithPhysicalBackup()` | ✅ | |
| `volume` | ✅ | ✅ `SetDefaults()`, `SetDefaultsWithPhysicalBackup()` | ✅ | **This is the field that triggered the upgrade error** |

### Fix

Add nil guards in all `BootstrapFrom` defaulting methods — only set derived fields when they haven't been set yet:

- `SetDefaults()`: guard `b.Volume` with `if b.Volume == nil` (two locations: PITR path and physical backup S3/AzureBlob path)
- `SetDefaultsWithPhysicalBackup()`: guard `b.Volume`, `b.S3`, and `b.AzureBlob` individually
- `SetDefaultsWithVolumeSnapshotRef()`: guard `b.VolumeSnapshotRef`

This is consistent with how `inmutableinit` fields should be handled — set once, never overwritten by defaulting logic.

### Affected versions

- **Latent bug present since**: introduction of `inmutableinit` validation on `bootstrapFrom.volume`
- **Triggered by**: the PVC key rename in `46538a5d` (included in v26.x releases)
- **Verified fix**: tested on a live cluster with existing MariaDB CRs that had `bootstrapFrom` with the old `-pb-staging` PVC names — all CRs recovered to `Ready: True` after applying this fix

## Test plan

- [x] `make build` — compiles successfully
- [x] `make test` — all unit tests pass (api, pkg, webhook, helm)
- [x] Verified on live cluster: existing MariaDB CRs with old `-pb-staging` PVC names recover to `Ready: True`

