### PR TITLE
docs: add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,259 @@
+# AGENTS.md
+
+Guidance for AI coding assistants working in `mariadb-operator/mariadb-operator`. Read this file before making changes.
+
+## Project overview
+
+mariadb-operator is a Kubernetes operator for MariaDB built with controller-runtime. It manages the full lifecycle of MariaDB clusters including replication, Galera, backups, restores, and point-in-time recovery. The operator exposes a `k8s.mariadb.com/v1alpha1` API group with CRDs for MariaDB, Backup, PhysicalBackup, Restore, User, Grant, Database, Connection, SQLJob, MaxScale, ExternalMariaDB, and PointInTimeRecovery.
+
+The codebase follows a **phase-based reconciliation** pattern where the main `Reconcile` loop iterates over an ordered list of phase functions. Each phase returns `(ctrl.Result, error)` and short-circuits on non-zero results. Sub-reconcilers in `pkg/controller/` handle child resource reconciliation (StatefulSets, Services, Secrets, ConfigMaps, RBAC, Certificates, etc.).
+
+## Repository layout
+
+- `api/v1alpha1/` -- CRD type definitions, kubebuilder markers, and field indexers
+- `cmd/controller/` -- Entry point with cobra-based multi-command (controller, webhook, backup, restore, pitr, init, agent)
+- `internal/controller/` -- All Kubernetes controllers (MariaDB, Backup, Restore, User, Grant, Database, Connection, SQLJob, MaxScale, etc.)
+- `internal/webhook/v1alpha1/` -- Validation webhooks per CRD
+- `pkg/` -- Shared packages:
+  - `pkg/builder/` -- Central builder for Kubernetes resources (StatefulSets, Services, Jobs, etc.)
+  - `pkg/controller/` -- Sub-reconcilers (secret, configmap, statefulset, service, rbac, auth, deployment, pvc, servicemonitor, certificate, replication, galera, sql, batch)
+  - `pkg/sql/` -- SQL client for MariaDB operations (users, grants, databases, replication, Galera)
+  - `pkg/condition/` -- Status condition management (Ready, Complete, and MariaDB-specific conditions)
+  - `pkg/refresolver/` -- Reference resolver for Kubernetes objects (Secrets, ConfigMaps, MariaDB, MaxScale, etc.)
+  - `pkg/watch/` -- WatcherIndexer for indexed watches on external resources
+  - `pkg/environment/` -- Operator and pod environment configuration
+  - `pkg/discovery/` -- Runtime API discovery for optional features (cert-manager, Prometheus, VolumeSnapshot)
+- `config/` -- Kubernetes manifests for operator deployment (CRDs, RBAC, webhooks)
+- `deploy/` -- Generated deployment manifests and Helm chart
+- `test/e2e/` -- End-to-end tests with Ginkgo/Gomega
+- `make/` -- Split Makefile targets (build, dev, deploy, gen, helm, etc.)
+
+## Build and test commands
+
+All targets in the root `Makefile`, which includes modular files under `make/`.
+
+- `make build` -- Build the `bin/mariadb-operator` binary
+- `make docker-build` -- Build Docker image
+- `make docker-dev` -- Build and load image into KIND cluster
+- `make run` -- Run controller locally against a cluster (runs lint first)
+- `make webhook` -- Run webhook server locally
+- `make test` -- Run unit tests (api, pkg, helmtest, webhook)
+- `make test-int` -- Run integration tests against envtest (controller tests)
+- `make test-int-basic` -- Run basic integration tests only
+- `make lint` -- Run golangci-lint
+- `make gen` -- Run all code generation (manifests, deepcopy, embed, helm, docs, examples)
+- `make manifests` -- Generate CRDs, RBAC, and webhook manifests via controller-gen
+- `make code` -- Generate DeepCopy methods via controller-gen
+- `make release` -- Test release locally with goreleaser
+
+Run a single test: `make test TEST_ARGS='-run TestMyTest -v'`
+Run a single integration test: `make test-int TEST_ARGS='-run TestMyTest -v'`
+
+## Controller patterns
+
+### Phase-based reconciliation
+
+The main MariaDB controller defines an ordered slice of `reconcilePhaseMariaDB` structs. Each phase has a name and a reconcile function. The loop iterates phases, logs progress, handles errors with status patching, and short-circuits on non-zero results:
+
+```go
+phases := []reconcilePhaseMariaDB{
+    {Name: "Spec", Reconcile: r.setSpecDefaults},
+    {Name: "Status", Reconcile: r.reconcileStatus},
+    // ... more phases
+}
+for _, p := range phases {
+    result, err := p.Reconcile(ctx, &mariadb)
+    if err != nil {
+        if shouldSkipPhase(err) { continue }
+        // Patch status with failure, aggregate errors
+    }
+    if !result.IsZero() { return result, err }
+}
+```
+
+**When adding a new phase**, append to the slice in the correct logical order. Phase ordering matters: infrastructure (Secrets, ConfigMaps, TLS, RBAC) comes before workloads (StatefulSet, Services), which comes before data operations (Replication, SQL, Restore).
+
+### Sub-reconciler pattern
+
+Sub-reconcilers in `pkg/controller/` handle reconciliation of child Kubernetes resources. They are injected into the main controller struct and follow a consistent pattern:
+
+```go
+type StatefulSetReconciler struct {
+    Client    client.Client
+    Scheme    *runtime.Scheme
+    Builder   *builder.Builder
+    Discovery *discovery.Discovery
+}
+
+func (r *StatefulSetReconciler) Reconcile(ctx context.Context, mdb *mariadbv1alpha1.MariaDB) error {
+    sts, err := r.Builder.BuildMariadbStatefulSet(mdb)
+    // ... create or patch using server-side apply or client.MergeFrom
+}
+```
+
+### SQL reconciler pattern (generic)
+
+The `pkg/controller/sql/controller.go` provides a generic reconciler used by User, Grant, Database, and SQLJob controllers. Key interfaces:
+
+- `Resource` -- The CRD being reconciled (MariaDBRef, IsBeingDeleted, RequeueInterval, etc.)
+- `WrappedReconciler` -- Resource-specific SQL operations and status patching
+- `Finalizer` -- Cleanup logic on deletion
+
+The generic controller handles: deletion finalization, MariaDB reference resolution, health waiting, binlog replay checking, SQL client creation, and requeue with jitter.
+
+### Status patching
+
+Use `client.MergeFrom()` for status patches. The pattern is:
+
+```go
+func (r *Reconciler) patchStatus(ctx context.Context, obj *MyCRD, patcher func(*MyCRDStatus) error) error {
+    patch := client.MergeFrom(obj.DeepCopy())
+    patcher(&obj.Status)
+    return r.Status().Patch(ctx, obj, patch)
+}
+```
+
+### Condition management
+
+Use `pkg/condition` for status conditions. Two main types:
+- `Ready` -- For resources with ongoing lifecycle (MariaDB, User, Grant, etc.)
+- `Complete` -- For one-time resources (Backup, Restore, SQLJob)
+
+Set conditions using helpers like `conditions.SetReadyHealthy(c)`, `conditions.SetReadyFailed(c)`, `conditions.SetReadyWithStatefulSet(c, sts)`.
+
+### Watch and indexing
+
+Use `pkg/watch.WatcherIndexer` to set up indexed watches on external resources. Each CRD that references external resources implements `IndexerFuncForFieldPath` and registers watches in its `Index*` function (e.g. `api/v1alpha1/mariadb_indexes.go`).
+
+## Webhook patterns
+
+Validation webhooks live in `internal/webhook/v1alpha1/`. Each CRD has a validator that implements `admission.Validator[*Type]`. The pattern:
+
+```go
+type MariaDBCustomValidator struct{}
+var _ admission.Validator[*v1alpha1.MariaDB] = &MariaDBCustomValidator{}
+
+func (v *MariaDBCustomValidator) ValidateCreate(ctx context.Context, obj *v1alpha1.MariaDB) (admission.Warnings, error) {
+    validateFns := []func(*v1alpha1.MariaDB) error{
+        validateHA, validateReplication, validateStorage, ...
+    }
+    for _, fn := range validateFns {
+        if err := fn(obj); err != nil { return nil, err }
+    }
+    return nil, nil
+}
+```
+
+Immutable fields are enforced via `pkg/webhook/inmutable_webhook.go` using struct tags `webhook:"inmutable"` and `webhook:"inmutableinit"`. Always call the immutable validator first in `ValidateUpdate`.
+
+## SQL client
+
+The `pkg/sql/` package provides a comprehensive MariaDB client. Key operations:
+- **Connection**: `NewClient()`, `NewClientWithMariaDB()`, `NewInternalClientWithPodIndex()`, `NewLocalClientWithPodEnv()`
+- **Users**: `CreateUser`, `DropUser`, `AlterUser`, `UserExists`
+- **Privileges**: `Grant`, `Revoke`
+- **Database**: `CreateDatabase`, `DropDatabase`
+- **Replication**: `ChangeMaster`, `StartSlave`, `StopAllSlaves`, `ResetAllSlaves`, `WaitForReplicaGtid`
+- **Galera**: `GaleraClusterSize`, `GaleraClusterStatus`, `GaleraLocalState`
+- **Binary logs**: `ResetMaster`, `BinaryLogIndex`, `GtidBinlogPos`, `GtidCurrentPos`, `SetGtidSlavePos`
+- **Locking**: `LockTablesWithReadLock`, `UnlockTables`, `EnableReadOnly`, `DisableReadOnly`
+
+Always use the appropriate client constructor for the context:
+- `NewClientWithMariaDB` -- From the controller, connecting to a MariaDB CR
+- `NewInternalClientWithPodIndex` -- Connecting to a specific pod by index
+- `NewLocalClientWithPodEnv` -- From inside a pod (init containers, sidecars)
+
+## Kubernetes best practices
+
+- **Owner references**: Always set `OwnerReferences` on child resources so they are garbage-collected when the parent is deleted. Use `ctrl.SetControllerReference()`.
+- **Finalizers**: Add finalizers for cleanup logic on deletion. The generic SQL reconciler handles this pattern. Use `client.IgnoreNotFound()` when deleting resources in finalizers.
+- **Reconcile idempotency**: Every reconcile must be idempotent. Use `Get` + `Create` or `Update` pattern, or server-side apply. Never assume state.
+- **Status subresource**: Always patch status separately from spec. Never mutate spec in status updates.
+- **Requeue with backoff**: Return `ctrl.Result{RequeueAfter: duration}` for expected wait conditions. Use jitter to avoid thundering herds.
+- **Resource limits**: Controllers should set `controller.Options{MaxConcurrentReconciles: n}` to avoid overwhelming the API server.
+- **Leader election**: The manager enables leader election by default. Only one controller instance reconciles at a time.
+- **RBAC markers**: Use `//+kubebuilder:rbac:` markers above reconciler structs. Run `make manifests` to generate RBAC YAML.
+
+## Database best practices
+
+- **Idempotent SQL**: All SQL operations must be idempotent. Use `CREATE USER IF NOT EXISTS` semantics (check existence first, then create or alter).
+- **Connection handling**: Always close SQL connections. The `sql.Client` handles connection lifecycle, but be aware of connection timeouts.
+- **Replication safety**: When modifying data on a primary, ensure replicas have caught up using `WaitForReplicaGtid` before proceeding.
+- **Galera consensus**: Galera operations require cluster quorum. Check `GaleraClusterSize` and `GaleraClusterStatus` before making changes.
+- **Backup consistency**: Logical backups use `mysqldump` with `--single-transaction`. Physical backups use `mariabackup` with binlog position tracking.
+- **Binary log retention**: PITR depends on binary logs. Ensure binlog retention is configured appropriately.
+- **Password handling**: Never log passwords. Use `SecretKeyRef` patterns to reference passwords stored in Kubernetes Secrets.
+
+## Code conventions
+
+### Error handling
+
+- Use `github.com/hashicorp/go-multierror` for error aggregation
+- Wrap errors with `fmt.Errorf("context: %w", err)` for chain inspection
+- Use `apierrors.IsNotFound(err)` for Kubernetes not-found checks
+- Return `client.IgnoreNotFound(err)` in reconcile loops for cleanup operations
+- Never swallow errors silently
+
+### Logging
+
+- Use `log.FromContext(ctx)` from controller-runtime
+- Named loggers: `log.FromContext(ctx).WithName("component")`
+- Verbose levels: `logger.V(1).Info("message")` for debug-level logging
+- Never log secrets, passwords, or tokens
+
+### Import organization
+
+1. Standard library
+2. Third-party imports
+3. Project imports (`github.com/mariadb-operator/mariadb-operator/v26/...`)
+4. Kubernetes imports (`k8s.io/...`, `sigs.k8s.io/...`)
+
+### Builder pattern
+
+Use `pkg/builder.Builder` to construct Kubernetes resources. The builder holds the scheme, environment, and discovery client. Methods like `BuildMariadbStatefulSet`, `BuildService`, `BuildBackupJob` etc. produce resources with proper labels, owner references, and environment configuration.
+
+### Environment configuration
+
+The operator reads configuration from environment variables via `pkg/environment.OperatorEnv`. Related images (MariaDB, MaxScale, Exporter) are injected at deployment time. Never hardcode image references.
+
+## Testing
+
+### Unit tests
+
+- Use Ginkgo v2 / Gomega
+- Structured in `*_test.go` files alongside source
+- Run with `make test`
+
+### Integration tests
+
+- Use controller-runtime's `envtest` for an in-process fake Kubernetes API
+- Test suite in `internal/controller/suite_test.go` installs cert-manager and volume snapshot CRDs
+- Run with `make test-int`
+- Tests are labeled (e.g. `Label("basic")`) for selective execution with `--label-filter=basic`
+
+### E2E tests
+
+- Use Ginkgo/Gomega with kind clusters
+- Live against real Kubernetes clusters with real MariaDB pods
+- Located in `test/e2e/`
+
+## Codegen and generated files
+
+- `make manifests` -- Generates CRDs, RBAC, webhook configs via controller-gen
+- `make code` -- Generates DeepCopy methods
+- `make embed-entrypoint` -- Fetches MariaDB docker entrypoint script
+- `make helm-gen` -- Generates Helm chart from config/
+- `make gen` -- Runs all code generation
+
+**Never hand-edit** generated files in `config/crd/bases/`, `config/rbac/`, or deepcopy output.
+
+## Gotchas and non-obvious rules
+
+- **Module path is versioned**: The Go module path is `github.com/mariadb-operator/mariadb-operator/v26`. All internal imports use the `v26` prefix. When adding new imports, use the correct versioned path.
+- **Phase ordering matters**: The reconciliation phase order in `mariadb_controller.go` is carefully designed. Infrastructure phases must complete before workload phases, which must complete before data phases. Adding a new phase requires understanding its dependencies.
+- **envtest setup**: Integration tests require `controller-runtime/pkg/envtest` Kubernetes binaries. Run `make envtest` to install them. The `KUBEBUILDER_ASSETS` env var must point to the installed binaries.
+- **CRD size limit**: CRDs have a hard Kubernetes limit of 1MB. The `make crd-size` target enforces a 900KB soft limit. Adding large OpenAPI v3 schemas to CRDs can exceed this limit.
+- **Multi-command binary**: The `cmd/controller/main.go` uses cobra to support multiple commands (controller, webhook, backup CLI, restore CLI, pitr CLI, init, agent). The controller and webhook commands share the same binary.
+- **Related images**: The operator does not bundle MariaDB, MaxScale, or exporter images. They are referenced via environment variables (`RELATED_IMAGE_*`) and must be available in the target cluster's registry.
+- **Webhook certificates**: For local development, use `make cert-webhook` to generate self-signed certificates. The webhook command reads certs from `WEBHOOK_PKI_DIR`.
+- **Galera library path**: The Galera shared library path (`MARIADB_GALERA_LIB_PATH`) differs between MariaDB image variants (alpine vs ubi). Set correctly in the Makefile or environment.

