### PR TITLE
Add app.kubernetes.io/managed-by label to all operator-managed resources

### DIFF
--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -9,6 +9,7 @@ import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/discovery"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/environment"
+	mdbmetadata "github.com/mariadb-operator/mariadb-operator/v26/pkg/metadata"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -52,6 +53,7 @@ func assertObjectMeta(t *testing.T, objMeta *metav1.ObjectMeta, wantLabels, want
 	if objMeta == nil {
 		t.Fatal("expecting object metadata to not be nil")
 	}
+	wantLabels = withManagedByLabel(wantLabels)
 	if wantLabels != nil && !reflect.DeepEqual(wantLabels, objMeta.Labels) {
 		t.Errorf("unexpected labels, want: %v  got: %v", wantLabels, objMeta.Labels)
 	}
@@ -70,4 +72,17 @@ func assertMeta(t *testing.T, meta *mariadbv1alpha1.Metadata, wantLabels, wantAn
 	if wantAnnotations != nil && !reflect.DeepEqual(wantAnnotations, meta.Annotations) {
 		t.Errorf("unexpected annotations, want: %v  got: %v", wantAnnotations, meta.Annotations)
 	}
+}
+
+func withManagedByLabel(labels map[string]string) map[string]string {
+	if labels == nil {
+		return nil
+	}
+
+	labelsCopy := make(map[string]string, len(labels)+1)
+	for k, v := range labels {
+		labelsCopy[k] = v
+	}
+	labelsCopy[mdbmetadata.KubernetesManagedByLabel] = mdbmetadata.KubernetesManagedByValue
+	return labelsCopy
 }

--- a/pkg/builder/metadata/metadata.go
+++ b/pkg/builder/metadata/metadata.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
+	"github.com/mariadb-operator/mariadb-operator/v26/pkg/metadata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -58,5 +59,6 @@ func (b *MetadataBuilder) WithAnnotations(annotations map[string]string) *Metada
 }
 
 func (b *MetadataBuilder) Build() metav1.ObjectMeta {
+	b.objMeta.Labels[metadata.KubernetesManagedByLabel] = metadata.KubernetesManagedByValue
 	return b.objMeta
 }

--- a/pkg/builder/metadata/metadata_test.go
+++ b/pkg/builder/metadata/metadata_test.go
@@ -1,0 +1,37 @@
+package metadata
+
+import (
+	"testing"
+
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
+	pkgmetadata "github.com/mariadb-operator/mariadb-operator/v26/pkg/metadata"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestMetadataBuilderSetsManagedByLabel(t *testing.T) {
+	meta := NewMetadataBuilder(types.NamespacedName{
+		Name:      "test",
+		Namespace: "default",
+	}).Build()
+
+	if got := meta.Labels[pkgmetadata.KubernetesManagedByLabel]; got != pkgmetadata.KubernetesManagedByValue {
+		t.Fatalf("expected %s=%s, got %q", pkgmetadata.KubernetesManagedByLabel, pkgmetadata.KubernetesManagedByValue, got)
+	}
+}
+
+func TestMetadataBuilderPreservesManagedByLabel(t *testing.T) {
+	meta := NewMetadataBuilder(types.NamespacedName{
+		Name:      "test",
+		Namespace: "default",
+	}).
+		WithMetadata(&mariadbv1alpha1.Metadata{
+			Labels: map[string]string{
+				pkgmetadata.KubernetesManagedByLabel: "custom-value",
+			},
+		}).
+		Build()
+
+	if got := meta.Labels[pkgmetadata.KubernetesManagedByLabel]; got != pkgmetadata.KubernetesManagedByValue {
+		t.Fatalf("expected %s=%s, got %q", pkgmetadata.KubernetesManagedByLabel, pkgmetadata.KubernetesManagedByValue, got)
+	}
+}

--- a/pkg/metadata/metadata.go
+++ b/pkg/metadata/metadata.go
@@ -8,6 +8,8 @@ var (
 	KubernetesEndpointSliceManagedByLabel = "endpointslice.kubernetes.io/managed-by"
 	KubernetesEndpointSliceManagedByValue = "mariadb-operator.k8s.mariadb.com"
 	KubernetesHostnameLabel               = "kubernetes.io/hostname"
+	KubernetesManagedByLabel              = "app.kubernetes.io/managed-by"
+	KubernetesManagedByValue              = "mariadb-operator"
 
 	ReplicationAnnotation = "k8s.mariadb.com/replication"
 	GtidAnnotation        = "k8s.mariadb.com/gtid"


### PR DESCRIPTION
## Summary

Add the standard Kubernetes `app.kubernetes.io/managed-by: mariadb-operator` label to operator-managed objects built through `MetadataBuilder`. This enables users to target operator-created resources with a single label selector useful for NetworkPolicies, monitoring, and RBAC scoping.

Fixes #1186

## What changed

- Defined `KubernetesManagedByLabel` and `KubernetesManagedByValue`
- The label is enforced in `MetadataBuilder.Build()` so every resource gets it regardless of `inheritMetadata` configuration, this is an operator-owned label reflecting an operational fact, not a user preference (same approach as Prometheus Operator and etc.)

## What it does NOT touch

`LabelsBuilder` and `Selector.MatchLabels` are completely untouched. StatefulSet selectors are immutable after creation - adding a label there would break every existing deployment on upgrade.

## Upgrade impact

- Pod template labels change. With rolling update strategies this can trigger a one-time rollout on first reconciliation after upgrade; with non-rolling strategies, pods may require manual recreate/delete to pick up the label.
- Retroactive label backfill on already existing resources is currently reconciler-dependent. Services merge labels from the desired object today, while some other resources patch a narrower subset of fields. All newly created resources get the label immediately.
- VolumeClaimTemplate PVCs will not receive the label since they use `LabelsBuilder`, not `MetadataBuilder`.

## Follow-up

- Reconciler label drift fix: update StatefulSet, ConfigMap, Secret, and other reconcilers to patch `ObjectMeta.Labels` on existing resources (same pattern as `ServiceReconciler`)
