### PR TITLE
test: migrate pkg/maxscale/config tests to Ginkgo

### DIFF
--- a/pkg/maxscale/config/config_test.go
+++ b/pkg/maxscale/config/config_test.go
@@ -1,31 +1,38 @@
 package config
 
 import (
-	"reflect"
 	"sort"
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"k8s.io/utils/ptr"
 )
 
-func TestMaxScaleConfig(t *testing.T) {
-	tests := []struct {
-		name       string
-		mxs        *mariadbv1alpha1.MaxScale
-		wantConfig string
-	}{
-		{
-			name: "default",
-			mxs: &mariadbv1alpha1.MaxScale{
+var _ = Describe("Config", func() {
+	DescribeTable("rendering MaxScale config",
+		func(mxs *mariadbv1alpha1.MaxScale, wantConfig string) {
+			bytes, err := Config(mxs)
+			Expect(err).NotTo(HaveOccurred())
+			config := string(bytes)
+			wantLines := strings.Split(wantConfig, "\n")
+			gotLines := strings.Split(config, "\n")
+			// Sort both slices for predictable order, as the parameters might be rendered in different order
+			sort.Strings(wantLines)
+			sort.Strings(gotLines)
+			Expect(gotLines).To(Equal(wantLines))
+		},
+		Entry("default",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Admin: mariadbv1alpha1.MaxScaleAdmin{
 						Port: 8989,
 					},
 				},
 			},
-			wantConfig: `[maxscale]
+			`[maxscale]
 threads=auto
 persist_runtime_changes=true
 load_persisted_configs=true
@@ -34,10 +41,9 @@ admin_port=8989
 admin_gui=true
 admin_secure_gui=false
 `,
-		},
-		{
-			name: "tls",
-			mxs: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("tls",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Admin: mariadbv1alpha1.MaxScaleAdmin{
 						Port: 8989,
@@ -47,7 +53,7 @@ admin_secure_gui=false
 					},
 				},
 			},
-			wantConfig: `[maxscale]
+			`[maxscale]
 threads=auto
 persist_runtime_changes=true
 load_persisted_configs=true
@@ -59,10 +65,9 @@ admin_ssl_key=/etc/pki/admin.key
 admin_ssl_cert=/etc/pki/admin.crt
 admin_ssl_ca_cert=/etc/pki/ca.crt
 `,
-		},
-		{
-			name: "extra params",
-			mxs: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("extra params",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Config: mariadbv1alpha1.MaxScaleConfig{
 						Params: map[string]string{
@@ -78,7 +83,7 @@ admin_ssl_ca_cert=/etc/pki/ca.crt
 					},
 				},
 			},
-			wantConfig: `[maxscale]
+			`[maxscale]
 threads=auto
 persist_runtime_changes=true
 load_persisted_configs=true
@@ -91,10 +96,9 @@ logdir=/var/log/maxscale/
 datadir=/var/lib/maxscale/
 persistdir=/var/lib/maxscale/maxscale.cnf.d/
 `,
-		},
-		{
-			name: "override params",
-			mxs: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("override params",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Config: mariadbv1alpha1.MaxScaleConfig{
 						Params: map[string]string{
@@ -108,7 +112,7 @@ persistdir=/var/lib/maxscale/maxscale.cnf.d/
 					},
 				},
 			},
-			wantConfig: `[maxscale]
+			`[maxscale]
 threads=4
 persist_runtime_changes=true
 load_persisted_configs=true
@@ -119,10 +123,9 @@ admin_secure_gui=false
 datadir=/var/lib/maxscale/
 persistdir=/var/lib/maxscale/maxscale.cnf.d/
 `,
-		},
-		{
-			name: "override query_classifier_cache_size",
-			mxs: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("override query_classifier_cache_size",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Config: mariadbv1alpha1.MaxScaleConfig{
 						Params: map[string]string{
@@ -134,7 +137,7 @@ persistdir=/var/lib/maxscale/maxscale.cnf.d/
 					},
 				},
 			},
-			wantConfig: `[maxscale]
+			`[maxscale]
 threads=auto
 query_classifier_cache_size=10MB
 persist_runtime_changes=true
@@ -144,10 +147,9 @@ admin_port=8989
 admin_gui=true
 admin_secure_gui=false
 `,
-		},
-		{
-			name: "non overridable params",
-			mxs: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("non overridable params",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Config: mariadbv1alpha1.MaxScaleConfig{
 						Params: map[string]string{
@@ -162,7 +164,7 @@ admin_secure_gui=false
 					},
 				},
 			},
-			wantConfig: `[maxscale]
+			`[maxscale]
 threads=4
 persist_runtime_changes=true
 load_persisted_configs=true
@@ -171,24 +173,6 @@ admin_port=8989
 admin_gui=true
 admin_secure_gui=false
 `,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bytes, err := Config(tt.mxs)
-			if err != nil {
-				t.Error("expect error to have occurred, got nil")
-			}
-			config := string(bytes)
-			wantLines := strings.Split(tt.wantConfig, "\n")
-			gotLines := strings.Split(config, "\n")
-			// Sort both slices for predictable order, as the parameters might be rendered in different order
-			sort.Strings(wantLines)
-			sort.Strings(gotLines)
-			if !reflect.DeepEqual(wantLines, gotLines) {
-				t.Errorf("expecting config to be:\n%v\ngot:\n%v\n", tt.wantConfig, config)
-			}
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/maxscale/config/defaults_test.go
+++ b/pkg/maxscale/config/defaults_test.go
@@ -1,22 +1,22 @@
 package config
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-func TestThreads(t *testing.T) {
-	tests := []struct {
-		name       string
-		mxs        *mariadbv1alpha1.MaxScale
-		wantString string
-	}{
-		{
-			name: "cpu limit defined",
-			mxs: &mariadbv1alpha1.MaxScale{
+var _ = Describe("threads", func() {
+	DescribeTable("computing threads",
+		func(mxs *mariadbv1alpha1.MaxScale, wantString string) {
+			gotString := threads(mxs)
+			Expect(gotString).To(Equal(wantString))
+		},
+		Entry("cpu limit defined",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Resources: &mariadbv1alpha1.ResourceRequirements{
@@ -27,11 +27,10 @@ func TestThreads(t *testing.T) {
 					},
 				},
 			},
-			wantString: "1",
-		},
-		{
-			name: "cpu limit defined round up",
-			mxs: &mariadbv1alpha1.MaxScale{
+			"1",
+		),
+		Entry("cpu limit defined round up",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Resources: &mariadbv1alpha1.ResourceRequirements{
@@ -42,18 +41,16 @@ func TestThreads(t *testing.T) {
 					},
 				},
 			},
-			wantString: "1",
-		},
-		{
-			name: "resources not defined",
-			mxs: &mariadbv1alpha1.MaxScale{
+			"1",
+		),
+		Entry("resources not defined",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{},
 			},
-			wantString: "auto",
-		},
-		{
-			name: "only requests defined",
-			mxs: &mariadbv1alpha1.MaxScale{
+			"auto",
+		),
+		Entry("only requests defined",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Resources: &mariadbv1alpha1.ResourceRequirements{
@@ -64,11 +61,10 @@ func TestThreads(t *testing.T) {
 					},
 				},
 			},
-			wantString: "auto",
-		},
-		{
-			name: "other limit defined",
-			mxs: &mariadbv1alpha1.MaxScale{
+			"auto",
+		),
+		Entry("other limit defined",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Resources: &mariadbv1alpha1.ResourceRequirements{
@@ -79,29 +75,19 @@ func TestThreads(t *testing.T) {
 					},
 				},
 			},
-			wantString: "auto",
+			"auto",
+		),
+	)
+})
+
+var _ = Describe("queryClassifierCacheSize", func() {
+	DescribeTable("computing query classifier cache size",
+		func(mxs *mariadbv1alpha1.MaxScale, wantString string) {
+			gotString := queryClassifierCacheSize(mxs)
+			Expect(gotString).To(Equal(wantString))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotString := threads(tt.mxs)
-			if tt.wantString != gotString {
-				t.Errorf("unexpected result:\nexpected:\n%s\ngot:\n%s\n", tt.wantString, gotString)
-			}
-		})
-	}
-}
-
-func TestQueryClassifierCacheSize(t *testing.T) {
-	tests := []struct {
-		name       string
-		mxs        *mariadbv1alpha1.MaxScale
-		wantString string
-	}{
-		{
-			name: "memory limit defined",
-			mxs: &mariadbv1alpha1.MaxScale{
+		Entry("memory limit defined",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Resources: &mariadbv1alpha1.ResourceRequirements{
@@ -112,18 +98,16 @@ func TestQueryClassifierCacheSize(t *testing.T) {
 					},
 				},
 			},
-			wantString: "150000000",
-		},
-		{
-			name: "resources not defined",
-			mxs: &mariadbv1alpha1.MaxScale{
+			"150000000",
+		),
+		Entry("resources not defined",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{},
 			},
-			wantString: "",
-		},
-		{
-			name: "only requests defined",
-			mxs: &mariadbv1alpha1.MaxScale{
+			"",
+		),
+		Entry("only requests defined",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Resources: &mariadbv1alpha1.ResourceRequirements{
@@ -134,11 +118,10 @@ func TestQueryClassifierCacheSize(t *testing.T) {
 					},
 				},
 			},
-			wantString: "",
-		},
-		{
-			name: "other limit defined",
-			mxs: &mariadbv1alpha1.MaxScale{
+			"",
+		),
+		Entry("other limit defined",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Resources: &mariadbv1alpha1.ResourceRequirements{
@@ -149,16 +132,7 @@ func TestQueryClassifierCacheSize(t *testing.T) {
 					},
 				},
 			},
-			wantString: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotString := queryClassifierCacheSize(tt.mxs)
-			if tt.wantString != gotString {
-				t.Errorf("unexpected result:\nexpected:\n%s\ngot:\n%s\n", tt.wantString, gotString)
-			}
-		})
-	}
-}
+			"",
+		),
+	)
+})

--- a/pkg/maxscale/config/suite_test.go
+++ b/pkg/maxscale/config/suite_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMaxScaleConfigSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MaxScale Config Suite")
+}


### PR DESCRIPTION
Migrates `pkg/maxscale/config` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `config_test.go` and `defaults_test.go` converted to `DescribeTable` specs (15 entries total). Entry names match the original `t.Run()` names.

Verified with:
```
go test ./pkg/maxscale/config/...
```

Part of #368.
