### PR TITLE
test: migrate pkg/hash tests to Ginkgo

### DIFF
--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -1,9 +1,8 @@
 package hash
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 type TestStruct struct {
@@ -11,66 +10,30 @@ type TestStruct struct {
 	Field2 int    `json:"field2"`
 }
 
-func TestHashJSON(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   any
-		want    string
-		wantErr bool
-	}{
-		{
-			name:    "Struct",
-			input:   TestStruct{Field1: "value1", Field2: 42},
-			want:    Hash(`{"field1":"value1","field2":42}`),
-			wantErr: false,
-		},
-		{
-			name:    "Slice of structs",
-			input:   []TestStruct{{Field1: "value1", Field2: 42}, {Field1: "value2", Field2: 84}},
-			want:    Hash(`[{"field1":"value1","field2":42},{"field1":"value2","field2":84}]`),
-			wantErr: false,
-		},
-		{
-			name:    "Empty struct",
-			input:   TestStruct{},
-			want:    Hash(`{"field1":"","field2":0}`),
-			wantErr: false,
-		},
-		{
-			name: "Map",
-			input: map[string]string{
-				"a": "1",
-				"d": "4",
-				"b": "2",
-				"e": "5",
-				"c": "3",
-			},
-			want:    Hash(`{"a":"1","b":"2","c":"3","d":"4","e":"5"}`),
-			wantErr: false,
-		},
-		{
-			name:    "Nil",
-			input:   nil,
-			want:    Hash("null"),
-			wantErr: false,
-		},
-		{
-			name:    "Invalid input type",
-			input:   make(chan int),
-			want:    "",
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := HashJSON(tt.input)
-			if tt.wantErr {
-				assert.Error(t, err)
+var _ = Describe("HashJSON", func() {
+	DescribeTable("hashes various inputs",
+		func(input any, want string, wantErr bool) {
+			got, err := HashJSON(input)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
 			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, tt.want, got)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(got).To(Equal(want))
 			}
-		})
-	}
-}
+		},
+		Entry("Struct", TestStruct{Field1: "value1", Field2: 42}, Hash(`{"field1":"value1","field2":42}`), false),
+		Entry("Slice of structs",
+			[]TestStruct{{Field1: "value1", Field2: 42}, {Field1: "value2", Field2: 84}},
+			Hash(`[{"field1":"value1","field2":42},{"field1":"value2","field2":84}]`),
+			false,
+		),
+		Entry("Empty struct", TestStruct{}, Hash(`{"field1":"","field2":0}`), false),
+		Entry("Map",
+			map[string]string{"a": "1", "b": "2", "c": "3", "d": "4", "e": "5"},
+			Hash(`{"a":"1","b":"2","c":"3","d":"4","e":"5"}`),
+			false,
+		),
+		Entry("Nil", nil, Hash("null"), false),
+		Entry("Invalid input type", make(chan int), "", true),
+	)
+})

--- a/pkg/hash/suite_test.go
+++ b/pkg/hash/suite_test.go
@@ -1,0 +1,13 @@
+package hash
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHash(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Hash Suite")
+}


### PR DESCRIPTION
Migrates \`pkg/hash\` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- \`suite_test.go\`: new file, Ginkgo suite bootstrap
- \`hash_test.go\`: \`TestHashJSON\` (6 cases) → \`DescribeTable\` with 6 \`Entry\` items
  All Entry names match the original \`t.Run()\` names exactly.

Verified with:
\`\`\`
go test ./pkg/hash/...
\`\`\`

Part of #368.