### PR TITLE
Add strategy and revisionHistoryLimit to the Deployments in the Helm Chart

### DIFF
--- a/deploy/charts/mariadb-operator/README.md
+++ b/deploy/charts/mariadb-operator/README.md
@@ -45,6 +45,7 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | certController.renewBeforePercentage | int | `33` | How long before the certificate expiration should the renewal process be triggered. For example, if a certificate is valid for 60 minutes, and renewBeforePercentage=25, cert-controller will begin to attempt to renew the certificate 45 minutes after it was issued (i.e. when there are 15 minutes (25%) remaining until the certificate is no longer valid). |
 | certController.requeueDuration | string | `"5m"` | Requeue duration to ensure that certificate gets renewed. |
 | certController.resources | object | `{}` | Resources to add to cert-controller container |
+| certController.revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | certController.securityContext | object | `{}` | Security context to add to cert-controller Pod |
 | certController.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | certController.serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the Pod |
@@ -57,6 +58,7 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | certController.serviceMonitor.metricRelabelings | list | `[]` |  |
 | certController.serviceMonitor.relabelings | list | `[]` |  |
 | certController.serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
+| certController.strategy | object | `{}` | Set deployment strategy |
 | certController.tolerations | list | `[]` | Tolerations to add to cert-controller container |
 | certController.topologySpreadConstraints | list | `[]` | topologySpreadConstraints to add to cert-controller container |
 | clusterName | string | `"cluster.local"` | Cluster DNS name |
@@ -103,12 +105,14 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | rbac.aggregation.enabled | bool | `true` | Specifies whether the cluster roles aggrate to view and edit predefinied roles |
 | rbac.enabled | bool | `true` | Specifies whether RBAC resources should be created |
 | resources | object | `{}` | Resources to add to controller container |
+| revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | securityContext | object | `{}` | Security context to add to controller container |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the Pod |
 | serviceAccount.enabled | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.extraLabels | object | `{}` | Extra Labels to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and enabled is true, a name is generated using the fullname template |
+| strategy | object | `{}` | Set deployment strategy |
 | tolerations | list | `[]` | Tolerations to add to controller Pod |
 | topologySpreadConstraints | list | `[]` | topologySpreadConstraints to add to controller Pod |
 | webhook.affinity | object | `{}` | Affinity to add to webhook Pod |
@@ -142,6 +146,7 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | webhook.port | int | `9443` | Port to be used by the webhook server |
 | webhook.priorityClassName | string | `""` | priorityClassName to add to webhook Pod |
 | webhook.resources | object | `{}` | Resources to add to webhook container |
+| webhook.revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | webhook.securityContext | object | `{}` | Security context to add to webhook container |
 | webhook.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | webhook.serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the Pod |
@@ -154,5 +159,6 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | webhook.serviceMonitor.metricRelabelings | list | `[]` |  |
 | webhook.serviceMonitor.relabelings | list | `[]` |  |
 | webhook.serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
+| webhook.strategy | object | `{}` | Set deployment strategy |
 | webhook.tolerations | list | `[]` | Tolerations to add to webhook Pod |
 | webhook.topologySpreadConstraints | list | `[]` | topologySpreadConstraints to add to webhook Pod |

--- a/deploy/charts/mariadb-operator/README.md
+++ b/deploy/charts/mariadb-operator/README.md
@@ -45,7 +45,6 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | certController.renewBeforePercentage | int | `33` | How long before the certificate expiration should the renewal process be triggered. For example, if a certificate is valid for 60 minutes, and renewBeforePercentage=25, cert-controller will begin to attempt to renew the certificate 45 minutes after it was issued (i.e. when there are 15 minutes (25%) remaining until the certificate is no longer valid). |
 | certController.requeueDuration | string | `"5m"` | Requeue duration to ensure that certificate gets renewed. |
 | certController.resources | object | `{}` | Resources to add to cert-controller container |
-| certController.revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | certController.securityContext | object | `{}` | Security context to add to cert-controller Pod |
 | certController.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | certController.serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the Pod |
@@ -58,7 +57,6 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | certController.serviceMonitor.metricRelabelings | list | `[]` |  |
 | certController.serviceMonitor.relabelings | list | `[]` |  |
 | certController.serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
