### PR TITLE
fix: prevent Grant from hanging in Terminating on finalizer removal

### DIFF
--- a/internal/controller/database_controller_finalizer.go
+++ b/internal/controller/database_controller_finalizer.go
@@ -58,7 +58,7 @@ func (wf *wrappedDatabaseFinalizer) Reconcile(ctx context.Context, mdbClient *sq
 
 func (wf *wrappedDatabaseFinalizer) patch(ctx context.Context, database *mariadbv1alpha1.Database,
 	patchFn func(*mariadbv1alpha1.Database)) error {
-	patch := client.MergeFrom(database.DeepCopy())
+	patch := client.MergeFromWithOptions(database.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	patchFn(database)
 
 	if err := wf.Patch(ctx, database, patch); err != nil {

--- a/internal/controller/grant_controller_finalizer.go
+++ b/internal/controller/grant_controller_finalizer.go
@@ -78,7 +78,7 @@ func (wf *wrappedGrantFinalizer) Reconcile(ctx context.Context, mdbClient *sqlCl
 
 func (wf *wrappedGrantFinalizer) patch(ctx context.Context, grant *mariadbv1alpha1.Grant,
 	patchFn func(*mariadbv1alpha1.Grant)) error {
-	patch := client.MergeFrom(grant.DeepCopy())
+	patch := client.MergeFromWithOptions(grant.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	patchFn(grant)
 
 	if err := wf.Patch(ctx, grant, patch); err != nil {

--- a/internal/controller/grant_controller_test.go
+++ b/internal/controller/grant_controller_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Grant", Label("basic"), func() {
 	})
 })
 
-var _ = Describe("Grant deletion idempotency", Label("finalizer"), Focus, func() {
+var _ = Describe("Grant deletion idempotency", Label("finalizer"), func() {
 	BeforeEach(func() {
 		By("Waiting for MariaDB to be ready")
 		expectMariadbReady(testCtx, k8sClient, testMdbkey)

--- a/internal/controller/grant_controller_test.go
+++ b/internal/controller/grant_controller_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Grant", Label("basic"), func() {
 	})
 })
 
-var _ = Describe("Grant deletion idempotency", Label("finalizer"), func() {
+var _ = Describe("Grant deletion idempotency", Label("finalizer"), Focus, func() {
 	BeforeEach(func() {
 		By("Waiting for MariaDB to be ready")
 		expectMariadbReady(testCtx, k8sClient, testMdbkey)

--- a/internal/controller/grant_controller_test.go
+++ b/internal/controller/grant_controller_test.go
@@ -1,13 +1,16 @@
 package controller
 
 import (
+	"fmt"
 	"time"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -232,6 +235,208 @@ var _ = Describe("Grant", Label("basic"), func() {
 				return false
 			}
 			return controllerutil.ContainsFinalizer(&grant, grantFinalizerName)
+		}, testTimeout, testInterval).Should(BeTrue())
+	})
+})
+
+var _ = Describe("Grant deletion idempotency", Label("finalizer"), func() {
+	BeforeEach(func() {
+		By("Waiting for MariaDB to be ready")
+		expectMariadbReady(testCtx, k8sClient, testMdbkey)
+	})
+
+	It("should delete Grant cleanly after out-of-band REVOKE", func() {
+		By("Creating a User")
+		userKey := types.NamespacedName{
+			Name:      "grant-revoke-ooo-user",
+			Namespace: testNamespace,
+		}
+		user := mariadbv1alpha1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      userKey.Name,
+				Namespace: userKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.UserSpec{
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{
+						Name: testMdbkey.Name,
+					},
+					WaitForIt: true,
+				},
+				PasswordSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: testPwdKey.Name,
+					},
+					Key: testPwdSecretKey,
+				},
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &user)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(testCtx, &user)).To(Succeed())
+		})
+
+		By("Expecting User to be ready eventually")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, userKey, &user); err != nil {
+				return false
+			}
+			return user.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Creating a Grant")
+		grantKey := types.NamespacedName{
+			Name:      "grant-revoke-ooo-test",
+			Namespace: testNamespace,
+		}
+		grant := mariadbv1alpha1.Grant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      grantKey.Name,
+				Namespace: grantKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.GrantSpec{
+				SQLTemplate: mariadbv1alpha1.SQLTemplate{
+					RetryInterval: &metav1.Duration{Duration: 1 * time.Second},
+				},
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{
+						Name: testMdbkey.Name,
+					},
+					WaitForIt: true,
+				},
+				Privileges: []string{"SELECT"},
+				Database:   testDatabase,
+				Table:      "*",
+				Username:   userKey.Name,
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &grant)).To(Succeed())
+
+		By("Expecting Grant to be ready eventually")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, grantKey, &grant); err != nil {
+				return false
+			}
+			return grant.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Expecting Grant to have finalizer")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, grantKey, &grant); err != nil {
+				return false
+			}
+			return controllerutil.ContainsFinalizer(&grant, grantFinalizerName)
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Revoking grant out-of-band to simulate grant already gone")
+		var mdb mariadbv1alpha1.MariaDB
+		Expect(k8sClient.Get(testCtx, testMdbkey, &mdb)).To(Succeed())
+		executeSqlInPodByIndex(
+			&mdb,
+			0,
+			fmt.Sprintf("REVOKE SELECT ON `%s`.* FROM '%s'@'%s'", testDatabase, userKey.Name, "%"),
+		)
+
+		By("Deleting the Grant")
+		Expect(k8sClient.Delete(testCtx, &grant)).To(Succeed())
+
+		By("Expecting Grant to be deleted cleanly (not stuck in Terminating)")
+		Eventually(func() bool {
+			err := k8sClient.Get(testCtx, grantKey, &grant)
+			return apierrors.IsNotFound(err)
+		}, testTimeout, testInterval).Should(BeTrue())
+	})
+
+	It("should delete Grant cleanly with foreground propagation", func() {
+		By("Creating a User")
+		userKey := types.NamespacedName{
+			Name:      "grant-fd-user",
+			Namespace: testNamespace,
+		}
+		user := mariadbv1alpha1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      userKey.Name,
+				Namespace: userKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.UserSpec{
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{
+						Name: testMdbkey.Name,
+					},
+					WaitForIt: true,
+				},
+				PasswordSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: testPwdKey.Name,
+					},
+					Key: testPwdSecretKey,
+				},
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &user)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(testCtx, &user)).To(Succeed())
+		})
+
+		By("Expecting User to be ready eventually")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, userKey, &user); err != nil {
+				return false
+			}
+			return user.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Creating a Grant")
+		grantKey := types.NamespacedName{
+			Name:      "grant-fd-test",
+			Namespace: testNamespace,
+		}
+		grant := mariadbv1alpha1.Grant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      grantKey.Name,
+				Namespace: grantKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.GrantSpec{
+				SQLTemplate: mariadbv1alpha1.SQLTemplate{
+					RetryInterval: &metav1.Duration{Duration: 1 * time.Second},
+				},
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{
+						Name: testMdbkey.Name,
+					},
+					WaitForIt: true,
+				},
+				Privileges: []string{"SELECT"},
+				Database:   testDatabase,
+				Table:      "*",
+				Username:   userKey.Name,
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &grant)).To(Succeed())
+
+		By("Expecting Grant to be ready eventually")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, grantKey, &grant); err != nil {
+				return false
+			}
+			return grant.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Expecting Grant to have finalizer")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, grantKey, &grant); err != nil {
+				return false
+			}
+			return controllerutil.ContainsFinalizer(&grant, grantFinalizerName)
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Deleting the Grant with foreground propagation (simulates Argo CD foreground prune)")
+		Expect(k8sClient.Delete(testCtx, &grant, client.PropagationPolicy(metav1.DeletePropagationForeground))).To(Succeed())
+
+		By("Expecting Grant to be deleted cleanly (not Forbidden on finalizer patch)")
+		Eventually(func() bool {
+			err := k8sClient.Get(testCtx, grantKey, &grant)
+			return apierrors.IsNotFound(err)
 		}, testTimeout, testInterval).Should(BeTrue())
 	})
 })

