### PR TITLE
test: migrate pkg/controller/service tests to Ginkgo

### DIFF
--- a/pkg/controller/service/controller_test.go
+++ b/pkg/controller/service/controller_test.go
@@ -1,244 +1,207 @@
 package service
 
 import (
-	"reflect"
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func Test_updateServicePorts(t *testing.T) {
-	t.Run("Nil services", func(t *testing.T) {
-		updateServicePorts(nil, nil)
-	})
-
-	t.Run("Existing service has no ports", func(t *testing.T) {
-		existingSvc := &corev1.Service{}
-		desiredSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
+var _ = Describe("updateServicePorts", func() {
+	DescribeTable("updates the existing service ports",
+		func(existingSvc, desiredSvc, expectedSvc *corev1.Service) {
+			updateServicePorts(existingSvc, desiredSvc)
+			if expectedSvc == nil {
+				Expect(existingSvc).To(BeNil())
+			} else {
+				Expect(existingSvc).To(Equal(expectedSvc))
+			}
+		},
+		Entry("Nil services", nil, nil, nil),
+		Entry("Existing service has no ports",
+			&corev1.Service{},
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+						},
 					},
 				},
 			},
-		}
-
-		expectedSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+						},
 					},
 				},
 			},
-		}
-
-		updateServicePorts(existingSvc, desiredSvc)
-
-		if !reflect.DeepEqual(existingSvc, expectedSvc) {
-			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
-		}
-	})
-
-	t.Run("Existing service has ports with overlapping ports", func(t *testing.T) {
-		existingSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     80,
-						Protocol: corev1.ProtocolTCP,
+		),
+		Entry("Existing service has ports with overlapping ports",
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     80,
+							Protocol: corev1.ProtocolTCP,
+						},
 					},
 				},
 			},
-		}
-
-		desiredSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     80,
-						Protocol: corev1.ProtocolTCP,
-					},
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
-					},
-				},
-			},
-		}
-
-		expectedSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     80,
-						Protocol: corev1.ProtocolTCP,
-					},
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     80,
+							Protocol: corev1.ProtocolTCP,
+						},
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+						},
 					},
 				},
 			},
-		}
-
-		updateServicePorts(existingSvc, desiredSvc)
-
-		if !reflect.DeepEqual(existingSvc, expectedSvc) {
-			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
-		}
-	})
-
-	t.Run("Desired service has NodePort type and existing port has non-zero NodePort", func(t *testing.T) {
-		existingSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
-						NodePort: 30000,
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     80,
+							Protocol: corev1.ProtocolTCP,
+						},
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+						},
 					},
 				},
 			},
-		}
-
-		desiredSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeNodePort,
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
+		),
+		Entry("Desired service has NodePort type and existing port has non-zero NodePort",
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+							NodePort: 30000,
+						},
 					},
 				},
 			},
-		}
-
-		expectedSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
-						NodePort: 30000,
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeNodePort,
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+						},
 					},
 				},
 			},
-		}
-
-		updateServicePorts(existingSvc, desiredSvc)
-
-		if !reflect.DeepEqual(existingSvc, expectedSvc) {
-			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
-		}
-	})
-
-	t.Run("Desired service has ClusterIP type and existing port has non-zero NodePort", func(t *testing.T) {
-		existingSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
-						NodePort: 30000,
-					},
-					{
-						Port:     80,
-						Protocol: corev1.ProtocolTCP,
-						NodePort: 30001,
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+							NodePort: 30000,
+						},
 					},
 				},
 			},
-		}
-
-		desiredSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeClusterIP,
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
+		),
+		Entry("Desired service has ClusterIP type and existing port has non-zero NodePort",
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+							NodePort: 30000,
+						},
+						{
+							Port:     80,
+							Protocol: corev1.ProtocolTCP,
+							NodePort: 30001,
+						},
 					},
 				},
 			},
-		}
-
-		expectedSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
-					},
-					{
-						Port:     80,
-						Protocol: corev1.ProtocolTCP,
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeClusterIP,
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+						},
 					},
 				},
 			},
-		}
-
-		updateServicePorts(existingSvc, desiredSvc)
-
-		if !reflect.DeepEqual(existingSvc, expectedSvc) {
-			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
-		}
-	})
-
-	t.Run("Desired service has LoadBalancer type and existing port has non-zero NodePort", func(t *testing.T) {
-		existingSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
-						NodePort: 30000,
-					},
-					{
-						Port:     80,
-						Protocol: corev1.ProtocolTCP,
-						NodePort: 30001,
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+						},
+						{
+							Port:     80,
+							Protocol: corev1.ProtocolTCP,
+						},
 					},
 				},
 			},
-		}
-
-		desiredSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Type: corev1.ServiceTypeLoadBalancer,
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
+		),
+		Entry("Desired service has LoadBalancer type and existing port has non-zero NodePort",
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+							NodePort: 30000,
+						},
+						{
+							Port:     80,
+							Protocol: corev1.ProtocolTCP,
+							NodePort: 30001,
+						},
 					},
 				},
 			},
-		}
-
-		expectedSvc := &corev1.Service{
-			Spec: corev1.ServiceSpec{
-				Ports: []corev1.ServicePort{
-					{
-						Port:     3306,
-						Protocol: corev1.ProtocolTCP,
-						NodePort: 30000,
-					},
-					{
-						Port:     80,
-						Protocol: corev1.ProtocolTCP,
-						NodePort: 30001,
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Type: corev1.ServiceTypeLoadBalancer,
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+						},
 					},
 				},
 			},
-		}
-
-		updateServicePorts(existingSvc, desiredSvc)
-
-		if !reflect.DeepEqual(existingSvc, expectedSvc) {
-			t.Errorf("updateServicePorts() = %v, want %v", existingSvc, expectedSvc)
-		}
-	})
-}
+			&corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:     3306,
+							Protocol: corev1.ProtocolTCP,
+							NodePort: 30000,
+						},
+						{
+							Port:     80,
+							Protocol: corev1.ProtocolTCP,
+							NodePort: 30001,
+						},
+					},
+				},
+			},
+		),
+	)
+})

--- a/pkg/controller/service/suite_test.go
+++ b/pkg/controller/service/suite_test.go
@@ -1,0 +1,13 @@
+package service
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestServiceController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Service Controller Suite")
+}


### PR DESCRIPTION
Migrates `pkg/controller/service` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `controller_test.go` converted to a `DescribeTable` (6 entries). Entry names match the original `t.Run()` names.

Verified with:
```
go test ./pkg/controller/service/...
```

Part of #368.
