### PR TITLE
fix(datastructures): preserve repeatable --ignore-* flags in UniqueArgs

### DIFF
--- a/pkg/datastructures/datastructures.go
+++ b/pkg/datastructures/datastructures.go
@@ -127,10 +127,26 @@ func Unique[T comparable](elements ...T) []T {
 	return result
 }
 
+// repeatableFlags are CLI flags whose mariadb-dump / mariadb-binlog
+// semantics let the user pass the option multiple times, each value
+// adding to the previous one rather than overriding it. UniqueArgs must
+// keep every occurrence of these flags; dropping all but the last would
+// silently lose user-supplied entries (see issue #1691).
+var repeatableFlags = map[string]struct{}{
+	"--ignore-table":      {},
+	"--ignore-table-data": {},
+	"--ignore-databases":  {},
+	"--ignore-tables":     {},
+}
+
 // UniqueArgs returns unique CLI arguments with smart deduplication:
-//   - For exact duplicates (same string), keeps the first occurrence to preserve order
-//   - For flag name conflicts with different values (e.g., --flag vs --flag=value),
-//     keeps the last occurrence so user-specified args can override defaults
+//   - For repeatable flags (e.g. --ignore-table) every occurrence is
+//     kept regardless of value, only exact-string duplicates are folded.
+//   - For other exact duplicates (same string), keeps the first
+//     occurrence to preserve order.
+//   - For flag name conflicts with different values (e.g., --flag vs
+//     --flag=value), keeps the last occurrence so user-specified args
+//     can override defaults.
 func UniqueArgs(args ...string) []string {
 	type occurrence struct {
 		index int
@@ -146,26 +162,40 @@ func UniqueArgs(args ...string) []string {
 
 	// Determine which index to keep for each flag
 	keepIndex := make(map[int]bool)
-	for _, occurrences := range flagOccurrences {
+	for flagName, occurrences := range flagOccurrences {
 		if len(occurrences) == 1 {
 			keepIndex[occurrences[0].index] = true
-		} else {
-			// Check if all args are identical (exact duplicates)
-			allSame := true
-			first := occurrences[0].arg
-			for _, occ := range occurrences[1:] {
-				if occ.arg != first {
-					allSame = false
-					break
+			continue
+		}
+
+		if _, repeatable := repeatableFlags[flagName]; repeatable {
+			// Repeatable flags: keep every distinct full-string occurrence
+			// (collapse exact duplicates only).
+			seen := make(map[string]bool, len(occurrences))
+			for _, occ := range occurrences {
+				if !seen[occ.arg] {
+					seen[occ.arg] = true
+					keepIndex[occ.index] = true
 				}
 			}
-			if allSame {
-				// Keep first for exact duplicates (preserve order)
-				keepIndex[occurrences[0].index] = true
-			} else {
-				// Keep last for value overrides (user args win)
-				keepIndex[occurrences[len(occurrences)-1].index] = true
+			continue
+		}
+
+		// Check if all args are identical (exact duplicates)
+		allSame := true
+		first := occurrences[0].arg
+		for _, occ := range occurrences[1:] {
+			if occ.arg != first {
+				allSame = false
+				break
 			}
+		}
+		if allSame {
+			// Keep first for exact duplicates (preserve order)
+			keepIndex[occurrences[0].index] = true
+		} else {
+			// Keep last for value overrides (user args win)
+			keepIndex[occurrences[len(occurrences)-1].index] = true
 		}
 	}
 

--- a/pkg/datastructures/datastructures_test.go
+++ b/pkg/datastructures/datastructures_test.go
@@ -428,6 +428,56 @@ func TestUniqueArgs(t *testing.T) {
 				"--verbose",
 			},
 		},
+		{
+			// mariadb-dump's --ignore-table is repeatable: each instance
+			// adds another table to ignore. UniqueArgs must not collapse
+			// distinct values (#1691).
+			name: "repeatable --ignore-table flags are preserved",
+			args: []string{
+				"--single-transaction",
+				"--all-databases",
+				"--ignore-table=mysql.help_category",
+				"--ignore-table=mysql.help_relation",
+				"--ignore-table=mysql.help_topic",
+			},
+			wantElements: []string{
+				"--single-transaction",
+				"--all-databases",
+				"--ignore-table=mysql.help_category",
+				"--ignore-table=mysql.help_relation",
+				"--ignore-table=mysql.help_topic",
+			},
+		},
+		{
+			// Exact-string repeats of a repeatable flag are still
+			// collapsed so we don't grow argv when defaults overlap with
+			// user args.
+			name: "repeatable flag exact duplicates are collapsed",
+			args: []string{
+				"--ignore-table=mysql.global_priv",
+				"--ignore-table=mysql.help_category",
+				"--ignore-table=mysql.global_priv",
+			},
+			wantElements: []string{
+				"--ignore-table=mysql.global_priv",
+				"--ignore-table=mysql.help_category",
+			},
+		},
+		{
+			name: "repeatable --ignore-databases flags are preserved",
+			args: []string{
+				"--ignore-databases=db_a",
+				"--ignore-databases=db_b",
+				"--ignore-table-data=db_c.t1",
+				"--ignore-table-data=db_c.t2",
+			},
+			wantElements: []string{
+				"--ignore-databases=db_a",
+				"--ignore-databases=db_b",
+				"--ignore-table-data=db_c.t1",
+				"--ignore-table-data=db_c.t2",
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Closes #1691.

`UniqueArgs` deduplicates CLI arguments by flag name and, when a flag appears more than once with different values, keeps only the *last* occurrence on the assumption that user-supplied flags override defaults. That works for scalar flags (`--default-character-set`, `--skip-add-locks`, …) but is wrong for the mariadb-dump options that the dump tool documents as **repeatable**, where each instance adds another database / table to the ignore list rather than replacing the previous one:

```yaml
args:
  - --single-transaction
  - --all-databases
  - --ignore-table=mysql.help_category
  - --ignore-table=mysql.help_relation
```

Before this change only the second `--ignore-table` survived (regression introduced in #1546) and `mysql.help_category` was silently restored.

## Fix

Maintain a small `repeatableFlags` whitelist:

| flag | mariadb-dump semantics |
|---|---|
| `--ignore-table` | repeat to add tables |
| `--ignore-table-data` | repeat to add tables (data only) |
| `--ignore-databases` | repeat to add databases |
| `--ignore-tables` | repeat to add tables |

, that `UniqueArgs` treats specially: every **distinct** full-string occurrence is kept; only exact-string repeats (e.g. when a user duplicates one of the operator's defaults like `--ignore-table=mysql.global_priv`) are still collapsed, so argv doesn't grow.

## Test plan

- [x] `go build ./pkg/datastructures/...`
- [x] `go test ./pkg/datastructures/...`, existing tests still pass
- [x] Three new regression cases under `TestUniqueArgs`:
  - `repeatable --ignore-table flags are preserved`
  - `repeatable flag exact duplicates are collapsed`
  - `repeatable --ignore-databases flags are preserved`