### PR TITLE
Fix stale staging area

### DIFF
--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -33,14 +33,9 @@ var restoreCommand = &cobra.Command{
 		ctx, cancel := newContext()
 		defer cancel()
 
-		physicalBackupExists, err := checkPhysicalBackupDir()
-		if err != nil {
-			logger.Error(err, "error checking physical backup directory")
+		if err := cleanupStaleStagingArea(); err != nil {
+			logger.Error(err, "error cleaning up stale staging area")
 			os.Exit(1)
-		}
-		if physicalBackupExists {
-			logger.Info("physical backup directory already exists.")
-			os.Exit(0)
 		}
 
 		backupProcessor, err := getBackupProcessor()
@@ -100,20 +95,31 @@ var restoreCommand = &cobra.Command{
 	},
 }
 
-func checkPhysicalBackupDir() (bool, error) {
+// cleanupStaleStagingArea cleans up /backup/full staging directory in case that it has been used before.
+// Manually provisioned backup PVCs use /backup/full directory and do not clean it up after the restoration,
+// potentially leading to the usage of a stale backup in further restorations.
+// See: https://github.com/mariadb-operator/mariadb-operator/pull/1744
+func cleanupStaleStagingArea() error {
 	if backupContentType != string(mariadbv1alpha1.BackupContentTypePhysical) || physicalBackupDirPath == "" {
-		return false, nil
+		return nil
 	}
-	logger.Info("checking existing physical backup directory", "dir-path", physicalBackupDirPath)
+	logger.Info("checking stale staging area", "dir-path", physicalBackupDirPath)
 
 	entries, err := os.ReadDir(physicalBackupDirPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, nil
+			return nil
 		}
-		return false, fmt.Errorf("error reading physical backup directory path (%s): %v", physicalBackupDirPath, err)
+		return fmt.Errorf("error reading staging area directory path (%s): %v", physicalBackupDirPath, err)
 	}
-	return len(entries) > 0, nil
+	if len(entries) > 0 {
+		logger.Info("cleaning up staging area", "dir-path", physicalBackupDirPath)
+
+		if err := os.RemoveAll(physicalBackupDirPath); err != nil {
+			return fmt.Errorf("error removing staging area directory path (%s): %v", physicalBackupDirPath, err)
+		}
+	}
+	return nil
 }
 
 func getTargetTime() (time.Time, error) {

--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -1,12 +1,10 @@
 package command
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
-	"text/template"
 	"time"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
@@ -448,19 +446,9 @@ fi`
 		"mariadb-backup --copy-back --target-dir=%s --force-non-empty-directories",
 		b.BackupFullDirPath,
 	)
-	existingBackupRestoreCmd, err := b.existingBackupRestoreCmd(
-		dataDirPath,
-		cleanupDataDirCmd,
-		copyBackupCmd,
-		restoreOpts...,
-	)
-	if err != nil {
-		return nil, fmt.Errorf("error getting existing backup command: %v", err)
-	}
 
 	cmds := []string{
 		"set -euo pipefail",
-		existingBackupRestoreCmd,
 		"echo 💾 Extracting backup",
 		fmt.Sprintf(
 			"mkdir -p %s",
@@ -531,45 +519,6 @@ func (b *BackupCommand) MariadbBinlog(mariadb *mariadbv1alpha1.MariaDB) (*Comman
 		return nil, fmt.Errorf("error getting mariadb-binlog args: %v", err)
 	}
 	return NewBashCommand(mariadbBinlogArgs), nil
-}
-
-func (b *BackupCommand) existingBackupRestoreCmd(dataDirPath, cleanupDataDirCmd, copyBackupCmd string,
-	restoreOpts ...MariaDBBackupRestoreOpt) (string, error) {
-	opts := MariaDBBackupRestoreOpts{}
-	for _, setOpt := range restoreOpts {
-		setOpt(&opts)
-	}
-
-	tpl := createTpl("restore.sh", `if [ -d {{ .BackupDir }} ]; then
-  echo '💾 Existing backup directory found. Copying backup to data directory';
-  {{- if .CleanupDataDir }}
-  { {{ .CleanupDataDirCmd }}; } &&
-  {{- end }}
-  { {{ .CopyBackupCmd }}; } &&
-  {{- range $cmd := .CopyBinlogMetaCmds }}
-  { {{ $cmd }}; } &&
-  {{- end }}
-  exit 0
-fi`)
-	buf := new(bytes.Buffer)
-	err := tpl.Execute(buf, struct {
-		BackupDir          string
-		CleanupDataDir     bool
-		CleanupDataDirCmd  string
-		CopyBackupCmd      string
-		CopyBinlogMetaCmds []string
-	}{
-		BackupDir:          b.BackupFullDirPath,
-		CleanupDataDir:     opts.cleanupDataDir,
-		CleanupDataDirCmd:  cleanupDataDirCmd,
-		CopyBackupCmd:      copyBackupCmd,
-		CopyBinlogMetaCmds: copyBinlogMetaCmds(b.BackupFullDirPath, dataDirPath),
-	})
-	if err != nil {
-		return "", err
-	}
-	// Trim surrounding whitespace and newlines to reduce bash syntax error risk
-	return strings.TrimSpace(buf.String()), nil
 }
 
 func (b *BackupCommand) newBackupFile() string {
@@ -847,8 +796,4 @@ fi`,
 		copyBinlogMetaCmd(replication.BinlogFileName),
 		copyBinlogMetaCmd(replication.LegacyBinlogFileName),
 	}
-}
-
-func createTpl(name, t string) *template.Template {
-	return template.Must(template.New(name).Parse(t))
 }

