### PR TITLE
feat: Add configurable backup filename format

### DIFF
--- a/api/v1alpha1/backup_types.go
+++ b/api/v1alpha1/backup_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -60,6 +61,19 @@ type BackupSpec struct {
 	// +optional
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:booleanSwitch","urn:alm:descriptor:com.tectonic.ui:advanced"}
 	IgnoreGlobalPriv *bool `json:"ignoreGlobalPriv,omitempty"`
+	// FileNamePrefix is the prefix for backup file names. It defaults to 'backup'.
+	// Must not contain dots.
+	// +optional
+	// +kubebuilder:default=backup
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	FileNamePrefix string `json:"fileNamePrefix,omitempty" webhook:"inmutable"`
+	// TimestampFormat defines the format of the timestamp used in backup filenames.
+	// It defaults to 'iso8601'.
+	// +optional
+	// +kubebuilder:default=iso8601
+	// +kubebuilder:validation:Enum=iso8601;compact
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,xDescriptors={"urn:alm:descriptor:com.tectonic.ui:advanced"}
+	TimestampFormat BackupTimestampFormat `json:"timestampFormat,omitempty" webhook:"inmutable"`
 	// LogLevel to be used in the Backup Job. It defaults to 'info'.
 	// +optional
 	// +kubebuilder:default=info
@@ -131,6 +145,12 @@ func (b *Backup) Validate() error {
 	if err := b.Spec.Compression.Validate(); err != nil {
 		return fmt.Errorf("invalid Compression: %v", err)
 	}
+	if b.Spec.FileNamePrefix != "" && strings.Contains(b.Spec.FileNamePrefix, ".") {
+		return errors.New("'spec.fileNamePrefix' must not contain dots")
+	}
+	if err := b.Spec.TimestampFormat.Validate(); err != nil {
+		return fmt.Errorf("invalid TimestampFormat: %v", err)
+	}
 	if b.Spec.Storage.S3 == nil && b.Spec.StagingStorage != nil {
 		return errors.New("'spec.stagingStorage' may only be specified when 'spec.storage.s3' is set")
 	}
@@ -150,6 +170,12 @@ func (b *Backup) SetDefaults(mariadb *MariaDB) {
 	if b.Spec.IgnoreGlobalPriv == nil {
 		b.Spec.IgnoreGlobalPriv = ptr.To(ptr.Deref(mariadb.Spec.Galera, Galera{}).Enabled)
 	}
+	if b.Spec.FileNamePrefix == "" {
+		b.Spec.FileNamePrefix = "backup"
+	}
+	if b.Spec.TimestampFormat == BackupTimestampFormat("") {
+		b.Spec.TimestampFormat = TimestampFormatISO8601
+	}
 	b.Spec.SetDefaults(b.ObjectMeta, mariadb.ObjectMeta)
 }
 
@@ -162,6 +188,12 @@ func (b *Backup) SetExternalDefaults(mariadb *ExternalMariaDB) {
 	}
 	if b.Spec.BackoffLimit == 0 {
 		b.Spec.BackoffLimit = 5
+	}
+	if b.Spec.FileNamePrefix == "" {
+		b.Spec.FileNamePrefix = "backup"
+	}
+	if b.Spec.TimestampFormat == BackupTimestampFormat("") {
+		b.Spec.TimestampFormat = TimestampFormatISO8601
 	}
 
 	b.Spec.SetExternalDefaults(b.ObjectMeta)

--- a/api/v1alpha1/base_types.go
+++ b/api/v1alpha1/base_types.go
@@ -839,6 +839,45 @@ func CompressionFromExtension(ext string) (CompressAlgorithm, error) {
 	}
 }
 
+// BackupTimestampFormat defines the format of the timestamp used in backup filenames.
+type BackupTimestampFormat string
+
+const (
+	// TimestampFormatISO8601 uses ISO 8601 / RFC 3339 format: 2006-01-02T15:04:05Z
+	TimestampFormatISO8601 BackupTimestampFormat = "iso8601"
+	// TimestampFormatCompact uses a compact numeric format without separators: 20060102150405
+	TimestampFormatCompact BackupTimestampFormat = "compact"
+)
+
+func (f BackupTimestampFormat) Validate() error {
+	switch f {
+	case BackupTimestampFormat(""), TimestampFormatISO8601, TimestampFormatCompact:
+		return nil
+	default:
+		return fmt.Errorf("invalid timestamp format: %v, supported formats: [%v|%v]", f, TimestampFormatISO8601, TimestampFormatCompact)
+	}
+}
+
+// GoLayout returns the Go time layout string for parsing timestamps produced with this format.
+func (f BackupTimestampFormat) GoLayout() string {
+	switch f {
+	case TimestampFormatCompact:
+		return "20060102150405"
+	default:
+		return time.RFC3339
+	}
+}
+
+// ShellFormat returns the strftime format string used by the shell `date` command.
+func (f BackupTimestampFormat) ShellFormat() string {
+	switch f {
+	case TimestampFormatCompact:
+		return "%Y%m%d%H%M%S"
+	default:
+		return "%Y-%m-%dT%H:%M:%SZ"
+	}
+}
+
 // BackupStorage defines the final storage for backups.
 type BackupStorage struct {
 	// S3 defines the configuration to store backups in a S3 compatible storage.

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -57,7 +57,9 @@ var (
 
 	maxRetention time.Duration
 
-	compression string
+	compression     string
+	fileNamePrefix  string
+	timestampFormat string
 )
 
 func init() {
@@ -98,6 +100,10 @@ func init() {
 
 	RootCmd.PersistentFlags().StringVar(&compression, "compression", string(mariadbv1alpha1.CompressNone),
 		"Compression algorithm: none, gzip or bzip2.")
+	RootCmd.PersistentFlags().StringVar(&fileNamePrefix, "file-name-prefix", "backup",
+		"Prefix for backup file names.")
+	RootCmd.PersistentFlags().StringVar(&timestampFormat, "timestamp-format", string(mariadbv1alpha1.TimestampFormatISO8601),
+		"Timestamp format for backup file names: iso8601 or compact.")
 
 	RootCmd.PersistentFlags().StringVar(&physicalBackupDirPath, "physical-backup-dir-path", "",
 		"Directory path where the physical backup is located. Only considered when backup-content-type is Physical.")
@@ -209,7 +215,10 @@ func getBackupProcessor() (backup.BackupProcessor, error) {
 	switch backType {
 	case mariadbv1alpha1.BackupContentTypeLogical:
 		logger.Info("configuring logical backup processor")
-		return backup.NewLogicalBackupProcessor(), nil
+		return backup.NewLogicalBackupProcessor(
+			backup.WithLogicalBackupPrefix(fileNamePrefix),
+			backup.WithLogicalBackupTimestampFormat(mariadbv1alpha1.BackupTimestampFormat(timestampFormat)),
+		), nil
 	case mariadbv1alpha1.BackupContentTypePhysical:
 		logger.Info("configuring physical backup processor")
 		return backup.NewPhysicalBackupProcessor(), nil

--- a/config/crd/bases/k8s.mariadb.com_backups.yaml
+++ b/config/crd/bases/k8s.mariadb.com_backups.yaml
@@ -312,6 +312,12 @@ spec:
                 format: int32
                 minimum: 0
                 type: integer
+              fileNamePrefix:
+                default: backup
+                description: |-
+                  FileNamePrefix is the prefix for backup file names. It defaults to 'backup'.
+                  Must not contain dots.
+                type: string
               ignoreGlobalPriv:
                 description: |-
                   IgnoreGlobalPriv indicates to ignore the mysql.global_priv in backups.
@@ -1035,6 +1041,15 @@ spec:
               timeZone:
                 description: TimeZone defines the timezone associated with the cron
                   expression.
+                type: string
+              timestampFormat:
+                default: iso8601
+                description: |-
+                  TimestampFormat defines the format of the timestamp used in backup filenames.
+                  It defaults to 'iso8601'.
+                enum:
+                - iso8601
+                - compact
                 type: string
               tolerations:
                 description: Tolerations to be used in the Pod.

--- a/pkg/backup/processor.go
+++ b/pkg/backup/processor.go
@@ -28,11 +28,38 @@ type backupDiff struct {
 }
 
 // LogicalBackupProcessor processes logical backups.
-type LogicalBackupProcessor struct{}
+type LogicalBackupProcessor struct {
+	fileNamePrefix  string
+	timestampFormat mariadbv1alpha1.BackupTimestampFormat
+}
+
+// LogicalBackupProcessorOpt is an option to modify LogicalBackupProcessor behavior.
+type LogicalBackupProcessorOpt func(*LogicalBackupProcessor)
+
+// WithLogicalBackupPrefix configures a custom file name prefix (default: "backup").
+func WithLogicalBackupPrefix(prefix string) LogicalBackupProcessorOpt {
+	return func(p *LogicalBackupProcessor) {
+		p.fileNamePrefix = prefix
+	}
+}
+
+// WithLogicalBackupTimestampFormat configures a custom timestamp format (default: iso8601).
+func WithLogicalBackupTimestampFormat(f mariadbv1alpha1.BackupTimestampFormat) LogicalBackupProcessorOpt {
+	return func(p *LogicalBackupProcessor) {
+		p.timestampFormat = f
+	}
+}
 
 // NewLogicalBackupProcessor creates a new LogicalBackupProcessor.
-func NewLogicalBackupProcessor() BackupProcessor {
-	return &LogicalBackupProcessor{}
+func NewLogicalBackupProcessor(opts ...LogicalBackupProcessorOpt) BackupProcessor {
+	p := &LogicalBackupProcessor{
+		fileNamePrefix:  "backup",
+		timestampFormat: mariadbv1alpha1.TimestampFormatISO8601,
+	}
+	for _, setOpt := range opts {
+		setOpt(p)
+	}
+	return p
 }
 
 // GetBackupTargetFile returns the backup file whose timestamp is closest to, but not after, the target recovery time.
@@ -92,9 +119,8 @@ func (p *LogicalBackupProcessor) GetOldBackupFiles(backupFileNames []string, max
 
 // IsValidBackupFile determines whether a backup file name is valid.
 func (p *LogicalBackupProcessor) IsValidBackupFile(fileName string) bool {
-	// Must start with "backup." and contain ".sql" either as suffix (uncompressed)
-	// or before the compression extension (e.g. ".sql.gz", ".sql.bz2").
-	if !strings.HasPrefix(fileName, "backup.") || !strings.Contains(fileName, ".sql") {
+	prefix := p.fileNamePrefix + "."
+	if !strings.HasPrefix(fileName, prefix) || !strings.Contains(fileName, ".sql") {
 		return false
 	}
 	_, err := p.ParseCompressionAlgorithm(fileName)
@@ -159,7 +185,12 @@ func (p *LogicalBackupProcessor) parseDateInBackupFile(fileName string) (time.Ti
 	if len(parts) != 3 && len(parts) != 4 {
 		return time.Time{}, fmt.Errorf("invalid backup file name: %s", fileName)
 	}
-	return ParseBackupDate(parts[1])
+	layout := p.timestampFormat.GoLayout()
+	t, err := time.Parse(layout, parts[1])
+	if err != nil {
+		return time.Time{}, fmt.Errorf("error parsing backup date: %v", err)
+	}
+	return t, nil
 }
 
 // PhysicalBackupProcessor processes physical backups.

--- a/pkg/backup/processor_test.go
+++ b/pkg/backup/processor_test.go
@@ -528,6 +528,224 @@ func TestLogicalGetUncompressedBackupFile(t *testing.T) {
 	}
 }
 
+func TestLogicalCustomPrefixIsValidBackupFile(t *testing.T) {
+	p := NewLogicalBackupProcessor(
+		WithLogicalBackupPrefix("mydb"),
+	)
+	tests := []struct {
+		name       string
+		backupFile string
+		wantValid  bool
+	}{
+		{
+			name:       "default prefix rejected",
+			backupFile: "backup.2023-12-18T16:14:00Z.sql",
+			wantValid:  false,
+		},
+		{
+			name:       "custom prefix valid",
+			backupFile: "mydb.2023-12-18T16:14:00Z.sql",
+			wantValid:  true,
+		},
+		{
+			name:       "custom prefix with gzip",
+			backupFile: "mydb.2023-12-18T16:14:00Z.sql.gz",
+			wantValid:  true,
+		},
+		{
+			name:       "custom prefix with bzip2",
+			backupFile: "mydb.2023-12-18T16:14:00Z.sql.bz2",
+			wantValid:  true,
+		},
+		{
+			name:       "wrong prefix",
+			backupFile: "other.2023-12-18T16:14:00Z.sql",
+			wantValid:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid := p.IsValidBackupFile(tt.backupFile)
+			if tt.wantValid != valid {
+				t.Fatalf("unexpected backup file validity, expected: %v got: %v", tt.wantValid, valid)
+			}
+		})
+	}
+}
+
+func TestLogicalCompactTimestampIsValidBackupFile(t *testing.T) {
+	p := NewLogicalBackupProcessor(
+		WithLogicalBackupTimestampFormat(mariadbv1alpha1.TimestampFormatCompact),
+	)
+	tests := []struct {
+		name       string
+		backupFile string
+		wantValid  bool
+	}{
+		{
+			name:       "iso8601 rejected",
+			backupFile: "backup.2023-12-18T16:14:00Z.sql",
+			wantValid:  false,
+		},
+		{
+			name:       "compact valid",
+			backupFile: "backup.20231218161400.sql",
+			wantValid:  true,
+		},
+		{
+			name:       "compact with gzip",
+			backupFile: "backup.20231218161400.sql.gz",
+			wantValid:  true,
+		},
+		{
+			name:       "compact with bzip2",
+			backupFile: "backup.20231218161400.sql.bz2",
+			wantValid:  true,
+		},
+		{
+			name:       "invalid compact timestamp",
+			backupFile: "backup.2023121816.sql",
+			wantValid:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			valid := p.IsValidBackupFile(tt.backupFile)
+			if tt.wantValid != valid {
+				t.Fatalf("unexpected backup file validity, expected: %v got: %v", tt.wantValid, valid)
+			}
+		})
+	}
+}
+
+func TestLogicalCustomPrefixAndCompactGetTargetFile(t *testing.T) {
+	p := NewLogicalBackupProcessor(
+		WithLogicalBackupPrefix("mydb"),
+		WithLogicalBackupTimestampFormat(mariadbv1alpha1.TimestampFormatCompact),
+	)
+	tests := []struct {
+		name           string
+		backupFiles    []string
+		targetRecovery time.Time
+		wantFile       string
+		wantErr        bool
+	}{
+		{
+			name: "single compact backup",
+			backupFiles: []string{
+				"mydb.20231218155800.sql",
+			},
+			targetRecovery: time.Now(),
+			wantFile:       "mydb.20231218155800.sql",
+			wantErr:        false,
+		},
+		{
+			name: "multiple compact backups",
+			backupFiles: []string{
+				"mydb.20231218155800.sql",
+				"mydb.20231218160000.sql",
+				"mydb.20231218160300.sql",
+			},
+			targetRecovery: mustParseCompactDate(t, "20231218160100"),
+			wantFile:       "mydb.20231218160000.sql",
+			wantErr:        false,
+		},
+		{
+			name: "exact match",
+			backupFiles: []string{
+				"mydb.20231218155800.sql",
+				"mydb.20231218160000.sql",
+			},
+			targetRecovery: mustParseCompactDate(t, "20231218160000"),
+			wantFile:       "mydb.20231218160000.sql",
+			wantErr:        false,
+		},
+		{
+			name: "iso8601 files ignored",
+			backupFiles: []string{
+				"backup.2023-12-18T15:58:00Z.sql",
+			},
+			targetRecovery: time.Now(),
+			wantFile:       "",
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := p.GetBackupTargetFile(tt.backupFiles, tt.targetRecovery, logger)
+			if err != nil && !tt.wantErr {
+				t.Fatalf("unexpected error getting target recovery file: %v", err)
+			}
+			if tt.wantFile != file {
+				t.Fatalf("unexpected backup target file, expected: %v got: %v", tt.wantFile, file)
+			}
+			if tt.wantErr && err == nil {
+				t.Error("expect error to have occurred, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expect error to not have occurred, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestLogicalCustomPrefixAndCompactGetOldBackupFiles(t *testing.T) {
+	p := NewLogicalBackupProcessor(
+		WithLogicalBackupPrefix("mydb"),
+		WithLogicalBackupTimestampFormat(mariadbv1alpha1.TimestampFormatCompact),
+	)
+	previousNowFn := now
+	tests := []struct {
+		name         string
+		nowFn        func() time.Time
+		backupFiles  []string
+		maxRetention time.Duration
+		wantBackups  []string
+	}{
+		{
+			name:  "multiple old compact backups",
+			nowFn: testTimeFn(mustParseCompactDate(t, "20231222221000")),
+			backupFiles: []string{
+				"mydb.20231222130000.sql",
+				"mydb.20231222140000.sql",
+				"mydb.20231222150000.sql",
+				"mydb.20231222200000.sql",
+			},
+			maxRetention: 8 * time.Hour,
+			wantBackups: []string{
+				"mydb.20231222130000.sql",
+				"mydb.20231222140000.sql",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			now = tt.nowFn
+			t.Cleanup(func() {
+				now = previousNowFn
+			})
+
+			backups := p.GetOldBackupFiles(tt.backupFiles, tt.maxRetention, logger)
+			if !reflect.DeepEqual(tt.wantBackups, backups) {
+				t.Fatalf("unexpected backup files, expected: %v got: %v", tt.wantBackups, backups)
+			}
+		})
+	}
+}
+
+func mustParseCompactDate(t *testing.T, dateString string) time.Time {
+	t.Helper()
+	target, err := time.Parse("20060102150405", dateString)
+	if err != nil {
+		t.Fatalf("unexpected error parsing compact date: %v", err)
+	}
+	return target
+}
+
 func TestPhysicalGetTargetFile(t *testing.T) {
 	p := NewPhysicalBackupProcessor()
 	tests := []struct {

--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -68,6 +68,8 @@ func (b *Builder) BuildBackupJob(key types.NamespacedName, backup *mariadbv1alph
 		command.WithCleanupTargetFile(backupShouldCleanupTargetFile(backup)),
 		command.WithMaxRetention(backup.Spec.MaxRetention.Duration),
 		command.WithCompression(backup.Spec.Compression),
+		command.WithFileNamePrefix(backup.Spec.FileNamePrefix),
+		command.WithTimestampFormat(backup.Spec.TimestampFormat),
 		command.WithUserEnv(batchUserEnv),
 		command.WithPasswordEnv(batchPasswordEnv),
 		command.WithLogLevel(backup.Spec.LogLevel),

--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -34,6 +34,8 @@ type BackupOpts struct {
 	StartGtid            *replication.Gtid
 	TargetTime           time.Time
 	Compression          mariadbv1alpha1.CompressAlgorithm
+	FileNamePrefix       string
+	TimestampFormat      mariadbv1alpha1.BackupTimestampFormat
 	LogLevel             string
 	ExtraOpts            []string
 
@@ -109,6 +111,18 @@ func WithTargetTime(t time.Time) BackupOpt {
 func WithCompression(c mariadbv1alpha1.CompressAlgorithm) BackupOpt {
 	return func(bo *BackupOpts) {
 		bo.Compression = c
+	}
+}
+
+func WithFileNamePrefix(p string) BackupOpt {
+	return func(bo *BackupOpts) {
+		bo.FileNamePrefix = p
+	}
+}
+
+func WithTimestampFormat(f mariadbv1alpha1.BackupTimestampFormat) BackupOpt {
+	return func(bo *BackupOpts) {
+		bo.TimestampFormat = f
 	}
 }
 
@@ -349,6 +363,18 @@ func (b *BackupCommand) MariadbOperatorBackup() (*Command, error) {
 			b.LogLevel,
 		}...)
 	}
+	if b.FileNamePrefix != "" {
+		args = append(args, []string{
+			"--file-name-prefix",
+			b.FileNamePrefix,
+		}...)
+	}
+	if b.TimestampFormat != "" {
+		args = append(args, []string{
+			"--timestamp-format",
+			string(b.TimestampFormat),
+		}...)
+	}
 
 	args = append(args, b.s3Args()...)
 	args = append(args, b.absArgs()...)
@@ -573,19 +599,25 @@ fi`)
 }
 
 func (b *BackupCommand) newBackupFile() string {
+	prefix := b.FileNamePrefix
+	if prefix == "" {
+		prefix = "backup"
+	}
+	shellFmt := b.TimestampFormat.ShellFormat()
+
 	var fileName string
 	if b.Compression == mariadbv1alpha1.CompressNone {
 		fileName = fmt.Sprintf(
-			"backup.$(date -u +'%s').sql",
-			"%Y-%m-%dT%H:%M:%SZ",
+			"%s.$(date -u +'%s').sql",
+			prefix,
+			shellFmt,
 		)
 	} else {
-		// Use standard extension format: .sql.gz or .sql.bz2
-		// This allows tools like gunzip to recognize the file format
 		ext, _ := b.Compression.Extension()
 		fileName = fmt.Sprintf(
-			"backup.$(date -u +'%s').sql.%s",
-			"%Y-%m-%dT%H:%M:%SZ",
+			"%s.$(date -u +'%s').sql.%s",
+			prefix,
+			shellFmt,
 			ext,
 		)
 	}


### PR DESCRIPTION
## Summary
- Add two new optional fields to `BackupSpec`: `fileNamePrefix` (default: `"backup"`) and `timestampFormat` (enum: `iso8601`|`compact`, default: `iso8601`)
- Allows users to customize backup filenames, e.g. `mydb.20231218161400.sql.gz` instead of the hardcoded `backup.2023-12-18T16:14:00Z.sql.gz`
- Passes the new settings through the full chain: API types -> builder -> backup command -> backup binary -> processor

## Test plan
- [x] Existing processor tests pass (no regressions)
- [x] New tests for custom prefix validation (`TestLogicalCustomPrefixIsValidBackupFile`)
- [x] New tests for compact timestamp validation (`TestLogicalCompactTimestampIsValidBackupFile`)
- [x] New tests for combined prefix + compact target file selection (`TestLogicalCustomPrefixAndCompactGetTargetFile`)
- [x] New tests for combined prefix + compact retention cleanup (`TestLogicalCustomPrefixAndCompactGetOldBackupFiles`)
- [x] `make code` and `make manifests` run cleanly
- [x] Full project compiles with `go build ./...`
- [ ] E2E: deploy operator, create Backup with custom `fileNamePrefix`/`timestampFormat`, verify filenames match