### PR TITLE
test: migrate pkg/reflect tests to Ginkgo

### DIFF
--- a/pkg/reflect/reflect_test.go
+++ b/pkg/reflect/reflect_test.go
@@ -1,40 +1,33 @@
 package reflect
 
 import (
-	"testing"
 	"unsafe"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestIsNil(t *testing.T) {
-	tests := []struct {
-		name  string
-		input interface{}
-		want  bool
-	}{
-		{"nil channel", (chan int)(nil), true},
-		{"nil func", (func())(nil), true},
-		{"nil interface containing nil pointer", interface{}((*int)(nil)), true},
-		{"nil interface", nil, true},
-		{"nil map", (map[string]int)(nil), true},
-		{"nil pointer", (*int)(nil), true},
-		{"nil slice", ([]int)(nil), true},
-		{"nil unsafe pointer", (unsafe.Pointer)(nil), true},
-		{"non-nil channel", make(chan int), false},
-		{"non-nil func", func() {}, false},
-		{"non-nil int", 123, false},
-		{"non-nil interface", interface{}(0), false},
-		{"non-nil map", map[string]int{}, false},
-		{"non-nil pointer", new(int), false},
-		{"non-nil slice", []int{}, false},
-		{"non-nil string", "hello", false},
-		{"non-nil unsafe pointer", unsafe.Pointer(new(int)), false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := IsNil(tt.input); got != tt.want {
-				t.Errorf("IsNil(%v) = %v, want %v", tt.input, got, tt.want)
-			}
-		})
-	}
-}
+var _ = Describe("IsNil", func() {
+	DescribeTable("detects nil values correctly",
+		func(input interface{}, want bool) {
+			Expect(IsNil(input)).To(Equal(want))
+		},
+		Entry("nil channel", (chan int)(nil), true),
+		Entry("nil func", (func())(nil), true),
+		Entry("nil interface containing nil pointer", interface{}((*int)(nil)), true),
+		Entry("nil interface", nil, true),
+		Entry("nil map", (map[string]int)(nil), true),
+		Entry("nil pointer", (*int)(nil), true),
+		Entry("nil slice", ([]int)(nil), true),
+		Entry("nil unsafe pointer", (unsafe.Pointer)(nil), true),
+		Entry("non-nil channel", make(chan int), false),
+		Entry("non-nil func", func() {}, false),
+		Entry("non-nil int", 123, false),
+		Entry("non-nil interface", interface{}(0), false),
+		Entry("non-nil map", map[string]int{}, false),
+		Entry("non-nil pointer", new(int), false),
+		Entry("non-nil slice", []int{}, false),
+		Entry("non-nil string", "hello", false),
+		Entry("non-nil unsafe pointer", unsafe.Pointer(new(int)), false),
+	)
+})

--- a/pkg/reflect/suite_test.go
+++ b/pkg/reflect/suite_test.go
@@ -1,0 +1,13 @@
+package reflect
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReflect(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Reflect Suite")
+}


### PR DESCRIPTION
Migrates \`pkg/reflect\` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- \`suite_test.go\`: new file, Ginkgo suite bootstrap
- \`reflect_test.go\`: \`TestIsNil\` (17 cases) → \`DescribeTable\` with 17 \`Entry\` items
  All Entry names match the original \`t.Run()\` names exactly.

Verified with:
\`\`\`
go test ./pkg/reflect/...
\`\`\`

Part of #368.