### PR TITLE
test: migrate pkg/volumesnapshot tests to Ginkgo

### DIFF
--- a/pkg/volumesnapshot/suite_test.go
+++ b/pkg/volumesnapshot/suite_test.go
@@ -1,0 +1,13 @@
+package volumesnapshot
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVolumesnapshot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Volumesnapshot Suite")
+}

--- a/pkg/volumesnapshot/volumesnapshot_test.go
+++ b/pkg/volumesnapshot/volumesnapshot_test.go
@@ -1,112 +1,87 @@
 package volumesnapshot
 
 import (
-	"testing"
 	"time"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
-func TestIsVolumeSnapshotProvisioned(t *testing.T) {
-	now := metav1.Time{Time: time.Now()}
-	cases := []struct {
-		name string
-		snap *volumesnapshotv1.VolumeSnapshot
-		want bool
-	}{
-		{
-			name: "nil status",
-			snap: &volumesnapshotv1.VolumeSnapshot{},
-			want: false,
+var now = metav1.Time{Time: time.Now()}
+
+var _ = Describe("IsVolumeSnapshotProvisioned", func() {
+	DescribeTable("returns whether the volume snapshot is provisioned",
+		func(snap *volumesnapshotv1.VolumeSnapshot, want bool) {
+			Expect(IsVolumeSnapshotProvisioned(snap)).To(Equal(want))
 		},
-		{
-			name: "bound empty",
-			snap: &volumesnapshotv1.VolumeSnapshot{
+		Entry("nil status", &volumesnapshotv1.VolumeSnapshot{}, false),
+		Entry("bound empty",
+			&volumesnapshotv1.VolumeSnapshot{
 				Status: &volumesnapshotv1.VolumeSnapshotStatus{},
 			},
-			want: false,
-		},
-		{
-			name: "bound present but creationTime nil",
-			snap: &volumesnapshotv1.VolumeSnapshot{
+			false,
+		),
+		Entry("bound present but creationTime nil",
+			&volumesnapshotv1.VolumeSnapshot{
 				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					BoundVolumeSnapshotContentName: ptr.To("bvs-1"),
 				},
 			},
-			want: false,
-		},
-		{
-			name: "bound and creationTime present, no error",
-			snap: &volumesnapshotv1.VolumeSnapshot{
+			false,
+		),
+		Entry("bound and creationTime present, no error",
+			&volumesnapshotv1.VolumeSnapshot{
 				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					BoundVolumeSnapshotContentName: ptr.To("bvs-2"),
 					CreationTime:                   &now,
 				},
 			},
-			want: true,
-		},
-		{
-			name: "bound and creationTime present, but error present",
-			snap: &volumesnapshotv1.VolumeSnapshot{
+			true,
+		),
+		Entry("bound and creationTime present, but error present",
+			&volumesnapshotv1.VolumeSnapshot{
 				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					BoundVolumeSnapshotContentName: ptr.To("bvs-3"),
 					CreationTime:                   &now,
 					Error:                          &volumesnapshotv1.VolumeSnapshotError{Message: ptr.To("boom")},
 				},
 			},
-			want: false,
-		},
-	}
+			false,
+		),
+	)
+})
 
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := IsVolumeSnapshotProvisioned(c.snap)
-			if got != c.want {
-				t.Fatalf("IsVolumeSnapshotProvisioned(%s) = %v, want %v", c.name, got, c.want)
-			}
-		})
-	}
-}
-
-func TestIsVolumeSnapshotReady(t *testing.T) {
-	now := metav1.Time{Time: time.Now()}
-	cases := []struct {
-		name string
-		snap *volumesnapshotv1.VolumeSnapshot
-		want bool
-	}{
-		{
-			name: "not provisioned",
-			snap: &volumesnapshotv1.VolumeSnapshot{},
-			want: false,
+var _ = Describe("IsVolumeSnapshotReady", func() {
+	DescribeTable("returns whether the volume snapshot is ready",
+		func(snap *volumesnapshotv1.VolumeSnapshot, want bool) {
+			Expect(IsVolumeSnapshotReady(snap)).To(Equal(want))
 		},
-		{
-			name: "provisioned but not ready",
-			snap: &volumesnapshotv1.VolumeSnapshot{
+		Entry("not provisioned", &volumesnapshotv1.VolumeSnapshot{}, false),
+		Entry("provisioned but not ready",
+			&volumesnapshotv1.VolumeSnapshot{
 				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					BoundVolumeSnapshotContentName: ptr.To("bvs-4"),
 					CreationTime:                   &now,
 					ReadyToUse:                     ptr.To(false),
 				},
 			},
-			want: false,
-		},
-		{
-			name: "provisioned and ready",
-			snap: &volumesnapshotv1.VolumeSnapshot{
+			false,
+		),
+		Entry("provisioned and ready",
+			&volumesnapshotv1.VolumeSnapshot{
 				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					BoundVolumeSnapshotContentName: ptr.To("bvs-5"),
 					CreationTime:                   &now,
 					ReadyToUse:                     ptr.To(true),
 				},
 			},
-			want: true,
-		},
-		{
-			name: "provisioned and ready but error present",
-			snap: &volumesnapshotv1.VolumeSnapshot{
+			true,
+		),
+		Entry("provisioned and ready but error present",
+			&volumesnapshotv1.VolumeSnapshot{
 				Status: &volumesnapshotv1.VolumeSnapshotStatus{
 					BoundVolumeSnapshotContentName: ptr.To("bvs-6"),
 					CreationTime:                   &now,
@@ -114,16 +89,7 @@ func TestIsVolumeSnapshotReady(t *testing.T) {
 					Error:                          &volumesnapshotv1.VolumeSnapshotError{Message: ptr.To("err")},
 				},
 			},
-			want: false,
-		},
-	}
-
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			got := IsVolumeSnapshotReady(c.snap)
-			if got != c.want {
-				t.Fatalf("IsVolumeSnapshotReady(%s) = %v, want %v", c.name, got, c.want)
-			}
-		})
-	}
-}
+			false,
+		),
+	)
+})


### PR DESCRIPTION
Migrates `pkg/volumesnapshot` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `volumesnapshot_test.go`: converted to `Describe` blocks with 2 `DescribeTable` blocks (9 entries total). Entry names match the original `t.Run()` names.

Verified with:
```
go test ./pkg/volumesnapshot/...
```

Part of #368.