--- a/pkg/command/backup_test.go
+++ b/pkg/command/backup_test.go
@@ -1401,66 +1401,6 @@ func TestMariadbBinlogArgs(t *testing.T) {
 	}
 }
 
-func TestExistingBackupRestoreCmd(t *testing.T) {
-	tests := []struct {
-		name              string
-		cleanupDataDirCmd string
-		copyBackupCmd     string
-		restoreOpts       []MariaDBBackupRestoreOpt
-		wantCleanup       bool
-	}{
-		{
-			name:              "no cleanup",
-			cleanupDataDirCmd: `if [ -d /var/lib/mysql ]; then echo "cleanup"; rm -rf /var/lib/mysql/*; fi`,
-			copyBackupCmd:     "mariadb-backup --copy-back --target-dir=/backup/full --force-non-empty-directories",
-			restoreOpts:       nil,
-			wantCleanup:       false,
-		},
-		{
-			name:              "cleanup",
-			cleanupDataDirCmd: `if [ -d /var/lib/mysql ]; then echo "cleanup"; rm -rf /var/lib/mysql/*; fi`,
-			copyBackupCmd:     "mariadb-backup --copy-back --target-dir=/backup/full --force-non-empty-directories",
-			restoreOpts:       []MariaDBBackupRestoreOpt{WithCleanupDataDir(true)},
-			wantCleanup:       true,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			backupFullDirPath := "/backup/full"
-			b := &BackupCommand{
-				BackupOpts: BackupOpts{
-					BackupFullDirPath: backupFullDirPath,
-				},
-			}
-			dataDirPath := "/var/lib/mysql"
-			out, err := b.existingBackupRestoreCmd(
-				dataDirPath,
-				tt.cleanupDataDirCmd,
-				tt.copyBackupCmd,
-				tt.restoreOpts...,
-			)
-			assert.NoError(t, err)
-			assert.NotEmpty(t, out)
-
-			assert.Contains(t, out, "if [ -d "+backupFullDirPath+" ]; then")
-			assert.Contains(t, out, tt.copyBackupCmd)
-			assert.Contains(t, out, "exit 0")
-
-			if tt.wantCleanup {
-				assert.Contains(t, out, "rm -rf /var/lib/mysql/*")
-			} else {
-				assert.NotContains(t, out, "rm -rf /var/lib/mysql/*")
-			}
-
-			for _, cmd := range copyBinlogMetaCmds(backupFullDirPath, dataDirPath) {
-				assert.Contains(t, out, cmd)
-			}
-		})
-	}
-}
-
 func TestPhysicalBackupArgs(t *testing.T) {
 	tests := []struct {
 		name               string


### PR DESCRIPTION
# Fix stale data skip logic in physical backup restore

## Summary

Physical backup restore Jobs would skip downloading and extracting the backup if `/backup/full` already contained files from a prior Job run on the same staging PVC.

## Root Cause

Two skip mechanisms short-circuited the restore pipeline when `/backup/full` had residual content:

1. **Go init container** (`cmd/backup/restore.go`): `checkPhysicalBackupDir()` returned `true` if `/backup/full` had any entries, then `os.Exit(0)` skipped download and decompression entirely.

2. **Bash main container** (`pkg/command/backup.go`): `existingBackupRestoreCmd` template checked `if [ -d /backup/full ]` and, if true, skipped extract and prepare, copying stale data directly to the data directory.

Both mechanisms were designed as optimizations to avoid redundant work when the staging PVC was shared between a PhysicalBackup Job (which extracts the backup) and the subsequent Restore Job. However, they fail when:

- The PhysicalBackup Job fails after extracting but before uploading to object storage
- A retry leaves residual `/backup/full` from a prior Job run
- The staging PVC is reused across multiple restore operations

## Changes

### `cmd/backup/restore.go`

- Replaced `checkPhysicalBackupDir()` (skip if content exists) with `cleanupPhysicalBackupDir()` (remove stale content before proceeding)
- The init container now always downloads and decompresses a fresh backup

### `pkg/command/backup.go`

- Removed `existingBackupRestoreCmd` function and template entirely
- `MariadbBackupRestore` now always runs the full extract → prepare → copy-back pipeline
- Removed unused `bytes` import

### `pkg/command/backup_test.go`

- Removed `TestExistingBackupRestoreCmd` (tested deleted function)

## Safety

The fix is safe because controller mutual exclusion guards ensure only one restore Job runs at a time per MariaDB instance:

- `isScalingOut` blocks when `IsRecoveringReplicas()`
- `shouldReconcileReplicaRecovery` blocks when `IsScalingOut()`
- Both block during `IsInitializing`, `IsRestoringBackup`, `IsSwitchingPrimary`, `IsResizingStorage`, `IsUpdating`

Therefore `/backup/full` is never concurrently accessed, and cleaning it before each restore is correct.

## Storage Backend Behavior

This fix applies uniformly to all physical backup storage backends. The skip logic resided in the restore command layer, which is shared by all storage paths. Backend differences only affect PVC lifecycle management, not restore command execution.

### PersistentVolumeClaim / Volume Storage
When `storage.persistentVolumeClaim` or `storage.volume` is configured, the operator mounts a pre-existing PVC directly at `/backup`. The operator does not manage the PVC lifecycle—`shouldProvisionPhysicalBackupStagingPVC()` returns `false` and `cleanupPhysicalBackupStagingPVC()` is skipped. Without this fix, `/backup/full` persists across restore Jobs on the same PVC, causing scale-out and replica recovery to silently reuse stale data. The fix removes stale contents at init container startup while leaving the PVC intact.

### S3 / AzureBlob Storage
When `storage.s3` or `storage.azureBlob` is configured, the operator provisions a temporary staging PVC per restore Job. `shouldProvisionPhysicalBackupStagingPVC()` returns `true` and `cleanupPhysicalBackupStagingPVC()` deletes the staging PVC after bootstrap completes. If the staging PVC is reused across Jobs before cleanup, `/backup/full` may contain stale data. The fix clears `/backup/full` at init container startup, and the existing PVC teardown continues unchanged.

### Why the Fix is Correct for Both Paths
- The skip logic (`checkPhysicalBackupDir`, `existingBackupRestoreCmd`) lived in the **restore command**, which runs inside every Job regardless of storage backend.
- The fix replaces the skip with a **directory-level cleanup** (`os.RemoveAll(physicalBackupDirPath)`) in the init container and removes the bash skip in the main container.
- This is safe because controller guards (`isScalingOut`, `shouldReconcileReplicaRecovery`) ensure only one restore Job runs at a time per MariaDB instance, so `/backup/full` is never concurrently accessed.
- PVC lifecycle management (`cleanupPhysicalBackupStagingPVC`) remains unchanged and continues to operate only on operator-provisioned staging PVCs.

## Known Limitation: Shared PVC Concurrency Risk

When the scale-out or replica recovery `PhysicalBackup` template uses the same PVC as scheduled `PhysicalBackup` Jobs (via `storage.volume.persistentVolumeClaim.claimName` or `storage.volume`), both workloads mount the same underlying volume at `/backup`. The scheduled backup controller skips reconciliation during initialization (`IsInitializing`) and logical restore (`IsRestoringBackup`), but does not skip during scale-out (`IsScalingOut`) or replica recovery (`IsRecoveringReplicas`). Conversely, the scale-out and recovery controllers cannot check for running `PhysicalBackup` Jobs without creating a deadlock, since they trigger their own `PhysicalBackup` Jobs and wait for them to complete.

If a scheduled backup runs concurrently with a scale-out or recovery restore Job, both may read from and write to `/backup` simultaneously, potentially corrupting the backup stream or extracted data directory.

### Mitigation: Dedicated Staging PVC

Use a separate PVC for the scale-out and replica recovery template, distinct from the PVC used by scheduled backups:

```yaml
# Scheduled backup -- holds historical backup streams
apiVersion: k8s.mariadb.com/v1alpha1
kind: PhysicalBackup
metadata:
  name: mydb-backup
spec:
  mariaDbRef:
    name: mydb
  schedule:
    cron: "0 2 * * *"
  storage:
    volume:
      persistentVolumeClaim:
        claimName: mydb-backup-pvc  # scheduled backups only
```

```yaml
# Scale-out / recovery template -- isolated staging area
apiVersion: k8s.mariadb.com/v1alpha1
kind: PhysicalBackup
metadata:
  name: mydb-backup-template
spec:
  mariaDbRef:
    name: mydb
    waitForIt: false
  schedule:
    suspend: true
  storage:
    volume:
      persistentVolumeClaim:
        claimName: mydb-backup-staging-pvc  # scale-out / recovery only
```

Reference the template in the MariaDB resource:

```yaml
apiVersion: k8s.mariadb.com/v1alpha1
kind: MariaDB
metadata:
  name: mydb
spec:
  replication:
    replica:
      bootstrapFrom:
        physicalBackupTemplateRef:
          name: mydb-backup-template
```