### PR TITLE
Add replication role label to metrics

### DIFF
--- a/pkg/builder/servicemonitor_builder.go
+++ b/pkg/builder/servicemonitor_builder.go
@@ -34,6 +34,7 @@ func (b *Builder) BuildServiceMonitor(mariadb *mariadbv1alpha1.MariaDB) (*monito
 		int(mariadb.Spec.Replicas),
 		mariadb.InternalServiceKey().Name,
 		mariadb.Spec.Port,
+		mariadb.Status.CurrentPrimaryPodIndex,
 		withEndpointInterval(metrics.ServiceMonitor.Interval),
 		withEndpointScrapeTimeout(metrics.ServiceMonitor.ScrapeTimeout),
 	)
@@ -79,6 +80,7 @@ func (b *Builder) BuildMaxScaleServiceMonitor(mxs *mariadbv1alpha1.MaxScale) (*m
 		int(mxs.Spec.Replicas),
 		mxs.InternalServiceKey().Name,
 		mxs.Spec.Admin.Port,
+		nil,
 		withEndpointInterval(metrics.ServiceMonitor.Interval),
 		withEndpointScrapeTimeout(metrics.ServiceMonitor.ScrapeTimeout),
 	)
@@ -119,15 +121,16 @@ func withEndpointScrapeTimeout(scrapeTimeout string) endpointOpt {
 }
 
 func serviceMonitorEndpoints(objMeta metav1.ObjectMeta, replicas int, serviceName string, port int32,
-	opts ...endpointOpt) []monitoringv1.Endpoint {
+	primaryPodIndex *int, opts ...endpointOpt) []monitoringv1.Endpoint {
 	endpoints := make([]monitoringv1.Endpoint, replicas)
 
 	for i := 0; i < replicas; i++ {
 		podName := statefulset.PodName(objMeta, i)
 		podFQDN := statefulset.PodFQDNWithService(objMeta, i, serviceName)
 		endpoint := monitoringv1.Endpoint{
-			Path: "/probe",
-			Port: MetricsPortName,
+			Path:           "/probe",
+			Port:           MetricsPortName,
+			RelabelConfigs: roleRelabelConfig(i, primaryPodIndex),
 			MetricRelabelConfigs: []monitoringv1.RelabelConfig{
 				{
 					Action:      "replace",
@@ -159,4 +162,21 @@ func serviceMonitorEndpoints(objMeta metav1.ObjectMeta, replicas int, serviceNam
 		endpoints[i] = endpoint
 	}
 	return endpoints
+}
+
+func roleRelabelConfig(podIndex int, primaryPodIndex *int) []monitoringv1.RelabelConfig {
+	if primaryPodIndex == nil {
+		return nil
+	}
+	role := "replica"
+	if podIndex == *primaryPodIndex {
+		role = "primary"
+	}
+	return []monitoringv1.RelabelConfig{
+		{
+			Action:      "replace",
+			Replacement: ptr.To(role),
+			TargetLabel: "role",
+		},
+	}
 }

--- a/pkg/builder/servicemonitor_builder_test.go
+++ b/pkg/builder/servicemonitor_builder_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
+	"k8s.io/utils/ptr"
 )
 
 func TestServiceMonitorMeta(t *testing.T) {
@@ -28,7 +29,7 @@ func TestServiceMonitorMeta(t *testing.T) {
 			},
 		},
 		{
-			name: "no meta",
+			name: "with meta",
 			mariadb: &mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -61,6 +62,58 @@ func TestServiceMonitorMeta(t *testing.T) {
 				t.Fatalf("unexpected error building ServiceMonitor: %v", err)
 			}
 			assertObjectMeta(t, &svcMonitor.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
+		})
+	}
+}
+
+func TestRoleRelabelConfig(t *testing.T) {
+	tests := []struct {
+		name            string
+		podIndex        int
+		primaryPodIndex *int
+		wantRole        string
+	}{
+		{
+			name:            "primary index is nil",
+			podIndex:        0,
+			primaryPodIndex: nil,
+			wantRole:        "",
+		},
+		{
+			name:            "pod is primary",
+			podIndex:        0,
+			primaryPodIndex: ptr.To(0),
+			wantRole:        "primary",
+		},
+		{
+			name:            "pod is replica",
+			podIndex:        1,
+			primaryPodIndex: ptr.To(0),
+			wantRole:        "replica",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			roleRelabelConfig := roleRelabelConfig(tt.podIndex, tt.primaryPodIndex)
+			if tt.wantRole == "" {
+				if roleRelabelConfig != nil {
+					t.Errorf("expected empty relabel config, got %v", roleRelabelConfig)
+				}
+				return
+			}
+			if len(roleRelabelConfig) != 1 {
+				t.Fatalf("expected 1 relabel config, got %d", len(roleRelabelConfig))
+			}
+			cfg := roleRelabelConfig[0]
+			if cfg.Action != "replace" {
+				t.Errorf("expected action 'replace', got %q", cfg.Action)
+			}
+			if cfg.TargetLabel != "role" {
+				t.Errorf("expected target label 'role', got %q", cfg.TargetLabel)
+			}
+			if cfg.Replacement == nil || *cfg.Replacement != tt.wantRole {
+				t.Errorf("expected role %q, got %v", tt.wantRole, cfg.Replacement)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR adds an optional `role` label to metrics that can be either `primary` or `replica`.

This can be used by consumers to fine tune custom alerts.