--- a/skills/mariadb-operator-pr-review/SKILL.md
+++ b/skills/mariadb-operator-pr-review/SKILL.md
@@ -1,0 +1,216 @@
+---
+name: mariadb-operator-pr-review
+description: >
+  Perform a structured PR review for mariadb-operator. Evaluates correctness, safety, pitfalls,
+  backwards compatibility, and code quality against project-specific patterns: phase-based reconciliation,
+  CRD lifecycle, StatefulSet impact, SQL idempotency, replication topology, Galera consensus, and webhook validation.
+  Use when asked to review a PR, assess a diff, or evaluate a pull request in the mariadb-operator repository.
+license: Apache-2.0
+metadata:
+  author: mariadb-operator
+  version: "1.0"
+compatibility: Requires GitHub API access (gh CLI or MCP tools) and the mariadb-operator repository checkout.
+allowed-tools: Read, Grep, Glob, Bash(git:*), Bash(gh:*)
+---
+
+# mariadb-operator PR Review Skill
+
+You are a maintainer of mariadb-operator performing an initial review of a pull request. Your job is to evaluate the PR for correctness, safety, pitfalls, and backwards compatibility, then provide an overall assessment.
+
+## Context
+
+Before reviewing, read `AGENTS.md` at the repository root for foundational patterns and conventions.
+
+---
+
+## Input
+
+You will be given a PR URL or PR number. Extract:
+
+1. **PR metadata** — title, body, author, state, add/remove stats
+2. **Full unified diff** of all changed files
+3. **Pre-change version** of each changed file in `/api/v1alpha1/`, `/internal/controller/`, or `/pkg/controller/` to understand existing behavior
+4. **Existing review comments** and reviews
+5. **Callers** of new functions or changed signatures (search blast radius)
+
+---
+
+## Review Process
+
+### Step 0: Quick Rejects
+
+Before deep review, check for automatic concerns. If any fire, note it prominently in your assessment.
+
+- [ ] CRD types changed but no `zz_generated.deepcopy.go` or `/config/crd/` updates in diff
+- [ ] No tests added for new functionality
+- [ ] StatefulSet pod template changed without good reason, causing a rolling restart impact on the next release
+
+### Step 1: Understand the Change
+
+- Read the PR description and diff to understand WHAT changed and WHY
+- Identify every function, type, or API surface touched
+- Map the call graph: what calls the changed code, what does it call
+- Note any behavioral changes vs purely structural changes (renames, formatting)
+- Classify the PR type: feature, bugfix, refactor, docs, dependency bump, generated files only
+
+### Step 2: Evaluate Each Dimension
+
+Evaluate the PR across these five dimensions. For each, state **PASS / CONCERN / FAIL** and justify.
+
+#### A. Correctness
+
+Does the code do what the PR claims? Check:
+
+- Logic is sound: control flow, conditionals, loops, error handling
+- API usage is valid: are functions/calls used according to their contract?
+- Edge cases: nil/empty/zero values, boundary conditions, race conditions
+- Type safety: pointers, generics, interfaces used correctly
+
+**Project-specific checks:**
+
+- **CRD changes**: If `/api/v1alpha1/` types are modified, were generated artifacts updated? Check `zz_generated.deepcopy.go`, `/config/crd/`, and `/deploy/crds/` are included in the PR.
+- **Reconciliation order**: New phases added in the correct position? Phases must run in dependency order (e.g. secrets before configmaps that reference them).
+- **Webhook validation**: If new fields are added, are validation webhooks and CEL constraints updated?
+- **Owner references**: New K8s resources set `OwnerReferences` for garbage collection?
+- **Error wrapping**: All errors wrapped with context? `multierror` used where multiple errors bundle?
+- **Sentinel errors**: `ErrSkipReconciliationPhase` used correctly with `errors.Is()`?
+- **Kubernetes API semantics**: Changes to CRDs valid per Kubernetes documentation?
+
+#### B. Safety
+
+Could this change cause data loss, outages, or security issues? Check:
+
+- Destructive operations: deletes, drops, truncates, overwrites
+- Concurrency: shared state, locks, goroutine safety, idempotency
+- Failure modes: what happens when dependencies fail, timeouts occur, or partial updates happen
+- Privilege escalation or secret exposure
+- Resource exhaustion: unbounded loops, missing limits, memory leaks
+- Rollback risk: can the change be reverted cleanly, or does it leave the system inconsistent
+
+**Project-specific checks:**
+
+- **StatefulSet changes**: Does the diff touch pod template, volume claims, or update strategy? These trigger rolling restarts or require manual intervention.
+- **Backup and restore paths**: Changes to backup logic could affect data recoverability. Check PITR, physical backup, and volume snapshot code paths.
+- **Replication topology**: Changes to replication logic could compromise the stability of the asynchronous replication topology.
+- **Secret handling**: Are credentials handled properly? No secrets logged, exposed in events, or stored plaintext where they should be encrypted.
+
+#### C. Pitfall Detection
+
+What subtle problems might surface later? Check:
+
+- Churn: does the change cause unnecessary resource updates, reconciliations, or API calls in hot paths
+- Cardinality: for metrics, logs, or indexed data, does the change multiply series, rows, or events
+- Stale state windows: are there periods where old and new state coexist, causing inconsistency
+- Cascading effects: does changing X silently break Y that depends on the old behavior
+- Assumptions that hold today but may not (e.g. "only one replica", "always runs on Linux")
+- Testing gaps: scenarios the diff doesn't cover but should
+
+**Project-specific checks:**
+
+- **Reconciliation churn**: Does the change cause unnecessary updates in hot paths? Check hash or equality logic that gates `Patch()` calls. A missing equality check causes infinite reconcile loops.
+- **Requeue behavior**: Does the change affect when/how often the controller requeues? Missing requeue on async operations leaves resources unreconciled.
+- **Controller-runtime client caching**: Does the code use the cached client correctly? Writes go through the cached client; reads that need live data use the uncached client.
+- **Testing gaps**: Are there Ginkgo tests with `Label("basic")` for the change? Integration tests using shared helpers from `utils_test.go`?
+
+#### D. Backwards Compatibility
+
+Is this change safe for existing users? Check:
+
+- API surface: added, removed, or changed parameters, fields, endpoints, labels
+- Default behavior: do defaults change, affecting users who rely on implicit behavior
+- Schema or data format: wire formats, DB schemas, config files, serialized state
+- Removals: are deprecated things actually gone, or properly transitioned
+- Migration path: do users need to take action, or is it transparent
+
+**Project-specific checks:**
+
+- **CRD schema changes**: New required fields break existing CRs. New optional fields need defaults. Removing or renaming fields is breaking.
+- **`webhook:"immutable"` tags**: Adding immutability to existing fields is breaking for users who need to update those fields.
+- **API version**: This is `v1alpha1`, which allows changes, but breaking changes still need communication and migration guidance.
+- **Helm chart values**: Do `/deploy/` chart values and `/examples/` manifests need updating?
+- **Additive vs behavioral vs breaking**: Classify each finding. Additive (new optional field, new CRD type) is safe. Behavioral (changed default, altered logic) is risky. Removals are breaking.
+
+#### E. Code Quality
+
+Is the code well-written and maintainable? Check:
+
+- Follows existing conventions: naming, structure, error handling patterns, imports
+- Complexity: is the change appropriately scoped, or does it over-engineer
+- Testability: are new functions isolated and testable
+- Dead code: unused variables, unreachable branches, leftover debug code
+- Formatting and style consistency with the surrounding codebase
+
+**Project-specific checks:**
+
+- **Lint compliance**: Must pass golangci-lint v2 — cyclo < 22, nesting < 12, line length < 140, no unchecked errors (`errcheck`), context passed to all HTTP/K8s calls (`noctx`)
+- **Test coverage**: New code has Ginkgo tests with appropriate `Label("basic")` or `Label("full")`
+- **Import ordering**: Standard lib, third party, project imports, each grouped
+- **Generated files**: If `make gen` output changed, it should be committed as part of the PR
+
+### Step 3: Overall Assessment
+
+Give one of four verdicts:
+
+- **Approve**: No substantive issues. The change is correct, safe, and well-written.
+- **Approve with notes**: Correct and safe, but has operational considerations or suggestions worth documenting before merge.
+- **Request changes**: Has correctness or safety issues that must be fixed before merge.
+- **Block**: Fundamental flaw in approach, severe safety risk, or breaking change without migration.
+
+Include:
+- A 1-2 sentence summary of what the PR does
+- The verdict
+- Specific, actionable items to address (if any)
+- Estimated risk level: LOW / MEDIUM / HIGH
+
+---
+
+## What Not to Flag
+
+Avoid raising issues on:
+
+- Generated file changes (`zz_generated.deepcopy.go`, CRD YAML in `/config/crd/`, `/deploy/crds/`) as code quality concerns — these are mechanical outputs
+- Missing godoc on internal functions — not a project convention
+- Go module version bumps from dependabot — trusted automation
+- Changes to `/examples/` or `/docs/` without corresponding code changes — may be preemptive
+- Formatting differences in auto-formatted files — CI enforces `gofmt` / `goimports`
+
+---
+
+## Output Format
+
+Use this exact structure:
+
+```
+PR Review:
+
+Summary:
+<1-2 sentences describing what the PR does and why>
+
+Correctness:
+<PASS / CONCERN / FAIL>
+<Justification with specific code references>
+
+Safety:
+<PASS / CONCERN / FAIL>
+<Justification with specific code references>
+
+Pitfall Detection:
+<PASS / CONCERN / FAIL>
+<Justification with specific code references>
+
+Backwards Compatibility:
+<PASS / CONCERN / FAIL>
+<Bullet points with specific findings. Classify each as additive, behavioral change, or breaking.>
+
+Code Quality:
+<PASS / CONCERN / FAIL>
+<Justification with specific code references>
+
+Overall Assessment:
+<Approve / Approve with notes / Request changes / Block>
+
+Risk level: <LOW / MEDIUM / HIGH>
+
+Suggested before merge:
+<Actionable items, if any. Empty if none.>
+```


### PR DESCRIPTION
Add project-specific guidance covering controller patterns, SQL client usage, Kubernetes and database best practices, code conventions, testing, and gotchas for AI agents working on the mariadb-operator codebase.