### PR TITLE
fix(helm): restart operator on configmap changes

### DIFF
--- a/deploy/charts/mariadb-operator/templates/operator/deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/operator/deployment.yaml
@@ -13,10 +13,11 @@ spec:
       {{- include "mariadb-operator.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/operator/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
         {{ toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "mariadb-operator.selectorLabels" . | nindent 8 }}
     spec:


### PR DESCRIPTION
## Summary
- Add `checksum/config` annotation to the operator deployment pod template that hashes the rendered `mariadb-operator-env` configmap
- When configmap values change via `helm upgrade` (e.g. image versions), the checksum changes and triggers a rolling restart of operator pods
- Without this, configmap changes are not picked up until pods are manually restarted

## Test plan
- [x] Helm template tests pass (`make test-helm`)
- [ ] Verify `helm template` output includes `checksum/config` annotation
- [ ] Verify `helm upgrade` with changed values triggers operator pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)