### PR TITLE
Purge binglogs on promoted replica before resetting slave position

### DIFF
--- a/pkg/controller/replication/config.go
+++ b/pkg/controller/replication/config.go
@@ -53,6 +53,9 @@ func (r *ReplicationConfigClient) ConfigurePrimary(ctx context.Context, mariadb 
 		if err := client.ResetAllSlaves(ctx); err != nil {
 			return fmt.Errorf("error resetting slave: %v", err)
 		}
+		if err := client.ResetMaster(ctx); err != nil {
+			return fmt.Errorf("error resetting binlogs: %v", err)
+		}
 		if err := client.ResetGtidSlavePos(ctx); err != nil {
 			return fmt.Errorf("error resetting slave position: %v", err)
 		}


### PR DESCRIPTION
Since all replicas have `log_bin`, it is possible for a replica to end with non-empty `gtid_binlog_pos` after some transient/unintended transactions are run. And if that happens, this replica will no longer be able to be promoted to primary as it will stumble on the resetting slave position step:

```
mariadb-operator-779f6464c4-dkxg2 controller {"level":"error","ts":1773738520.9370427,"msg":"Reconciler error","controller":"mariadb","controllerGroup":"k8s.mariadb.com","controllerKind":"MariaDB","MariaDB":{"name":"mariadb-cluster-3-db","namespace":"database"},"namespace":"database","name":"mariadb-cluster-3-db","reconcileID":"b38c69ac-e018-4108-b608-f350192a3996","error":"error reconciling Replication: 1 error occurred:\n\t* error in Configure new primary switchover reconcile phase: error configuring new primary vars: error resetting slave position: Error 1948 (HY000): Specified value for @@gtid_slave_pos contains no value for replication domain 0. This conflicts with the binary log which contains GTID 0-10-2677488514. If MASTER_GTID_POS=CURRENT_POS is used, the binlog position will override the new value of @@gtid_slave_pos\n\n","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:474\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:421\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.22.4/pkg/internal/controller/controller.go:296"}
```

This PR intends to avoid such a deadlock.

closes https://github.com/mariadb-operator/mariadb-operator/issues/1669