### PR TITLE
test: migrate pkg/controller/certificate tests to Ginkgo

### DIFF
--- a/pkg/controller/certificate/cert_manager_test.go
+++ b/pkg/controller/certificate/cert_manager_test.go
@@ -2,76 +2,60 @@ package certificate
 
 import (
 	"crypto/x509"
-	"testing"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestCertManagerKeyUsages(t *testing.T) {
-	tests := []struct {
-		name           string
-		opts           *CertReconcilerOpts
-		expectedUsages []certmanagerv1.KeyUsage
-	}{
-		{
-			name: "No key usages",
-			opts: &CertReconcilerOpts{
+var _ = Describe("CertManagerKeyUsages", func() {
+	DescribeTable("returns cert-manager key usages",
+		func(opts *CertReconcilerOpts, expectedUsages []certmanagerv1.KeyUsage) {
+			usages := certManagerKeyUsages(opts, logr.Discard())
+			Expect(usages).To(HaveLen(len(expectedUsages)))
+			for i := range usages {
+				Expect(usages[i]).To(Equal(expectedUsages[i]))
+			}
+		},
+		Entry("No key usages",
+			&CertReconcilerOpts{
 				certKeyUsage:    0,
 				certExtKeyUsage: nil,
 			},
-			expectedUsages: []certmanagerv1.KeyUsage{},
-		},
-		{
-			name: "Single key usage: DigitalSignature",
-			opts: &CertReconcilerOpts{
+			[]certmanagerv1.KeyUsage{},
+		),
+		Entry("Single key usage: DigitalSignature",
+			&CertReconcilerOpts{
 				certKeyUsage:    x509.KeyUsageDigitalSignature,
 				certExtKeyUsage: nil,
 			},
-			expectedUsages: []certmanagerv1.KeyUsage{certmanagerv1.UsageDigitalSignature},
-		},
-		{
-			name: "Multiple key usages",
-			opts: &CertReconcilerOpts{
+			[]certmanagerv1.KeyUsage{certmanagerv1.UsageDigitalSignature},
+		),
+		Entry("Multiple key usages",
+			&CertReconcilerOpts{
 				certKeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 				certExtKeyUsage: []x509.ExtKeyUsage{
 					x509.ExtKeyUsageServerAuth,
 					x509.ExtKeyUsageClientAuth,
 				},
 			},
-			expectedUsages: []certmanagerv1.KeyUsage{
+			[]certmanagerv1.KeyUsage{
 				certmanagerv1.UsageDigitalSignature,
 				certmanagerv1.UsageKeyEncipherment,
 				certmanagerv1.UsageServerAuth,
 				certmanagerv1.UsageClientAuth,
 			},
-		},
-		{
-			name: "Unsupported ExtKeyUsage",
-			opts: &CertReconcilerOpts{
+		),
+		Entry("Unsupported ExtKeyUsage",
+			&CertReconcilerOpts{
 				certKeyUsage: 0,
 				certExtKeyUsage: []x509.ExtKeyUsage{
 					x509.ExtKeyUsageTimeStamping,
 					99, // Unsupported ExtKeyUsage
 				},
 			},
-			expectedUsages: []certmanagerv1.KeyUsage{certmanagerv1.UsageTimestamping},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			usages := certManagerKeyUsages(tt.opts, logr.Discard())
-
-			if len(usages) != len(tt.expectedUsages) {
-				t.Errorf("unexpected number of usages: got %d, want %d", len(usages), len(tt.expectedUsages))
-			}
-
-			for i, usage := range usages {
-				if usage != tt.expectedUsages[i] {
-					t.Errorf("unexpected usage at index %d: got %v, want %v", i, usage, tt.expectedUsages[i])
-				}
-			}
-		})
-	}
-}
+			[]certmanagerv1.KeyUsage{certmanagerv1.UsageTimestamping},
+		),
+	)
+})

--- a/pkg/controller/certificate/suite_test.go
+++ b/pkg/controller/certificate/suite_test.go
@@ -1,0 +1,13 @@
+package certificate
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCertificate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Certificate Suite")
+}


### PR DESCRIPTION
Migrates `pkg/controller/certificate` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `cert_manager_test.go`: converted to a `Describe` block with a `DescribeTable` (4 entries). Entry names match the original `t.Run()` names.

Verified with:
```
go test ./pkg/controller/certificate/...
```

Part of #368.