--- a/internal/controller/grant_controller_test.go
+++ b/internal/controller/grant_controller_test.go
@@ -347,6 +347,100 @@ var _ = Describe("Grant deletion idempotency", Label("finalizer"), func() {
 		}, testTimeout, testInterval).Should(BeTrue())
 	})
 
+	It("should delete Grant with ALL PRIVILEGES and GRANT OPTION cleanly", func() {
+		By("Creating a User")
+		userKey := types.NamespacedName{
+			Name:      "grant-all-priv-user",
+			Namespace: testNamespace,
+		}
+		user := mariadbv1alpha1.User{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      userKey.Name,
+				Namespace: userKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.UserSpec{
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{
+						Name: testMdbkey.Name,
+					},
+					WaitForIt: true,
+				},
+				PasswordSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: testPwdKey.Name,
+					},
+					Key: testPwdSecretKey,
+				},
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &user)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(k8sClient.Delete(testCtx, &user)).To(Succeed())
+		})
+
+		By("Expecting User to be ready eventually")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, userKey, &user); err != nil {
+				return false
+			}
+			return user.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Creating a Grant with ALL PRIVILEGES and GRANT OPTION")
+		grantKey := types.NamespacedName{
+			Name:      "grant-all-priv-test",
+			Namespace: testNamespace,
+		}
+		grant := mariadbv1alpha1.Grant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      grantKey.Name,
+				Namespace: grantKey.Namespace,
+			},
+			Spec: mariadbv1alpha1.GrantSpec{
+				SQLTemplate: mariadbv1alpha1.SQLTemplate{
+					RetryInterval: &metav1.Duration{Duration: 1 * time.Second},
+				},
+				MariaDBRef: mariadbv1alpha1.MariaDBRef{
+					ObjectReference: mariadbv1alpha1.ObjectReference{
+						Name: testMdbkey.Name,
+					},
+					WaitForIt: true,
+				},
+				Privileges:  []string{"ALL PRIVILEGES"},
+				Database:    "*",
+				Table:       "*",
+				Username:    userKey.Name,
+				GrantOption: true,
+			},
+		}
+		Expect(k8sClient.Create(testCtx, &grant)).To(Succeed())
+
+		By("Expecting Grant to be ready eventually")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, grantKey, &grant); err != nil {
+				return false
+			}
+			return grant.IsReady()
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Expecting Grant to have finalizer")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, grantKey, &grant); err != nil {
+				return false
+			}
+			return controllerutil.ContainsFinalizer(&grant, grantFinalizerName)
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Deleting the Grant")
+		Expect(k8sClient.Delete(testCtx, &grant)).To(Succeed())
+
+		By("Expecting Grant to be deleted cleanly (not Error 1064 on malformed REVOKE)")
+		Eventually(func() bool {
+			err := k8sClient.Get(testCtx, grantKey, &grant)
+			return apierrors.IsNotFound(err)
+		}, testTimeout, testInterval).Should(BeTrue())
+	})
+
 	It("should delete Grant cleanly with foreground propagation", func() {
 		By("Creating a User")
 		userKey := types.NamespacedName{

--- a/internal/controller/user_controller_finalizer.go
+++ b/internal/controller/user_controller_finalizer.go
@@ -58,7 +58,7 @@ func (wf *wrappedUserFinalizer) Reconcile(ctx context.Context, mdbClient *sqlCli
 
 func (wf *wrappedUserFinalizer) patch(ctx context.Context, user *mariadbv1alpha1.User,
 	patchFn func(*mariadbv1alpha1.User)) error {
-	patch := client.MergeFrom(user.DeepCopy())
+	patch := client.MergeFromWithOptions(user.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	patchFn(user)
 
 	if err := wf.Patch(ctx, user, patch); err != nil {

--- a/pkg/sql/error.go
+++ b/pkg/sql/error.go
@@ -17,6 +17,9 @@ var (
 	SQLGtidSlavePosNoValueForDomain = 1948
 	// Ref: https://mariadb.com/docs/server/reference/error-codes/mariadb-error-codes-1000-to-1099/e1095
 	SQLYouAreNotOwnerOfThread = 1095
+	// Error 1141 (42000): There is no such grant defined for user on host
+	// Ref: https://mariadb.com/docs/server/reference/error-codes/mariadb-error-codes-1100-to-1199/e1141
+	SQLNonexistingGrant = 1141
 )
 
 // IsSQLErrorNumber checks if the error's string message contains the pattern
@@ -49,4 +52,10 @@ func IsGtidSlavePosNoValueForDomain(err error) bool {
 // You are not owner of thread
 func IgnoreYouAreNotOwnerOfThread(err error) error {
 	return returnNilIfErrorIsNumber(err, SQLYouAreNotOwnerOfThread)
+}
+
+// IgnoreNonExistingGrant returns nil if the error is ER_NONEXISTING_GRANT (1141),
+// mirroring the IF EXISTS semantics used by DROP USER IF EXISTS and DROP DATABASE IF EXISTS.
+func IgnoreNonExistingGrant(err error) error {
+	return returnNilIfErrorIsNumber(err, SQLNonexistingGrant)
 }

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -624,17 +624,36 @@ func (c *Client) Revoke(
 		setOpt(&grantOpts)
 	}
 
-	if grantOpts.grantOption {
-		privileges = append(privileges, "GRANT OPTION")
+	var query string
+	// MariaDB requires "REVOKE ALL PRIVILEGES, GRANT OPTION FROM" (no ON clause)
+	// for this specific combination. The normal "REVOKE ... ON ... FROM" syntax
+	// produces Error 1064 (syntax error) when ALL PRIVILEGES and GRANT OPTION
+	// are combined: https://mariadb.com/kb/en/revoke/
+	if grantOpts.grantOption && hasAllPrivileges(privileges) {
+		query = fmt.Sprintf("REVOKE ALL PRIVILEGES, GRANT OPTION FROM %s", accountName)
+	} else {
+		if grantOpts.grantOption {
+			privileges = append(privileges, "GRANT OPTION")
+		}
+		query = fmt.Sprintf("REVOKE %s ON %s.%s FROM %s",
+			strings.Join(privileges, ", "),
+			escapeWildcard(database),
+			escapeWildcard(table),
+			accountName,
+		)
 	}
-	query := fmt.Sprintf("REVOKE %s ON %s.%s FROM %s",
-		strings.Join(privileges, ","),
-		escapeWildcard(database),
-		escapeWildcard(table),
-		accountName,
-	)
 
 	return IgnoreNonExistingGrant(c.Exec(ctx, query))
+}
+
+func hasAllPrivileges(privileges []string) bool {
+	for _, p := range privileges {
+		upper := strings.ToUpper(strings.TrimSpace(p))
+		if upper == "ALL PRIVILEGES" || upper == "ALL" {
+			return true
+		}
+	}
+	return false
 }
 
 func escapeWildcard(s string) string {

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -634,7 +634,7 @@ func (c *Client) Revoke(
 		accountName,
 	)
 
-	return c.Exec(ctx, query)
+	return IgnoreNonExistingGrant(c.Exec(ctx, query))
 }
 
 func escapeWildcard(s string) string {


### PR DESCRIPTION
# Defect 1 — idempotent REVOKE (`pkg/sql/sql.go`, `pkg/sql/error.go`)

`Revoke()` now swallows MariaDB Error 1141 (`ER_NONEXISTING_GRANT`) and returns `nil`, mirroring the `IF EXISTS` semantics already used by `DropUser` and `DropDatabase`. Implemented via the existing error-handling pattern in `error.go` (`IgnoreNonExistingGrant`), consistent with `IgnoreYouAreNotOwnerOfThread`.

This fix applies to **both** the finalizer cleanup path and the normal reconciliation path (`privilegesToRevoke`), since both call the same `Revoke()` method.

# Defect 2 — safe finalizer removal (all 3 finalizers)

Changed `client.MergeFrom(obj.DeepCopy())` to `client.MergeFromWithOptions(obj.DeepCopy(), client.MergeFromWithOptimisticLock{})` in:

- `internal/controller/grant_controller_finalizer.go`
- `internal/controller/user_controller_finalizer.go`
- `internal/controller/database_controller_finalizer.go`

`MergeFromWithOptimisticLock` includes the `resourceVersion` from the cached object in the patch base. If the `finalizers` array has been modified concurrently (e.g. GC adding/removing `foregroundDeletion`), the API server returns **409 Conflict** instead of **403 Forbidden**. The 409 causes controller-runtime to re-fetch the latest version and retry the patch with the correct base.

# Defect 3: Malformed REVOKE SQL when `ALL PRIVILEGES` + `GRANT OPTION` (Error 1064)

A `Grant` with `privileges: ["ALL PRIVILEGES"]` and `grantOption: true` produces:
```sql
REVOKE ALL PRIVILEGES,GRANT OPTION ON *.* FROM 'user'@'%'
```
MariaDB requires a special syntax for this combination — no ON clause:

```sql
REVOKE ALL PRIVILEGES, GRANT OPTION FROM 'user'@'%'
```

