### PR TITLE
feat(helm): push charts to OCI registries on GHCR

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -145,6 +145,9 @@ jobs:
       - lint-crds
       - lint-operator
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -171,3 +174,36 @@ jobs:
           skip_existing: "true"
           pages_branch: gh-pages
           packages_with_index: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push charts to GHCR
+        if: steps.chart-releaser.outputs.changed_charts != ''
+        run: |
+          declare -A chart_oci
+          chart_oci["mariadb-cluster"]="ghcr.io/${{ github.repository_owner }}/mariadb-cluster-helm"
+          chart_oci["mariadb-operator-crds"]="ghcr.io/${{ github.repository_owner }}/mariadb-operator-crds-helm"
+          chart_oci["mariadb-operator"]="ghcr.io/${{ github.repository_owner }}/mariadb-operator-helm"
+
+          IFS=',' read -ra charts <<< "${{ steps.chart-releaser.outputs.changed_charts }}"
+          for chart_name in "${charts[@]}"; do
+            chart_version=$(grep '^version:' "deploy/charts/${chart_name}/Chart.yaml" | awk '{print $2}')
+            pkg=".cr-release-packages/${chart_name}-${chart_version}.tgz"
+
+            if [ ! -f "$pkg" ]; then
+              echo "Package not found: $pkg, skipping"
+              continue
+            fi
+            if [ -z "${chart_oci[$chart_name]+_}" ]; then
+              echo "No OCI mapping for chart '$chart_name', skipping"
+              continue
+            fi
+
+            echo "Pushing $pkg to ${chart_oci[$chart_name]}"
+            helm push "$pkg" "oci://${chart_oci[$chart_name]}"
+          done

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -8,6 +8,7 @@ Helm is the preferred way to install `mariadb-operator` in vanilla Kubernetes cl
 ## Table of contents
 <!-- toc -->
 - [Charts](#charts)
+- [OCI-based installation](#oci-based-installation)
 - [Control-plane](#control-plane)
 - [Installing CRDs](#installing-crds)
 - [Installing the operator](#installing-the-operator)
@@ -24,6 +25,40 @@ The installation of `mariadb-operator` is split into multiple different helm cha
 - [`mariadb-operator-crds`](../deploy/charts/mariadb-operator-crds/): Bundles the [`CustomResourceDefinitions`](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) required by the operator.
 - [`mariadb-operator`](../deploy/charts/mariadb-operator/): Contains the template manifests required to install the operator.
 - [`mariadb-cluster`](../deploy/charts/mariadb-cluster/): Contains the template maniffests to deploy a `MariaDB` cluster based on the operator CRDs.
+
+## OCI-based installation
+
+Helm charts are also available as OCI images on GitHub Container Registry (`ghcr.io`). This approach allows you to install charts without needing a Helm repository, using only the chart name and version.
+
+### Install
+
+Install the charts in the following order:
+
+```bash
+helm install mariadb-operator-crds oci://ghcr.io/mariadb-operator/mariadb-operator-crds-helm --version <version>
+helm install mariadb-operator oci://ghcr.io/mariadb-operator/mariadb-operator-helm --version <version>
+helm install mariadb-cluster oci://ghcr.io/mariadb-operator/mariadb-cluster-helm --version <version>
+```
+
+### Upgrade
+
+Upgrade the charts in the following order:
+
+```bash
+helm upgrade mariadb-operator-crds oci://ghcr.io/mariadb-operator/mariadb-operator-crds-helm --version <new-version>
+helm upgrade mariadb-operator oci://ghcr.io/mariadb-operator/mariadb-operator-helm --version <new-version>
+helm upgrade mariadb-cluster oci://ghcr.io/mariadb-operator/mariadb-cluster-helm --version <new-version>
+```
+
+### Uninstall
+
+Uninstall the charts in the following order:
+
+```bash
+helm uninstall mariadb-operator
+helm uninstall mariadb-operator-crds
+helm uninstall mariadb-cluster
+```
 
 ## Control-plane
 


### PR DESCRIPTION
> [!IMPORTANT]  
> Superseded by https://github.com/mariadb-operator/mariadb-operator/pull/1715/changes/e4e2287eb2e320db990bd7e07471d72517269c30

## Summary

- Add OCI-based Helm chart publishing to the `helm.yml` release workflow
- Push each chart to a dedicated GHCR repository alongside the traditional GitHub Pages index
- Only pushes charts that `chart-releaser-action` actually released (via `skip_existing: true` + `changed_charts` guard)

## OCI Repository Mapping

| Chart | OCI Repository |
|---|---|
| `mariadb-operator-crds` | `ghcr.io/mariadb-operator/mariadb-operator-crds-helm` |
| `mariadb-operator` | `ghcr.io/mariadb-operator/mariadb-operator-helm` |
| `mariadb-cluster` | `ghcr.io/mariadb-operator/mariadb-cluster-helm` |

## Usage

```bash
helm install mariadb-operator-crds oci://ghcr.io/mariadb-operator/mariadb-operator-crds-helm --version <version>
helm install mariadb-operator oci://ghcr.io/mariadb-operator/mariadb-operator-helm --version <version>
helm install mariadb-cluster oci://ghcr.io/mariadb-operator/mariadb-cluster-helm --version <version>