### PR TITLE
test: migrate pkg/compression tests to Ginkgo

### DIFF
--- a/pkg/compression/backup_compressor_test.go
+++ b/pkg/compression/backup_compressor_test.go
@@ -3,69 +3,40 @@ package compression
 import (
 	"os"
 	"path/filepath"
-	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/backup"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestBackupCompressors(t *testing.T) {
+var _ = Describe("BackupCompressors", func() {
 	content := "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
 	processor := backup.NewLogicalBackupProcessor()
 	logger := logr.Discard()
 
-	tests := []struct {
-		name            string
-		newCompressorFn func(basePath string, getUncompressedFilename GetBackupUncompressedFilenameFn, logger logr.Logger) BackupCompressor
-		fileName        string
-	}{
-		{
-			name:            "nop",
-			newCompressorFn: NewNopBackupCompressor,
-			fileName:        "backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name:            "gzip",
-			newCompressorFn: NewGzipBackupCompressor,
-			fileName:        "backup.2023-12-18T16:14:00Z.sql.gz",
-		},
-		{
-			name:            "bzip2",
-			newCompressorFn: NewBzip2BackupCompressor,
-			fileName:        "backup.2023-12-18T16:14:00Z.sql.bz2",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	DescribeTable("compresses and decompresses backup files",
+		//nolint:lll
+		func(newCompressorFn func(basePath string, getUncompressedFilename GetBackupUncompressedFilenameFn, logger logr.Logger) BackupCompressor, fileName string) {
 			dir, err := os.MkdirTemp("", "backup_test")
-			if err != nil {
-				t.Fatalf("Failed to create temp dir: %v", err)
-			}
-			defer os.RemoveAll(dir)
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(os.RemoveAll, dir)
 
-			compressor := tt.newCompressorFn(dir, processor.GetUncompressedBackupFile, logger)
+			compressor := newCompressorFn(dir, processor.GetUncompressedBackupFile, logger)
 
-			filePath := filepath.Join(dir, tt.fileName)
-			if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
-				t.Fatalf("Failed to write test file: %v", err)
-			}
+			filePath := filepath.Join(dir, fileName)
+			Expect(os.WriteFile(filePath, []byte(content), 0644)).To(Succeed())
 
-			if err := compressor.Compress(filePath); err != nil {
-				t.Fatalf("Failed to compress test file: %v", err)
-			}
+			Expect(compressor.Compress(filePath)).To(Succeed())
 			decompressedFileName, err := compressor.Decompress(filePath)
-			if err != nil {
-				t.Fatalf("Failed to decompress test file: %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
 
 			decompressedContent, err := os.ReadFile(decompressedFileName)
-			if err != nil {
-				t.Fatalf("Failed to read decompressed file: %v", err)
-			}
-			if string(decompressedContent) != content {
-				t.Errorf("Decompressed content does not match original content:\nGot: %s\nWant: %s", decompressedContent, content)
-			}
-		})
-	}
-}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(decompressedContent)).To(Equal(content))
+		},
+		Entry("nop", NewNopBackupCompressor, "backup.2023-12-18T16:14:00Z.sql"),
+		Entry("gzip", NewGzipBackupCompressor, "backup.2023-12-18T16:14:00Z.sql.gz"),
+		Entry("bzip2", NewBzip2BackupCompressor, "backup.2023-12-18T16:14:00Z.sql.bz2"),
+	)
+})

--- a/pkg/compression/suite_test.go
+++ b/pkg/compression/suite_test.go
@@ -1,0 +1,13 @@
+package compression
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCompression(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Compression Suite")
+}


### PR DESCRIPTION
Migrates `pkg/compression` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `backup_compressor_test.go`: converted to a `Describe` block with a `DescribeTable` (3 entries). Entry names match the original `t.Run()` names.

Verified with:
```
go test ./pkg/compression/...
```

Part of #368.