-| certController.strategy | object | `{}` | Set deployment strategy |
 | certController.tolerations | list | `[]` | Tolerations to add to cert-controller container |
 | certController.topologySpreadConstraints | list | `[]` | topologySpreadConstraints to add to cert-controller container |
 | clusterName | string | `"cluster.local"` | Cluster DNS name |
@@ -105,14 +103,12 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | rbac.aggregation.enabled | bool | `true` | Specifies whether the cluster roles aggrate to view and edit predefinied roles |
 | rbac.enabled | bool | `true` | Specifies whether RBAC resources should be created |
 | resources | object | `{}` | Resources to add to controller container |
-| revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | securityContext | object | `{}` | Security context to add to controller container |
 | serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the Pod |
 | serviceAccount.enabled | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.extraLabels | object | `{}` | Extra Labels to add to the service account |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and enabled is true, a name is generated using the fullname template |
-| strategy | object | `{}` | Set deployment strategy |
 | tolerations | list | `[]` | Tolerations to add to controller Pod |
 | topologySpreadConstraints | list | `[]` | topologySpreadConstraints to add to controller Pod |
 | webhook.affinity | object | `{}` | Affinity to add to webhook Pod |
@@ -146,7 +142,6 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | webhook.port | int | `9443` | Port to be used by the webhook server |
 | webhook.priorityClassName | string | `""` | priorityClassName to add to webhook Pod |
 | webhook.resources | object | `{}` | Resources to add to webhook container |
-| webhook.revisionHistoryLimit | int | `10` | Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy) |
 | webhook.securityContext | object | `{}` | Security context to add to webhook container |
 | webhook.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
 | webhook.serviceAccount.automount | bool | `true` | Automounts the service account token in all containers of the Pod |
@@ -159,6 +154,5 @@ Refer to the [helm documentation](https://github.com/mariadb-operator/mariadb-op
 | webhook.serviceMonitor.metricRelabelings | list | `[]` |  |
 | webhook.serviceMonitor.relabelings | list | `[]` |  |
 | webhook.serviceMonitor.scrapeTimeout | string | `"25s"` | Timeout if metrics can't be retrieved in given time interval |
-| webhook.strategy | object | `{}` | Set deployment strategy |
 | webhook.tolerations | list | `[]` | Tolerations to add to webhook Pod |
 | webhook.topologySpreadConstraints | list | `[]` | topologySpreadConstraints to add to webhook Pod |

--- a/deploy/charts/mariadb-operator/templates/cert-controller/deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/cert-controller/deployment.yaml
@@ -9,6 +9,11 @@ spec:
   {{- if .Values.certController.ha.enabled }}
   replicas: {{ .Values.certController.ha.replicas}}
   {{- end }}
+  {{- with .Values.certController.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.certController.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "mariadb-operator-cert-controller.selectorLabels" . | nindent 6 }}
@@ -82,7 +87,7 @@ spec:
             - containerPort: 8081
               protocol: TCP
               name: health
-          env: 
+          env:
             - name: CLUSTER_NAME
               value: {{ .Values.clusterName }}
           {{- with .Values.certController.extraVolumeMounts }}

--- a/deploy/charts/mariadb-operator/templates/operator/deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/operator/deployment.yaml
@@ -8,6 +8,11 @@ spec:
   {{- if .Values.ha.enabled }}
   replicas: {{ .Values.ha.replicas}}
   {{- end }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "mariadb-operator.selectorLabels" . | nindent 6 }}
@@ -107,7 +112,7 @@ spec:
           volumeMounts:
           {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
-          {{ with .Values.resources }}          
+          {{ with .Values.resources }}
           resources:
             {{ toYaml . | nindent 12 }}
           {{ end }}

--- a/deploy/charts/mariadb-operator/templates/webhook/deployment.yaml
+++ b/deploy/charts/mariadb-operator/templates/webhook/deployment.yaml
@@ -10,6 +10,11 @@ spec:
   {{- if .Values.webhook.ha.enabled }}
   replicas: {{ .Values.webhook.ha.replicas}}
   {{- end }}
+  {{- with .Values.webhook.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  revisionHistoryLimit: {{ .Values.webhook.revisionHistoryLimit }}
   selector:
     matchLabels:
       {{- include "mariadb-operator-webhook.selectorLabels" . | nindent 6 }}

--- a/deploy/charts/mariadb-operator/values.yaml
+++ b/deploy/charts/mariadb-operator/values.yaml
@@ -27,6 +27,10 @@ ha:
   enabled: false
   # -- Number of replicas
   replicas: 3
+# -- Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy)
+revisionHistoryLimit: 10
+# -- Set deployment strategy
+strategy: {}
 metrics:
   # -- Enable operator internal metrics. Prometheus must be installed in the cluster
   enabled: false
@@ -136,6 +140,10 @@ webhook:
     enabled: false
     # -- Number of replicas
     replicas: 3
+  # -- Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy)
+  revisionHistoryLimit: 10
+  # -- Set deployment strategy
+  strategy: {}
   cert:
     certManager:
       # -- Whether to use cert-manager to issue and rotate the certificate. If set to false, mariadb-operator's cert-controller will be used instead.
@@ -239,6 +247,10 @@ certController:
     enabled: false
     # -- Number of replicas
     replicas: 3
+  # -- Specifies the amount of historic ReplicaSets k8s should keep (see https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#clean-up-policy)
+  revisionHistoryLimit: 10
+  # -- Set deployment strategy
+  strategy: {}
   # -- CA certificate lifetime. It must be greater than certLifetime.
   caLifetime: 26280h
   # -- Certificate lifetime.

--- a/internal/helmtest/mariadb_operator_test.go
+++ b/internal/helmtest/mariadb_operator_test.go
@@ -436,3 +436,194 @@ func TestOperatorHelmPprof(t *testing.T) {
 		ContainerPort: 6060,
 	}))
 }
+
+func TestOperatorHelmRevisionHistoryLimit(t *testing.T) {
+	RegisterTestingT(t)
+	opts := &helm.Options{
+		KubectlOptions: &k8s.KubectlOptions{
+			Namespace: operatorTestNamespace,
+		},
+	}
+
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+
+	// Check default revision history limit
+	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(10)))
+
+	// Test with custom revision history limit
+	opts = &helm.Options{
+		SetValues: map[string]string{
+			"revisionHistoryLimit": "5",
+		},
+		KubectlOptions: &k8s.KubectlOptions{
+			Namespace: operatorTestNamespace,
+		},
+	}
+
+	deploymentData = helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/deployment.yaml"})
+	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+
+	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(5)))
+}
+
+func TestOperatorHelmStrategy(t *testing.T) {
+	RegisterTestingT(t)
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"strategy.type": "RollingUpdate",
+			"strategy.rollingUpdate.maxSurge": "1",
+			"strategy.rollingUpdate.maxUnavailable": "0",
+		},
+		KubectlOptions: &k8s.KubectlOptions{
+			Namespace: operatorTestNamespace,
+		},
+	}
+
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/operator/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+
+	Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
+	Expect(deployment.Spec.Strategy.RollingUpdate).ToNot(BeNil())
+	Expect(deployment.Spec.Strategy.RollingUpdate.MaxSurge.String()).To(Equal("1"))
+	Expect(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable.String()).To(Equal("0"))
+}
+
+func TestWebhookHelmRevisionHistoryLimit(t *testing.T) {
+	RegisterTestingT(t)
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"webhook.enabled": `true`,
+		},
+		KubectlOptions: &k8s.KubectlOptions{
+			Namespace: operatorTestNamespace,
+		},
+	}
+
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/webhook/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+
+	// Check default revision history limit
+	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(10)))
+
+	// Test with custom revision history limit
+	opts = &helm.Options{
+		SetValues: map[string]string{
+			"webhook.enabled":              `true`,
+			"webhook.revisionHistoryLimit": "3",
+		},
+		KubectlOptions: &k8s.KubectlOptions{
+			Namespace: operatorTestNamespace,
+		},
+	}
+
+	deploymentData = helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/webhook/deployment.yaml"})
+	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+
+	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(3)))
+}
+
+func TestWebhookHelmStrategy(t *testing.T) {
+	RegisterTestingT(t)
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"webhook.enabled": `true`,
+			"webhook.strategy.type": "Recreate",
+		},
+		KubectlOptions: &k8s.KubectlOptions{
+			Namespace: operatorTestNamespace,
+		},
+	}
+
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/webhook/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+
+	Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+}
+
+func TestCertControllerHelmRevisionHistoryLimit(t *testing.T) {
+	RegisterTestingT(t)
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"certController.enabled": `true`,
+		},
+		KubectlOptions: &k8s.KubectlOptions{
+			Namespace: operatorTestNamespace,
+		},
+	}
+
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/cert-controller/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+
+	// Check default revision history limit
+	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(10)))
+
+	// Test with custom revision history limit
+	opts = &helm.Options{
+		SetValues: map[string]string{
+			"certController.enabled":              `true`,
+			"certController.revisionHistoryLimit": "7",
+		},
+		KubectlOptions: &k8s.KubectlOptions{
+			Namespace: operatorTestNamespace,
+		},
+	}
+
+	deploymentData = helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/cert-controller/deployment.yaml"})
+	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+
+	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(7)))
+}
+
+func TestCertControllerHelmStrategy(t *testing.T) {
+	RegisterTestingT(t)
+	opts := &helm.Options{
+		SetValues: map[string]string{
+			"certController.enabled": `true`,
+			"certController.strategy.type": "RollingUpdate",
+			"certController.strategy.rollingUpdate.maxSurge": "25%",
+			"certController.strategy.rollingUpdate.maxUnavailable": "25%",
+		},
+		KubectlOptions: &k8s.KubectlOptions{
+			Namespace: operatorTestNamespace,
+		},
+	}
+
+	deploymentData := helm.RenderTemplate(t, opts,
+		operatorHelmChartPath, operatorHelmReleaseName,
+		[]string{"templates/cert-controller/deployment.yaml"})
+	var deployment appsv1.Deployment
+	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+
+	Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
+	Expect(deployment.Spec.Strategy.RollingUpdate).ToNot(BeNil())
+	Expect(deployment.Spec.Strategy.RollingUpdate.MaxSurge.String()).To(Equal("25%"))
+	Expect(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable.String()).To(Equal("25%"))
+}

--- a/internal/helmtest/mariadb_operator_test.go
+++ b/internal/helmtest/mariadb_operator_test.go
@@ -478,8 +478,8 @@ func TestOperatorHelmStrategy(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
-			"strategy.type": "RollingUpdate",
-			"strategy.rollingUpdate.maxSurge": "1",
+			"strategy.type":                         "RollingUpdate",
+			"strategy.rollingUpdate.maxSurge":       "1",
 			"strategy.rollingUpdate.maxUnavailable": "0",
 		},
 		KubectlOptions: &k8s.KubectlOptions{
@@ -544,7 +544,7 @@ func TestWebhookHelmStrategy(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
-			"webhook.enabled": `true`,
+			"webhook.enabled":       `true`,
 			"webhook.strategy.type": "Recreate",
 		},
 		KubectlOptions: &k8s.KubectlOptions{
@@ -606,9 +606,9 @@ func TestCertControllerHelmStrategy(t *testing.T) {
 	RegisterTestingT(t)
 	opts := &helm.Options{
 		SetValues: map[string]string{
-			"certController.enabled": `true`,
-			"certController.strategy.type": "RollingUpdate",
-			"certController.strategy.rollingUpdate.maxSurge": "25%",
+			"certController.enabled":                               `true`,
+			"certController.strategy.type":                         "RollingUpdate",
+			"certController.strategy.rollingUpdate.maxSurge":       "25%",
 			"certController.strategy.rollingUpdate.maxUnavailable": "25%",
 		},
 		KubectlOptions: &k8s.KubectlOptions{


### PR DESCRIPTION
This PR adds support for configuring the following Deployment fields in the Helm chart:
- strategy
- revisionHistoryLimit

This allows users to better control Deployment rollout behavior and the number of old ReplicaSets retained by Kubernetes.

**Motivation**
Some environments require:
- custom rolling update strategies,
- stricter control over rollout behavior,
- or limiting retained ReplicaSets to reduce resource usage.

Adding these fields improves the flexibility and production-readiness of the chart.