### PR TITLE
test: migrate pkg/pki tests to Ginkgo

### DIFF
--- a/pkg/pki/keypair_test.go
+++ b/pkg/pki/keypair_test.go
@@ -4,37 +4,37 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"math/big"
-	"reflect"
-	"testing"
 	"time"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestNewKeyPair(t *testing.T) {
-	tests := []struct {
-		name    string
-		certPEM []byte
-		keyPEM  []byte
-		opts    []KeyPairOpt
-		wantErr bool
-	}{
-		{
-			name:    "Empty Cert PEM",
-			certPEM: []byte(""),
-			keyPEM: []byte(`-----BEGIN EC PRIVATE KEY-----
+var _ = Describe("NewKeyPair", func() {
+	DescribeTable("creates a keypair from PEMs",
+		func(certPEM, keyPEM []byte, opts []KeyPairOpt, wantErr bool) {
+			_, err := NewKeyPair(certPEM, keyPEM, opts...)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		Entry("Empty Cert PEM",
+			[]byte(""),
+			[]byte(`-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIAdp3iKnNA1kO2Ep5Hw7owMcm06SecFGdOqW/vO4k2AjoAoGCCqGSM49
 AwEHoUQDQgAEiTVhkriBksuWW5W3Mv9L918m1BECaHUl7ZV/Pz2q84wY9aEbxe2P
 J3c22DtEFzg9emNuruVS5/HL+hanzz4o+g==
 -----END EC PRIVATE KEY-----
 `),
-			opts:    []KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeECDSA)},
-			wantErr: true,
-		},
-		{
-			name: "Empty Key PEM",
-			certPEM: []byte(`-----BEGIN CERTIFICATE-----
+			[]KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeECDSA)},
+			true,
+		),
+		Entry("Empty Key PEM",
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICXzCCAgagAwIBAgIRAIBgotjwHCDFrV2H9FWQrYIwCgYIKoZIzj0EAwIwNjEZ
 MBcGA1UEChMQbWFyaWFkYi1vcGVyYXRvcjEZMBcGA1UEAxMQbWFyaWFkYi1vcGVy
 YXRvcjAeFw0yNDEyMTkxNjI2NTVaFw0yNTEyMTkyMzI2NTVaMC8xLTArBgNVBAMT
@@ -48,27 +48,25 @@ cmlhZGItb3BlcmF0b3Itd2ViaG9vay5kZWZhdWx0LnN2Y4IgbWFyaWFkYi1vcGVy
 YXRvci13ZWJob29rLmRlZmF1bHSCGG1hcmlhZGItb3BlcmF0b3Itd2ViaG9vazAK
 BggqhkjOPQQDAgNHADBEAiBSWY1rVufSE+3i0w553uJGJCC4Fpa6cvRPEti8X3Kp
 1AIgG0qN5IT9EsRZaY4J2vBYsbN5LL+qRI5N0XGYqVWXuD8=
------END CERTIFICATE-----			
+-----END CERTIFICATE-----
 `),
-			keyPEM:  []byte(""),
-			opts:    []KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeECDSA)},
-			wantErr: true,
-		},
-		{
-			name:    "Invalid Cert PEM",
-			certPEM: []byte("invalid-cert"),
-			keyPEM: []byte(`-----BEGIN EC PRIVATE KEY-----
+			[]byte(""),
+			[]KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeECDSA)},
+			true,
+		),
+		Entry("Invalid Cert PEM",
+			[]byte("invalid-cert"),
+			[]byte(`-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIAdp3iKnNA1kO2Ep5Hw7owMcm06SecFGdOqW/vO4k2AjoAoGCCqGSM49
 AwEHoUQDQgAEiTVhkriBksuWW5W3Mv9L918m1BECaHUl7ZV/Pz2q84wY9aEbxe2P
 J3c22DtEFzg9emNuruVS5/HL+hanzz4o+g==
 -----END EC PRIVATE KEY-----
 `),
-			opts:    []KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeECDSA)},
-			wantErr: true,
-		},
-		{
-			name: "Invalid Key PEM",
-			certPEM: []byte(`-----BEGIN CERTIFICATE-----
+			[]KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeECDSA)},
+			true,
+		),
+		Entry("Invalid Key PEM",
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICXzCCAgagAwIBAgIRAIBgotjwHCDFrV2H9FWQrYIwCgYIKoZIzj0EAwIwNjEZ
 MBcGA1UEChMQbWFyaWFkYi1vcGVyYXRvcjEZMBcGA1UEAxMQbWFyaWFkYi1vcGVy
 YXRvcjAeFw0yNDEyMTkxNjI2NTVaFw0yNTEyMTkyMzI2NTVaMC8xLTArBgNVBAMT
@@ -82,15 +80,14 @@ cmlhZGItb3BlcmF0b3Itd2ViaG9vay5kZWZhdWx0LnN2Y4IgbWFyaWFkYi1vcGVy
 YXRvci13ZWJob29rLmRlZmF1bHSCGG1hcmlhZGItb3BlcmF0b3Itd2ViaG9vazAK
 BggqhkjOPQQDAgNHADBEAiBSWY1rVufSE+3i0w553uJGJCC4Fpa6cvRPEti8X3Kp
 1AIgG0qN5IT9EsRZaY4J2vBYsbN5LL+qRI5N0XGYqVWXuD8=
------END CERTIFICATE-----			
+-----END CERTIFICATE-----
 `),
-			keyPEM:  []byte("invalid-key"),
-			opts:    []KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeRSA)},
-			wantErr: true,
-		},
-		{
-			name: "Valid",
-			certPEM: []byte(`-----BEGIN CERTIFICATE-----
+			[]byte("invalid-key"),
+			[]KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeRSA)},
+			true,
+		),
+		Entry("Valid",
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICXzCCAgagAwIBAgIRAIBgotjwHCDFrV2H9FWQrYIwCgYIKoZIzj0EAwIwNjEZ
 MBcGA1UEChMQbWFyaWFkYi1vcGVyYXRvcjEZMBcGA1UEAxMQbWFyaWFkYi1vcGVy
 YXRvcjAeFw0yNDEyMTkxNjI2NTVaFw0yNTEyMTkyMzI2NTVaMC8xLTArBgNVBAMT
@@ -104,20 +101,19 @@ cmlhZGItb3BlcmF0b3Itd2ViaG9vay5kZWZhdWx0LnN2Y4IgbWFyaWFkYi1vcGVy
 YXRvci13ZWJob29rLmRlZmF1bHSCGG1hcmlhZGItb3BlcmF0b3Itd2ViaG9vazAK
 BggqhkjOPQQDAgNHADBEAiBSWY1rVufSE+3i0w553uJGJCC4Fpa6cvRPEti8X3Kp
 1AIgG0qN5IT9EsRZaY4J2vBYsbN5LL+qRI5N0XGYqVWXuD8=
------END CERTIFICATE-----			
+-----END CERTIFICATE-----
 `),
-			keyPEM: []byte(`-----BEGIN EC PRIVATE KEY-----
+			[]byte(`-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIAdp3iKnNA1kO2Ep5Hw7owMcm06SecFGdOqW/vO4k2AjoAoGCCqGSM49
 AwEHoUQDQgAEiTVhkriBksuWW5W3Mv9L918m1BECaHUl7ZV/Pz2q84wY9aEbxe2P
 J3c22DtEFzg9emNuruVS5/HL+hanzz4o+g==
 -----END EC PRIVATE KEY-----
 `),
-			opts:    []KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeECDSA)},
-			wantErr: false,
-		},
-		{
-			name: "Unmatched",
-			certPEM: []byte(`-----BEGIN CERTIFICATE-----
+			[]KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeECDSA)},
+			false,
+		),
+		Entry("Unmatched",
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICXzCCAgagAwIBAgIRAIBgotjwHCDFrV2H9FWQrYIwCgYIKoZIzj0EAwIwNjEZ
 MBcGA1UEChMQbWFyaWFkYi1vcGVyYXRvcjEZMBcGA1UEAxMQbWFyaWFkYi1vcGVy
 YXRvcjAeFw0yNDEyMTkxNjI2NTVaFw0yNTEyMTkyMzI2NTVaMC8xLTArBgNVBAMT
@@ -131,9 +127,9 @@ cmlhZGItb3BlcmF0b3Itd2ViaG9vay5kZWZhdWx0LnN2Y4IgbWFyaWFkYi1vcGVy
 YXRvci13ZWJob29rLmRlZmF1bHSCGG1hcmlhZGItb3BlcmF0b3Itd2ViaG9vazAK
 BggqhkjOPQQDAgNHADBEAiBSWY1rVufSE+3i0w553uJGJCC4Fpa6cvRPEti8X3Kp
 1AIgG0qN5IT9EsRZaY4J2vBYsbN5LL+qRI5N0XGYqVWXuD8=
------END CERTIFICATE-----			
+-----END CERTIFICATE-----
 `),
-			keyPEM: []byte(`-----BEGIN RSA PRIVATE KEY-----
+			[]byte(`-----BEGIN RSA PRIVATE KEY-----
 MIIEogIBAAKCAQEA1l202NMTln0/ngg4JXUJLJXvhSjjHimO22c47tHhWvnzhtnK
 CrH8cWBnnxO11os5PcNIUYTxn04mZPRs+p1YkE9DMlp9Lgy/38304rr4kjllVspv
 l9MdrelqbcDy520rgF/YObfMZvzeseH2F5UK386IXb1KYSmp8dn7RU2HvUf17Z/z
@@ -161,12 +157,11 @@ PEZhWvsvx9Qge+DhwW3vfTDH2RItevD5Av4x0jZX0TWPoII8aP07VmDQ4g0cEkKh
 nBZoGLkeDofSc+Ml4HRpi43U+fqhU77wr8Gq0YU74h7lFfiRI/M=
 -----END RSA PRIVATE KEY-----
 `),
-			opts:    []KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeRSA)},
-			wantErr: true,
-		},
-		{
-			name: "Unsupported",
-			certPEM: []byte(`-----BEGIN CERTIFICATE-----
+			[]KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeRSA)},
+			true,
+		),
+		Entry("Unsupported",
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICXzCCAgagAwIBAgIRAIBgotjwHCDFrV2H9FWQrYIwCgYIKoZIzj0EAwIwNjEZ
 MBcGA1UEChMQbWFyaWFkYi1vcGVyYXRvcjEZMBcGA1UEAxMQbWFyaWFkYi1vcGVy
 YXRvcjAeFw0yNDEyMTkxNjI2NTVaFw0yNTEyMTkyMzI2NTVaMC8xLTArBgNVBAMT
@@ -180,53 +175,44 @@ cmlhZGItb3BlcmF0b3Itd2ViaG9vay5kZWZhdWx0LnN2Y4IgbWFyaWFkYi1vcGVy
 YXRvci13ZWJob29rLmRlZmF1bHSCGG1hcmlhZGItb3BlcmF0b3Itd2ViaG9vazAK
 BggqhkjOPQQDAgNHADBEAiBSWY1rVufSE+3i0w553uJGJCC4Fpa6cvRPEti8X3Kp
 1AIgG0qN5IT9EsRZaY4J2vBYsbN5LL+qRI5N0XGYqVWXuD8=
------END CERTIFICATE-----			
+-----END CERTIFICATE-----
 `),
-			keyPEM: []byte(`-----BEGIN EC PRIVATE KEY-----
+			[]byte(`-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIAdp3iKnNA1kO2Ep5Hw7owMcm06SecFGdOqW/vO4k2AjoAoGCCqGSM49
 AwEHoUQDQgAEiTVhkriBksuWW5W3Mv9L918m1BECaHUl7ZV/Pz2q84wY9aEbxe2P
 J3c22DtEFzg9emNuruVS5/HL+hanzz4o+g==
 -----END EC PRIVATE KEY-----
 `),
-			opts:    []KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeRSA)},
-			wantErr: true,
-		},
-	}
+			[]KeyPairOpt{WithSupportedPrivateKeys(PrivateKeyTypeRSA)},
+			true,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewKeyPair(tt.certPEM, tt.keyPEM, tt.opts...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewKeyPair() error = %v, wantErr %v", err, tt.wantErr)
+var _ = Describe("NewKeyPairFromSecret", func() {
+	DescribeTable("creates a keypair from a secret",
+		func(secret *corev1.Secret, certKey, privateKeyKey string, opts []KeyPairOpt, wantErr bool) {
+			_, err := NewKeyPairFromSecret(secret, certKey, privateKeyKey, opts...)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
 			}
-		})
-	}
-}
-
-func TestNewKeyPairFromSecret(t *testing.T) {
-	tests := []struct {
-		name          string
-		secret        *corev1.Secret
-		certKey       string
-		privateKeyKey string
-		opts          []KeyPairOpt
-		wantErr       bool
-	}{
-		{
-			name: "Empty Secret",
-			secret: &corev1.Secret{
+		},
+		Entry("Empty Secret",
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 				},
 				Data: map[string][]byte{},
 			},
-			certKey:       TLSCertKey,
-			privateKeyKey: TLSKeyKey,
-			wantErr:       true,
-		},
-		{
-			name: "Missing Cert Key",
-			secret: &corev1.Secret{
+			TLSCertKey,
+			TLSKeyKey,
+			[]KeyPairOpt(nil),
+			true,
+		),
+		Entry("Missing Cert Key",
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 				},
@@ -239,13 +225,13 @@ J3c22DtEFzg9emNuruVS5/HL+hanzz4o+g==
 `),
 				},
 			},
-			certKey:       TLSCertKey,
-			privateKeyKey: TLSKeyKey,
-			wantErr:       true,
-		},
-		{
-			name: "Missing Key Key",
-			secret: &corev1.Secret{
+			TLSCertKey,
+			TLSKeyKey,
+			[]KeyPairOpt(nil),
+			true,
+		),
+		Entry("Missing Key Key",
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 				},
@@ -268,13 +254,13 @@ BggqhkjOPQQDAgNHADBEAiBSWY1rVufSE+3i0w553uJGJCC4Fpa6cvRPEti8X3Kp
 `),
 				},
 			},
-			certKey:       TLSCertKey,
-			privateKeyKey: TLSKeyKey,
-			wantErr:       true,
-		},
-		{
-			name: "Invalid Cert PEM",
-			secret: &corev1.Secret{
+			TLSCertKey,
+			TLSKeyKey,
+			[]KeyPairOpt(nil),
+			true,
+		),
+		Entry("Invalid Cert PEM",
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 				},
@@ -288,13 +274,13 @@ J3c22DtEFzg9emNuruVS5/HL+hanzz4o+g==
 `),
 				},
 			},
-			certKey:       TLSCertKey,
-			privateKeyKey: TLSKeyKey,
-			wantErr:       true,
-		},
-		{
-			name: "Invalid Key PEM",
-			secret: &corev1.Secret{
+			TLSCertKey,
+			TLSKeyKey,
+			[]KeyPairOpt(nil),
+			true,
+		),
+		Entry("Invalid Key PEM",
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 				},
@@ -318,13 +304,13 @@ BggqhkjOPQQDAgNHADBEAiBSWY1rVufSE+3i0w553uJGJCC4Fpa6cvRPEti8X3Kp
 					TLSKeyKey: []byte("invalid-key"),
 				},
 			},
-			certKey:       TLSCertKey,
-			privateKeyKey: TLSKeyKey,
-			wantErr:       true,
-		},
-		{
-			name: "Valid",
-			secret: &corev1.Secret{
+			TLSCertKey,
+			TLSKeyKey,
+			[]KeyPairOpt(nil),
+			true,
+		),
+		Entry("Valid",
+			&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test",
 				},
@@ -353,23 +339,15 @@ J3c22DtEFzg9emNuruVS5/HL+hanzz4o+g==
 `),
 				},
 			},
-			certKey:       TLSCertKey,
-			privateKeyKey: TLSKeyKey,
-			wantErr:       false,
-		},
-	}
+			TLSCertKey,
+			TLSKeyKey,
+			[]KeyPairOpt(nil),
+			false,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewKeyPairFromSecret(tt.secret, tt.certKey, tt.privateKeyKey, tt.opts...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewKeyPairFromSecret() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestNewKeyPairFromTemplate(t *testing.T) {
+var _ = Describe("NewKeyPairFromTemplate", func() {
 	// Subject: CN=mariadb-operator
 	caCertPEm := []byte(`-----BEGIN CERTIFICATE-----
 MIIByjCCAW+gAwIBAgIQInuHavw36CvWL7osylp/9jAKBggqhkjOPQQDAjA2MRkw
@@ -390,23 +368,33 @@ AwEHoUQDQgAEjHZZK5F9z3w9EkHz7siQWMsGHSOp1BdbAu0dba1jD4ysUm2F/3eR
 wMfXbaIBSyNnT+e9/glHQsUmYVLu5MskmA==
 -----END EC PRIVATE KEY-----
 `)
-	caKeyPair, err := NewKeyPair(caCertPEm, caPrivateKeyPEM)
-	if err != nil {
-		t.Fatalf("unexpected error generating CA keypair: %v", err)
-	}
+	var caKeyPair *KeyPair
+	BeforeEach(func() {
+		var err error
+		caKeyPair, err = NewKeyPair(caCertPEm, caPrivateKeyPEM)
+		Expect(err).NotTo(HaveOccurred())
+	})
 
-	tests := []struct {
-		name           string
-		tpl            *x509.Certificate
-		caKeyPair      *KeyPair
-		opts           []KeyPairOpt
-		wantErr        bool
-		wantCommonName string
-		wantIssuer     string
-	}{
-		{
-			name: "Invalid CA",
-			tpl: &x509.Certificate{
+	DescribeTable("creates a keypair from a template",
+		func(tpl *x509.Certificate, caKeyPairFn func() *KeyPair, wantErr bool, wantCommonName, wantIssuer string) {
+			keyPair, err := NewKeyPairFromTemplate(tpl, caKeyPairFn())
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			if wantErr {
+				return
+			}
+
+			cert, err := keyPair.LeafCertificate()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cert.Subject.CommonName).To(Equal(wantCommonName))
+			Expect(cert.Issuer.CommonName).To(Equal(wantIssuer))
+		},
+		Entry("Invalid CA",
+			&x509.Certificate{
 				SerialNumber: big.NewInt(1),
 				Subject: pkix.Name{
 					CommonName: "cert",
@@ -416,17 +404,18 @@ wMfXbaIBSyNnT+e9/glHQsUmYVLu5MskmA==
 				KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 				BasicConstraintsValid: true,
 			},
-			caKeyPair: &KeyPair{
-				CertPEM: []byte("invalid-cert"),
-				KeyPEM:  []byte("invalid-key"),
+			func() *KeyPair {
+				return &KeyPair{
+					CertPEM: []byte("invalid-cert"),
+					KeyPEM:  []byte("invalid-key"),
+				}
 			},
-			wantErr:        true,
-			wantCommonName: "",
-			wantIssuer:     "",
-		},
-		{
-			name: "Self-signed CA",
-			tpl: &x509.Certificate{
+			true,
+			"",
+			"",
+		),
+		Entry("Self-signed CA",
+			&x509.Certificate{
 				SerialNumber: big.NewInt(1),
 				Subject: pkix.Name{
 					CommonName: "ca",
@@ -437,14 +426,15 @@ wMfXbaIBSyNnT+e9/glHQsUmYVLu5MskmA==
 				BasicConstraintsValid: true,
 				IsCA:                  true,
 			},
-			caKeyPair:      nil,
-			wantErr:        false,
-			wantCommonName: "ca",
-			wantIssuer:     "ca",
-		},
-		{
-			name: "Leaf certificate",
-			tpl: &x509.Certificate{
+			func() *KeyPair {
+				return nil
+			},
+			false,
+			"ca",
+			"ca",
+		),
+		Entry("Leaf certificate",
+			&x509.Certificate{
 				SerialNumber: big.NewInt(1),
 				Subject: pkix.Name{
 					CommonName: "cert",
@@ -454,109 +444,72 @@ wMfXbaIBSyNnT+e9/glHQsUmYVLu5MskmA==
 				KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 				BasicConstraintsValid: true,
 			},
-			caKeyPair:      caKeyPair,
-			wantErr:        false,
-			wantCommonName: "cert",
-			wantIssuer:     "mariadb-operator",
+			func() *KeyPair {
+				return caKeyPair
+			},
+			false,
+			"cert",
+			"mariadb-operator",
+		),
+	)
+})
+
+var _ = Describe("UpdateSecret", func() {
+	DescribeTable("updates a secret with the keypair",
+		func(keyPair *KeyPair, secret *corev1.Secret, certKey, privateKeyKey string, want map[string][]byte) {
+			keyPair.UpdateSecret(secret, certKey, privateKeyKey)
+			Expect(secret.Data).To(Equal(want))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			keyPair, err := NewKeyPairFromTemplate(tt.tpl, tt.caKeyPair)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewKeyPairFromTemplate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.wantErr {
-				return
-			}
-
-			cert, err := keyPair.LeafCertificate()
-			if err != nil {
-				t.Errorf("error getting leaf certificate: %v", err)
-			}
-
-			if cert.Subject.CommonName != tt.wantCommonName {
-				t.Errorf("CommonName = %v, want %v", cert.Subject.CommonName, tt.wantCommonName)
-			}
-			if cert.Issuer.CommonName != tt.wantIssuer {
-				t.Errorf("Issuer = %v, want %v", cert.Issuer.CommonName, tt.wantIssuer)
-			}
-		})
-	}
-}
-
-func TestUpdateSecret(t *testing.T) {
-	tests := []struct {
-		name          string
-		keyPair       *KeyPair
-		secret        *corev1.Secret
-		certKey       string
-		privateKeyKey string
-		want          map[string][]byte
-	}{
-		{
-			name: "Update empty secret",
-			keyPair: &KeyPair{
+		Entry("Update empty secret",
+			&KeyPair{
 				CertPEM: []byte("cert"),
 				KeyPEM:  []byte("key"),
 			},
-			secret: &corev1.Secret{
+			&corev1.Secret{
 				Data: map[string][]byte{},
 			},
-			certKey:       TLSCertKey,
-			privateKeyKey: TLSKeyKey,
-			want: map[string][]byte{
+			TLSCertKey,
+			TLSKeyKey,
+			map[string][]byte{
 				TLSCertKey: []byte("cert"),
 				TLSKeyKey:  []byte("key"),
 			},
-		},
-		{
-			name: "Update existing secret",
-			keyPair: &KeyPair{
+		),
+		Entry("Update existing secret",
+			&KeyPair{
 				CertPEM: []byte("new-cert"),
 				KeyPEM:  []byte("new-key"),
 			},
-			secret: &corev1.Secret{
+			&corev1.Secret{
 				Data: map[string][]byte{
 					TLSCertKey: []byte("old-cert"),
 					TLSKeyKey:  []byte("old-key"),
 				},
 			},
-			certKey:       TLSCertKey,
-			privateKeyKey: TLSKeyKey,
-			want: map[string][]byte{
+			TLSCertKey,
+			TLSKeyKey,
+			map[string][]byte{
 				TLSCertKey: []byte("new-cert"),
 				TLSKeyKey:  []byte("new-key"),
 			},
-		},
-		{
-			name: "Update secret with other data",
-			keyPair: &KeyPair{
+		),
+		Entry("Update secret with other data",
+			&KeyPair{
 				CertPEM: []byte("another-cert"),
 				KeyPEM:  []byte("another-key"),
 			},
-			secret: &corev1.Secret{
+			&corev1.Secret{
 				Data: map[string][]byte{
 					"other-key": []byte("other-value"),
 				},
 			},
-			certKey:       TLSCertKey,
-			privateKeyKey: TLSKeyKey,
-			want: map[string][]byte{
+			TLSCertKey,
+			TLSKeyKey,
+			map[string][]byte{
 				TLSCertKey:  []byte("another-cert"),
 				TLSKeyKey:   []byte("another-key"),
 				"other-key": []byte("other-value"),
 			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tt.keyPair.UpdateSecret(tt.secret, tt.certKey, tt.privateKeyKey)
-			if !reflect.DeepEqual(tt.secret.Data, tt.want) {
-				t.Errorf("UpdateSecret() = %v, want %v", tt.secret.Data, tt.want)
-			}
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/pki/pem_test.go
+++ b/pkg/pki/pem_test.go
@@ -1,60 +1,52 @@
 package pki
 
 import (
-	"testing"
-
-	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestBundleCertificatePEMs(t *testing.T) {
-	tests := []struct {
-		name      string
-		pems      [][]byte
-		opts      []BundleOption
-		wantBytes []byte
-		wantErr   bool
-	}{
-		{
-			name:      "nil",
-			pems:      nil,
-			opts:      nil,
-			wantBytes: nil,
-			wantErr:   true,
+var _ = Describe("BundleCertificatePEMs", func() {
+	DescribeTable("bundles certificate PEMs",
+		func(pems [][]byte, opts []BundleOption, wantBytes []byte, wantErr bool) {
+			bundleBytes, err := BundleCertificatePEMs(pems, opts...)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Expect(bundleBytes).To(Equal(wantBytes))
 		},
-		{
-			name: "empty",
-			pems: [][]byte{
+		Entry("nil", [][]byte(nil), []BundleOption(nil), []byte(nil), true),
+		Entry("empty",
+			[][]byte{
 				[]byte(""),
 				[]byte(""),
 			},
-			opts:      nil,
-			wantBytes: nil,
-			wantErr:   true,
-		},
-		{
-			name: "invalid PEM",
-			pems: [][]byte{
+			[]BundleOption(nil),
+			[]byte(nil),
+			true,
+		),
+		Entry("invalid PEM",
+			[][]byte{
 				[]byte("test"),
 			},
-			opts:      nil,
-			wantBytes: nil,
-			wantErr:   true,
-		},
-		{
-			name: "invalid cert",
-			pems: [][]byte{
+			[]BundleOption(nil),
+			[]byte(nil),
+			true,
+		),
+		Entry("invalid cert",
+			[][]byte{
 				[]byte(`-----BEGIN CERTIFICATE-----
 FOO
 -----END CERTIFICATE-----
 `),
 			},
-			opts:      nil,
-			wantBytes: nil,
-			wantErr:   true,
-		},
-		{
-			name: "mixed valid and invalid PEMs",
-			pems: [][]byte{
+			[]BundleOption(nil),
+			[]byte(nil),
+			true,
+		),
+		Entry("mixed valid and invalid PEMs",
+			[][]byte{
 				// Subject: CN=mariadb-client-ca
 				// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
 				[]byte(`-----BEGIN CERTIFICATE-----
@@ -74,10 +66,10 @@ WVQiuKIOhYk=
 `),
 				[]byte("invalid data"),
 			},
-			opts: nil,
+			[]BundleOption(nil),
 			// Subject: CN=mariadb-client-ca
 			// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
-			wantBytes: []byte(`-----BEGIN CERTIFICATE-----
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICFDCCAX2gAwIBAgIUAKik9DYK3ZWXZYqwYE310UeuqWowDQYJKoZIhvcNAQEL
 BQAwHDEaMBgGA1UEAwwRbWFyaWFkYi1jbGllbnQtY2EwHhcNMjQxMTA4MTcxMTM0
 WhcNMjUxMTA4MTcxMTM0WjAcMRowGAYDVQQDDBFtYXJpYWRiLWNsaWVudC1jYTCB
@@ -92,11 +84,10 @@ VDiVGD+f28/5eme54pwI9FUuKxujP0pj4VPiCKR2igJcJnCIAeDTlNmcs7CiXtIn
 WVQiuKIOhYk=
 -----END CERTIFICATE-----
 `),
-			wantErr: false,
-		},
-		{
-			name: "single PEM with single block",
-			pems: [][]byte{
+			false,
+		),
+		Entry("single PEM with single block",
+			[][]byte{
 				// Subject: CN=mariadb-client-ca
 				// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
 				[]byte(`-----BEGIN CERTIFICATE-----
@@ -115,10 +106,10 @@ WVQiuKIOhYk=
 -----END CERTIFICATE-----
 `),
 			},
-			opts: nil,
+			[]BundleOption(nil),
 			// Subject: CN=mariadb-client-ca
 			// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
-			wantBytes: []byte(`-----BEGIN CERTIFICATE-----
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICFDCCAX2gAwIBAgIUAKik9DYK3ZWXZYqwYE310UeuqWowDQYJKoZIhvcNAQEL
 BQAwHDEaMBgGA1UEAwwRbWFyaWFkYi1jbGllbnQtY2EwHhcNMjQxMTA4MTcxMTM0
 WhcNMjUxMTA4MTcxMTM0WjAcMRowGAYDVQQDDBFtYXJpYWRiLWNsaWVudC1jYTCB
@@ -133,11 +124,10 @@ VDiVGD+f28/5eme54pwI9FUuKxujP0pj4VPiCKR2igJcJnCIAeDTlNmcs7CiXtIn
 WVQiuKIOhYk=
 -----END CERTIFICATE-----
 `),
-			wantErr: false,
-		},
-		{
-			name: "multiple PEMs with single block",
-			pems: [][]byte{
+			false,
+		),
+		Entry("multiple PEMs with single block",
+			[][]byte{
 				// Subject: CN=mariadb-client-ca
 				// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
 				[]byte(`-----BEGIN CERTIFICATE-----
@@ -173,12 +163,12 @@ idE60fGmuV8=
 -----END CERTIFICATE-----
 `),
 			},
-			opts: nil,
+			[]BundleOption(nil),
 			// Subject: CN=mariadb-client-ca
 			// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
 			// Subject: CN=mariadb-server-ca
 			// Serial Number: 0a:c3:3a:30:47:9e:b3:0e:2a:4d:8a:e9:e6:56:95:ad:98:70:a2:91
-			wantBytes: []byte(`-----BEGIN CERTIFICATE-----
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICFDCCAX2gAwIBAgIUAKik9DYK3ZWXZYqwYE310UeuqWowDQYJKoZIhvcNAQEL
 BQAwHDEaMBgGA1UEAwwRbWFyaWFkYi1jbGllbnQtY2EwHhcNMjQxMTA4MTcxMTM0
 WhcNMjUxMTA4MTcxMTM0WjAcMRowGAYDVQQDDBFtYXJpYWRiLWNsaWVudC1jYTCB
@@ -207,11 +197,10 @@ xj8tutwZ3pBj0lLiTnzYb6VnXpl12TiHImapwwAkZEpMZ3W3o0TjK2gyc6F9o2h/
 idE60fGmuV8=
 -----END CERTIFICATE-----
 `),
-			wantErr: false,
-		},
-		{
-			name: "multiple PEMs with multiple blocks",
-			pems: [][]byte{
+			false,
+		),
+		Entry("multiple PEMs with multiple blocks",
+			[][]byte{
 				// Subject: CN=mariadb-client-ca
 				// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
 				// Subject: CN=mariadb-client-ca
@@ -279,7 +268,7 @@ IOz3lKAeaG0=
 -----END CERTIFICATE-----
 `),
 			},
-			opts: nil,
+			[]BundleOption(nil),
 			// Subject: CN=mariadb-client-ca
 			// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
 			// Subject: CN=mariadb-client-ca
@@ -288,7 +277,7 @@ IOz3lKAeaG0=
 			// Serial Number: 0a:c3:3a:30:47:9e:b3:0e:2a:4d:8a:e9:e6:56:95:ad:98:70:a2:91
 			// Subject: CN=mariadb-server-ca
 			// Serial Number: 0d:05:59:c6:ea:0f:f8:d8:c7:ed:c8:59:2b:4e:be:ee:d9:b9:19:44
-			wantBytes: []byte(`-----BEGIN CERTIFICATE-----
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICFDCCAX2gAwIBAgIUAKik9DYK3ZWXZYqwYE310UeuqWowDQYJKoZIhvcNAQEL
 BQAwHDEaMBgGA1UEAwwRbWFyaWFkYi1jbGllbnQtY2EwHhcNMjQxMTA4MTcxMTM0
 WhcNMjUxMTA4MTcxMTM0WjAcMRowGAYDVQQDDBFtYXJpYWRiLWNsaWVudC1jYTCB
@@ -345,11 +334,10 @@ k1rkhnzkhp/qyt5VrpEtGjQmwDnwvbC/FYvbIWJ02asmjeqrg8IpSY+yJycbuzTW
 IOz3lKAeaG0=
 -----END CERTIFICATE-----
 `),
-			wantErr: false,
-		},
-		{
-			name: "duplicated certs",
-			pems: [][]byte{
+			false,
+		),
+		Entry("duplicated certs",
+			[][]byte{
 				// Subject: CN=mariadb-client-ca
 				// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
 				// Subject: CN=mariadb-client-ca
@@ -417,12 +405,12 @@ idE60fGmuV8=
 -----END CERTIFICATE-----
 `),
 			},
-			opts: nil,
+			[]BundleOption(nil),
 			// Subject: CN=mariadb-client-ca
 			// Serial Number: a8:a4:f4:36:0a:dd:95:97:65:8a:b0:60:4d:f5:d1:47:ae:a9:6a
 			// Subject: CN=mariadb-server-ca
 			// Serial Number: 0a:c3:3a:30:47:9e:b3:0e:2a:4d:8a:e9:e6:56:95:ad:98:70:a2:91
-			wantBytes: []byte(`-----BEGIN CERTIFICATE-----
+			[]byte(`-----BEGIN CERTIFICATE-----
 MIICFDCCAX2gAwIBAgIUAKik9DYK3ZWXZYqwYE310UeuqWowDQYJKoZIhvcNAQEL
 BQAwHDEaMBgGA1UEAwwRbWFyaWFkYi1jbGllbnQtY2EwHhcNMjQxMTA4MTcxMTM0
 WhcNMjUxMTA4MTcxMTM0WjAcMRowGAYDVQQDDBFtYXJpYWRiLWNsaWVudC1jYTCB
@@ -451,11 +439,10 @@ xj8tutwZ3pBj0lLiTnzYb6VnXpl12TiHImapwwAkZEpMZ3W3o0TjK2gyc6F9o2h/
 idE60fGmuV8=
 -----END CERTIFICATE-----
 `),
-			wantErr: false,
-		},
-		{
-			name: "expired cert",
-			pems: [][]byte{
+			false,
+		),
+		Entry("expired cert",
+			[][]byte{
 				// Expired cert
 				[]byte(`-----BEGIN CERTIFICATE-----
 MIIFSzCCBDOgAwIBAgIQSueVSfqavj8QDxekeOFpCTANBgkqhkiG9w0BAQsFADCB
@@ -490,27 +477,11 @@ RwxPuzZEaFZcVlmtqoq8
 -----END CERTIFICATE-----
 `),
 			},
-			opts: []BundleOption{
+			[]BundleOption{
 				WithSkipExpired(true),
 			},
-			wantBytes: nil,
-			wantErr:   true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bundleBytes, err := BundleCertificatePEMs(tt.pems, tt.opts...)
-
-			if tt.wantErr && err == nil {
-				t.Error("expect error to have occurred, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("expect error to not have occurred, got: %v", err)
-			}
-			if diff := cmp.Diff(tt.wantBytes, bundleBytes); diff != "" {
-				t.Errorf("unexpected bundle content (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
+			[]byte(nil),
+			true,
+		),
+	)
+})

--- a/pkg/pki/private_key_test.go
+++ b/pkg/pki/private_key_test.go
@@ -2,49 +2,43 @@ package pki
 
 import (
 	"crypto/ecdsa"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestPrivateKey(t *testing.T) {
-	privateKey, err := GeneratePrivateKey()
-	if err != nil {
-		t.Fatalf("unexpected error generating private key: %v", err)
-	}
+var _ = Describe("PrivateKey", func() {
+	It("generates, marshals, encodes and parses an ECDSA private key", func() {
+		privateKey, err := GeneratePrivateKey()
+		Expect(err).NotTo(HaveOccurred())
 
-	bytes, err := MarshalPrivateKey(privateKey)
-	if err != nil {
-		t.Fatalf("unexpected error marshaling private key: %v", err)
-	}
+		bytes, err := MarshalPrivateKey(privateKey)
+		Expect(err).NotTo(HaveOccurred())
 
-	pemKey, err := pemEncodePrivateKey(bytes, privateKey)
-	if err != nil {
-		t.Fatalf("unexpected error encoding private key: %v", err)
-	}
+		pemKey, err := pemEncodePrivateKey(bytes, privateKey)
+		Expect(err).NotTo(HaveOccurred())
 
-	parsedKey, err := ParsePrivateKey(pemKey, []PrivateKey{PrivateKeyTypeECDSA})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if _, ok := parsedKey.(*ecdsa.PrivateKey); !ok {
-		t.Fatalf("expected *ecdsa.PrivateKey, got %T", parsedKey)
-	}
-}
+		parsedKey, err := ParsePrivateKey(pemKey, []PrivateKey{PrivateKeyTypeECDSA})
+		Expect(err).NotTo(HaveOccurred())
+		_, ok := parsedKey.(*ecdsa.PrivateKey)
+		Expect(ok).To(BeTrue())
+	})
+})
 
-func TestParsePrivateKey(t *testing.T) {
-	tests := []struct {
-		name     string
-		pemKey   []byte
-		keyTypes []PrivateKey
-		wantErr  bool
-	}{
-		{
-			name:    "Invalid",
-			pemKey:  []byte("invalid"),
-			wantErr: true,
+var _ = Describe("ParsePrivateKey", func() {
+	DescribeTable("parses a private key",
+		func(pemKey []byte, wantErr bool) {
+			parsedKey, err := ParsePrivateKey(pemKey, []PrivateKey{PrivateKeyTypeECDSA})
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				_, ok := parsedKey.(*ecdsa.PrivateKey)
+				Expect(ok).To(BeTrue())
+			}
 		},
-		{
-			name: "Unsupported",
-			pemKey: []byte(`-----BEGIN RSA PRIVATE KEY-----
+		Entry("Invalid", []byte("invalid"), true),
+		Entry("Unsupported", []byte(`-----BEGIN RSA PRIVATE KEY-----
 MIIEogIBAAKCAQEA1l202NMTln0/ngg4JXUJLJXvhSjjHimO22c47tHhWvnzhtnK
 CrH8cWBnnxO11os5PcNIUYTxn04mZPRs+p1YkE9DMlp9Lgy/38304rr4kjllVspv
 l9MdrelqbcDy520rgF/YObfMZvzeseH2F5UK386IXb1KYSmp8dn7RU2HvUf17Z/z
@@ -71,32 +65,12 @@ FQdVAoGAUt0hi789SX+BKzkWWMnds8HZzO3a5OgN9on+Hd/BVaQG6+F4wBGyjdjz
 PEZhWvsvx9Qge+DhwW3vfTDH2RItevD5Av4x0jZX0TWPoII8aP07VmDQ4g0cEkKh
 nBZoGLkeDofSc+Ml4HRpi43U+fqhU77wr8Gq0YU74h7lFfiRI/M=
 -----END RSA PRIVATE KEY-----
-`),
-			wantErr: true,
-		},
-		{
-			name: "Valid",
-			pemKey: []byte(`-----BEGIN EC PRIVATE KEY-----
+`), true),
+		Entry("Valid", []byte(`-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIAdp3iKnNA1kO2Ep5Hw7owMcm06SecFGdOqW/vO4k2AjoAoGCCqGSM49
 AwEHoUQDQgAEiTVhkriBksuWW5W3Mv9L918m1BECaHUl7ZV/Pz2q84wY9aEbxe2P
 J3c22DtEFzg9emNuruVS5/HL+hanzz4o+g==
 -----END EC PRIVATE KEY-----
-`),
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			parsedKey, err := ParsePrivateKey(tt.pemKey, []PrivateKey{PrivateKeyTypeECDSA})
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("expected error: %v, got: %v", tt.wantErr, err)
-			}
-			if !tt.wantErr {
-				if _, ok := parsedKey.(*ecdsa.PrivateKey); !ok {
-					t.Fatalf("expected *ecdsa.PrivateKey, got %T", parsedKey)
-				}
-			}
-		})
-	}
-}
+`), false),
+	)
+})

--- a/pkg/pki/renewal_test.go
+++ b/pkg/pki/renewal_test.go
@@ -1,129 +1,47 @@
 package pki
 
 import (
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestRenewalDuration(t *testing.T) {
-	tests := []struct {
-		name                  string
-		duration              time.Duration
-		renewBeforePercentage int32
-		expectedDuration      time.Duration
-		expectError           bool
-	}{
-		{
-			name:                  "invalid percentage zero",
-			duration:              24 * time.Hour,
-			renewBeforePercentage: 0,
-			expectedDuration:      0,
-			expectError:           true,
-		},
-		{
-			name:                  "invalid percentage 100",
-			duration:              24 * time.Hour,
-			renewBeforePercentage: 100,
-			expectedDuration:      0,
-			expectError:           true,
-		},
-		{
-			name:                  "50% of 1 day",
-			duration:              24 * time.Hour,
-			renewBeforePercentage: 50,
-			expectedDuration:      12 * time.Hour,
-			expectError:           false,
-		},
-		{
-			name:                  "30% of 3 months",
-			duration:              3 * 730 * time.Hour, // 3 months
-			renewBeforePercentage: 30,
-			expectedDuration:      3 * 219 * time.Hour, // 30% of 3 months
-			expectError:           false,
-		},
-		{
-			name:                  "30% of 3 years",
-			duration:              3 * 12 * 730 * time.Hour, // 3 years
-			renewBeforePercentage: 30,
-			expectedDuration:      3 * 12 * 219 * time.Hour, // 30% of 3 years
-			expectError:           false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			renewalDuration, err := RenewalDuration(tt.duration, tt.renewBeforePercentage)
-			if (err != nil) != tt.expectError {
-				t.Errorf("expected error: %v, got: %v", tt.expectError, err)
+var _ = Describe("RenewalDuration", func() {
+	DescribeTable("calculates the renewal duration",
+		func(duration time.Duration, renewBeforePercentage int32, expectedDuration time.Duration, expectError bool) {
+			renewalDuration, err := RenewalDuration(duration, renewBeforePercentage)
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(*renewalDuration).To(Equal(expectedDuration))
 			}
-			if !tt.expectError && *renewalDuration != tt.expectedDuration {
-				t.Errorf("expected renewal duration: %v, got: %v", tt.expectedDuration, *renewalDuration)
-			}
-		})
-	}
-}
+		},
+		Entry("invalid percentage zero", 24*time.Hour, int32(0), time.Duration(0), true),
+		Entry("invalid percentage 100", 24*time.Hour, int32(100), time.Duration(0), true),
+		Entry("50% of 1 day", 24*time.Hour, int32(50), 12*time.Hour, false),
+		Entry("30% of 3 months", 3*730*time.Hour, int32(30), 3*219*time.Hour, false),
+		Entry("30% of 3 years", 3*12*730*time.Hour, int32(30), 3*12*219*time.Hour, false),
+	)
+})
 
-func TestRenewalTime(t *testing.T) {
+var _ = Describe("RenewalTime", func() {
 	now := time.Now()
-	tests := []struct {
-		name                  string
-		notBefore             time.Time
-		notAfter              time.Time
-		renewBeforePercentage int32
-		expectedRenewalTime   time.Time
-		expectError           bool
-	}{
-		{
-			name:                  "invalid percentage zero",
-			notBefore:             now,
-			notAfter:              now.Add(24 * time.Hour),
-			renewBeforePercentage: 0,
-			expectedRenewalTime:   time.Time{},
-			expectError:           true,
-		},
-		{
-			name:                  "invalid percentage 100",
-			notBefore:             now,
-			notAfter:              now.Add(24 * time.Hour),
-			renewBeforePercentage: 100,
-			expectedRenewalTime:   time.Time{},
-			expectError:           true,
-		},
-		{
-			name:                  "50% of 1 day",
-			notBefore:             now,
-			notAfter:              now.Add(24 * time.Hour),
-			renewBeforePercentage: 50,
-			expectedRenewalTime:   now.Add(12 * time.Hour),
-			expectError:           false,
-		},
-		{
-			name:                  "30% of 3 months",
-			notBefore:             now,
-			notAfter:              now.Add(3 * 730 * time.Hour), // 3 months
-			renewBeforePercentage: 30,
-			expectedRenewalTime:   now.Add(3 * 511 * time.Hour), // 70% of 3 months
-			expectError:           false,
-		},
-		{
-			name:                  "30% of 3 years",
-			notBefore:             now,
-			notAfter:              now.Add(3 * 12 * 730 * time.Hour), // 3 years
-			renewBeforePercentage: 30,
-			expectedRenewalTime:   now.Add(3 * 12 * 511 * time.Hour), // 70% of 3 years
-			expectError:           false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			renewalTime, err := RenewalTime(tt.notBefore, tt.notAfter, tt.renewBeforePercentage)
-			if (err != nil) != tt.expectError {
-				t.Errorf("expected error: %v, got: %v", tt.expectError, err)
+	DescribeTable("calculates the renewal time",
+		func(notBefore, notAfter time.Time, renewBeforePercentage int32, expectedRenewalTime time.Time, expectError bool) {
+			renewalTime, err := RenewalTime(notBefore, notAfter, renewBeforePercentage)
+			if expectError {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(renewalTime.Truncate(time.Second).Equal(expectedRenewalTime.Truncate(time.Second))).To(BeTrue())
 			}
-			if !tt.expectError && !renewalTime.Truncate(time.Second).Equal(tt.expectedRenewalTime.Truncate(time.Second)) {
-				t.Errorf("expected renewal time: %v, got: %v", tt.expectedRenewalTime, renewalTime)
-			}
-		})
-	}
-}
+		},
+		Entry("invalid percentage zero", now, now.Add(24*time.Hour), int32(0), time.Time{}, true),
+		Entry("invalid percentage 100", now, now.Add(24*time.Hour), int32(100), time.Time{}, true),
+		Entry("50% of 1 day", now, now.Add(24*time.Hour), int32(50), now.Add(12*time.Hour), false),
+		Entry("30% of 3 months", now, now.Add(3*730*time.Hour), int32(30), now.Add(3*511*time.Hour), false),
+		Entry("30% of 3 years", now, now.Add(3*12*730*time.Hour), int32(30), now.Add(3*12*511*time.Hour), false),
+	)
+})

--- a/pkg/pki/suite_test.go
+++ b/pkg/pki/suite_test.go
@@ -1,0 +1,13 @@
+package pki
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPKI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PKI Suite")
+}

--- a/pkg/pki/x509_test.go
+++ b/pkg/pki/x509_test.go
@@ -2,269 +2,314 @@ package pki
 
 import (
 	"crypto/x509"
-	"reflect"
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestCreateCA(t *testing.T) {
-	testCreateCert(
-		t,
-		[]testCaseCreateCert{
-			{
-				name:     "No CommonName",
-				x509Opts: []X509Opt{},
-				wantErr:  true,
-			},
-			{
-				name: "Invalid Lifetime",
-				x509Opts: []X509Opt{
-					WithNotBefore(time.Now().Add(2 * time.Hour)),
-					WithNotAfter(time.Now().Add(1 * time.Hour)),
-				},
-				wantErr: true,
-			},
-			{
-				name: "Valid",
-				x509Opts: []X509Opt{
-					WithCommonName("test"),
-				},
-				wantErr:        false,
-				wantCommonName: "test",
-				wantIssuer:     "test",
-				wantDNSNames:   []string{"test"},
-				wantKeyUsage:   x509.KeyUsageCertSign,
-				wantIsCA:       true,
-			},
-			{
-				name: "Custom Lifetime",
-				x509Opts: []X509Opt{
-					WithCommonName("test"),
-					WithNotBefore(time.Now().Add(-2 * time.Hour)),
-					WithNotAfter(time.Now().Add(5 * 365 * 24 * time.Hour)),
-				},
-				wantErr:        false,
-				wantCommonName: "test",
-				wantIssuer:     "test",
-				wantDNSNames:   []string{"test"},
-				wantKeyUsage:   x509.KeyUsageCertSign,
-				wantIsCA:       true,
-			},
-		},
-		CreateCA,
-		ValidateCA,
-	)
+type testCaseCreateCert struct {
+	x509Opts        []X509Opt
+	wantErr         bool
+	wantCommonName  string
+	wantIssuer      string
+	wantDNSNames    []string
+	wantKeyUsage    x509.KeyUsage
+	wantExtKeyUsage []x509.ExtKeyUsage
+	wantIsCA        bool
 }
 
-func TestCreateCert(t *testing.T) {
-	caName := "tetst"
-	caKeyPair, err := CreateCA(
-		WithCommonName(caName),
-	)
-	if err != nil {
-		t.Fatalf("CA cert creation should succeed. Got error: %v", err)
+func runCreateCertCase(
+	tt testCaseCreateCert,
+	createCertFn func(...X509Opt) (*KeyPair, error),
+	validateCertFn func(*KeyPair, string, time.Time) (bool, error),
+) {
+	keyPair, err := createCertFn(tt.x509Opts...)
+	if tt.wantErr {
+		Expect(err).To(HaveOccurred())
+	} else {
+		Expect(err).NotTo(HaveOccurred())
 	}
-	caCerts, err := caKeyPair.Certificates()
-	if err != nil {
-		t.Fatalf("Unable to get CA certificates: %v", err)
+	if tt.wantErr {
+		return
 	}
 
-	testCreateCert(
-		t,
-		[]testCaseCreateCert{
-			{
-				name: "Missing CommonName",
-				x509Opts: []X509Opt{
-					WithDNSNames("missing-common-name"),
-				},
-				wantErr: true,
-			},
-			{
-				name: "Missing DNSNames",
-				x509Opts: []X509Opt{
-					WithCommonName("missing-dns-names"),
-				},
-				wantErr: true,
-			},
-			{
-				name: "Invalid Lifetime",
-				x509Opts: []X509Opt{
-					WithCommonName("invalid-lifetime"),
-					WithDNSNames("invalid-lifetime"),
-					WithNotBefore(time.Now().Add(2 * time.Hour)),
-					WithNotAfter(time.Now().Add(1 * time.Hour)),
-				},
-				wantErr: true,
-			},
-			{
-				name: "Default Cert",
-				x509Opts: []X509Opt{
-					WithCommonName("default-cert"),
-					WithDNSNames("default-cert"),
-				},
-				wantErr:        false,
-				wantCommonName: "default-cert",
-				wantIssuer:     caName,
-				wantDNSNames:   []string{"default-cert"},
-				wantKeyUsage:   x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement,
-				wantIsCA:       false,
-			},
-			{
-				name: "Custom Key Usage",
-				x509Opts: []X509Opt{
-					WithCommonName("custom-key-usage"),
-					WithDNSNames("custom-key-usage"),
-					WithKeyUsage(x509.KeyUsageKeyEncipherment),
-				},
-				wantErr:        false,
-				wantCommonName: "custom-key-usage",
-				wantIssuer:     caName,
-				wantDNSNames:   []string{"custom-key-usage"},
-				wantKeyUsage:   x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement | x509.KeyUsageKeyEncipherment,
-				wantIsCA:       false,
-			},
-			{
-				name: "Custom Ext Key Usage",
-				x509Opts: []X509Opt{
-					WithCommonName("custom-ext-key-usage"),
-					WithDNSNames("custom-ext-key-usage"),
-					WithExtKeyUsage(x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth),
-				},
-				wantErr:         false,
-				wantCommonName:  "custom-ext-key-usage",
-				wantIssuer:      caName,
-				wantDNSNames:    []string{"custom-ext-key-usage"},
-				wantKeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement,
-				wantExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
-				wantIsCA:        false,
-			},
-		},
-		func(opts ...X509Opt) (*KeyPair, error) {
-			return CreateCert(caKeyPair, opts...)
-		},
-		func(kp *KeyPair, dnsName string, at time.Time) (bool, error) {
-			return ValidateCert(caCerts, kp, dnsName, at)
-		},
-	)
+	cert, err := keyPair.LeafCertificate() // we are only creating certificates with a single leaf cert, therefore only one PEM block
+	Expect(err).NotTo(HaveOccurred())
+	commonName := cert.Subject.CommonName
+	notBefore := cert.NotBefore
+
+	Expect(commonName).To(Equal(tt.wantCommonName))
+	Expect(cert.Issuer.CommonName).To(Equal(tt.wantIssuer))
+	Expect(cert.DNSNames).To(Equal(tt.wantDNSNames))
+	Expect(cert.KeyUsage).To(Equal(tt.wantKeyUsage))
+	Expect(cert.ExtKeyUsage).To(Equal(tt.wantExtKeyUsage))
+	Expect(cert.IsCA).To(Equal(tt.wantIsCA))
+
+	valid, err := validateCertFn(keyPair, commonName, notBefore.Add(-1*time.Hour))
+	Expect(err).To(HaveOccurred())
+	Expect(valid).To(BeFalse())
+
+	valid, err = validateCertFn(keyPair, "foo", time.Now())
+	Expect(err).To(HaveOccurred())
+	Expect(valid).To(BeFalse())
+
+	keyPair, err = createCertFn(tt.x509Opts...)
+	Expect(err).NotTo(HaveOccurred())
+
+	valid, err = validateCertFn(keyPair, commonName, time.Now())
+	Expect(err).NotTo(HaveOccurred())
+	Expect(valid).To(BeTrue())
 }
 
-func TestValidateCert(t *testing.T) {
-	rootCA := "test-root"
-	rootKeyPair, err := CreateCA(
-		WithCommonName(rootCA),
-	)
-	if err != nil {
-		t.Fatalf("CA cert creation should succeed. Got error: %v", err)
-	}
+func mustCreateCert(caKeyPair *KeyPair, opts ...X509Opt) *KeyPair {
+	keyPair, err := CreateCert(caKeyPair, opts...)
+	Expect(err).NotTo(HaveOccurred())
+	return keyPair
+}
 
-	intermediateCA := "test-intermediate"
-	intermediateCAKeyPair, err := CreateCert(
-		rootKeyPair,
-		WithCommonName(intermediateCA),
-		WithDNSNames(intermediateCA),
-		WithKeyUsage(x509.KeyUsageCertSign),
-		WithIsCA(true),
-	)
-	if err != nil {
-		t.Fatalf("Intermediate CA cert creation should succeed. Got error: %v", err)
-	}
-
-	rootCerts, err := rootKeyPair.Certificates()
-	if err != nil {
-		t.Fatalf("Unable to get CA certificates: %v", err)
-	}
-	if len(rootCerts) != 1 {
-		t.Fatalf("Unexpected number of root certs: %d", len(rootCerts))
-	}
-	rootCert := rootCerts[0]
-	if rootCert.Subject.CommonName != rootCA {
-		t.Fatalf("Unexpected root cert common name, got: %v, want: %v", rootCert.Subject.CommonName, rootCA)
-	}
-	if rootCert.Issuer.CommonName != rootCA {
-		t.Fatalf("Unexpected root cert issuer, got: %v, want: %v", rootCert.Issuer.CommonName, rootCA)
-	}
-
-	intermediateCerts, err := intermediateCAKeyPair.Certificates()
-	if err != nil {
-		t.Fatalf("Unable to get intermediate CA certificates: %v", err)
-	}
-	if len(intermediateCerts) != 1 {
-		t.Fatalf("Unexpected number of intermediate certs: %d", len(intermediateCerts))
-	}
-	intermediateCert := intermediateCerts[0]
-	if intermediateCert.Subject.CommonName != intermediateCA {
-		t.Fatalf("Unexpected intermediate cert common name, got: %v, want: %v", intermediateCert.Subject.CommonName, intermediateCA)
-	}
-	if intermediateCert.Issuer.CommonName != rootCA {
-		t.Fatalf("Unexpected intermediate cert issuer, got: %v, want: %v", intermediateCert.Issuer.CommonName, rootCA)
-	}
-
-	tests := []struct {
-		name                string
-		createCertKeyPairFn func() *KeyPair
-		dnsName             string
-		at                  time.Time
-		validateCertFn      func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error)
-		wantValid           bool
-		wantErr             bool
-	}{
-		{
-			name: "CA invalid lifetime",
-			createCertKeyPairFn: func() *KeyPair {
-				return rootKeyPair
-			},
-			dnsName:        rootCA,
-			at:             time.Now().Add(10 * 365 * 24 * time.Hour), // 10 years in the future
-			validateCertFn: ValidateCA,
-			wantValid:      false,
-			wantErr:        true,
+var _ = Describe("CreateCA", func() {
+	DescribeTable("creates a CA certificate",
+		func(tt testCaseCreateCert) {
+			runCreateCertCase(tt, CreateCA, ValidateCA)
 		},
-		{
-			name: "CA invalid DNS name",
-			createCertKeyPairFn: func() *KeyPair {
-				return rootKeyPair
+		Entry("No CommonName", testCaseCreateCert{
+			x509Opts: []X509Opt{},
+			wantErr:  true,
+		}),
+		Entry("Invalid Lifetime", testCaseCreateCert{
+			x509Opts: []X509Opt{
+				WithNotBefore(time.Now().Add(2 * time.Hour)),
+				WithNotAfter(time.Now().Add(1 * time.Hour)),
 			},
-			dnsName:        "foo",
-			at:             time.Now(),
-			validateCertFn: ValidateCA,
-			wantValid:      false,
-			wantErr:        true,
-		},
-		{
-			name: "CA valid root",
-			createCertKeyPairFn: func() *KeyPair {
-				return rootKeyPair
+			wantErr: true,
+		}),
+		Entry("Valid", testCaseCreateCert{
+			x509Opts: []X509Opt{
+				WithCommonName("test"),
 			},
-			dnsName:        rootCA,
-			at:             time.Now(),
-			validateCertFn: ValidateCA,
-			wantValid:      true,
 			wantErr:        false,
+			wantCommonName: "test",
+			wantIssuer:     "test",
+			wantDNSNames:   []string{"test"},
+			wantKeyUsage:   x509.KeyUsageCertSign,
+			wantIsCA:       true,
+		}),
+		Entry("Custom Lifetime", testCaseCreateCert{
+			x509Opts: []X509Opt{
+				WithCommonName("test"),
+				WithNotBefore(time.Now().Add(-2 * time.Hour)),
+				WithNotAfter(time.Now().Add(5 * 365 * 24 * time.Hour)),
+			},
+			wantErr:        false,
+			wantCommonName: "test",
+			wantIssuer:     "test",
+			wantDNSNames:   []string{"test"},
+			wantKeyUsage:   x509.KeyUsageCertSign,
+			wantIsCA:       true,
+		}),
+	)
+})
+
+var _ = Describe("CreateCert", func() {
+	caName := "tetst"
+	var (
+		caKeyPair *KeyPair
+		caCerts   []*x509.Certificate
+	)
+	BeforeEach(func() {
+		var err error
+		caKeyPair, err = CreateCA(
+			WithCommonName(caName),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		caCerts, err = caKeyPair.Certificates()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	DescribeTable("creates a certificate signed by a CA",
+		func(tt testCaseCreateCert) {
+			runCreateCertCase(
+				tt,
+				func(opts ...X509Opt) (*KeyPair, error) {
+					return CreateCert(caKeyPair, opts...)
+				},
+				func(kp *KeyPair, dnsName string, at time.Time) (bool, error) {
+					return ValidateCert(caCerts, kp, dnsName, at)
+				},
+			)
 		},
-		{
-			name: "CA valid intermediate",
-			createCertKeyPairFn: func() *KeyPair {
+		Entry("Missing CommonName", testCaseCreateCert{
+			x509Opts: []X509Opt{
+				WithDNSNames("missing-common-name"),
+			},
+			wantErr: true,
+		}),
+		Entry("Missing DNSNames", testCaseCreateCert{
+			x509Opts: []X509Opt{
+				WithCommonName("missing-dns-names"),
+			},
+			wantErr: true,
+		}),
+		Entry("Invalid Lifetime", testCaseCreateCert{
+			x509Opts: []X509Opt{
+				WithCommonName("invalid-lifetime"),
+				WithDNSNames("invalid-lifetime"),
+				WithNotBefore(time.Now().Add(2 * time.Hour)),
+				WithNotAfter(time.Now().Add(1 * time.Hour)),
+			},
+			wantErr: true,
+		}),
+		Entry("Default Cert", testCaseCreateCert{
+			x509Opts: []X509Opt{
+				WithCommonName("default-cert"),
+				WithDNSNames("default-cert"),
+			},
+			wantErr:        false,
+			wantCommonName: "default-cert",
+			wantIssuer:     "tetst",
+			wantDNSNames:   []string{"default-cert"},
+			wantKeyUsage:   x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement,
+			wantIsCA:       false,
+		}),
+		Entry("Custom Key Usage", testCaseCreateCert{
+			x509Opts: []X509Opt{
+				WithCommonName("custom-key-usage"),
+				WithDNSNames("custom-key-usage"),
+				WithKeyUsage(x509.KeyUsageKeyEncipherment),
+			},
+			wantErr:        false,
+			wantCommonName: "custom-key-usage",
+			wantIssuer:     "tetst",
+			wantDNSNames:   []string{"custom-key-usage"},
+			wantKeyUsage:   x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement | x509.KeyUsageKeyEncipherment,
+			wantIsCA:       false,
+		}),
+		Entry("Custom Ext Key Usage", testCaseCreateCert{
+			x509Opts: []X509Opt{
+				WithCommonName("custom-ext-key-usage"),
+				WithDNSNames("custom-ext-key-usage"),
+				WithExtKeyUsage(x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth),
+			},
+			wantErr:         false,
+			wantCommonName:  "custom-ext-key-usage",
+			wantIssuer:      "tetst",
+			wantDNSNames:    []string{"custom-ext-key-usage"},
+			wantKeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyAgreement,
+			wantExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+			wantIsCA:        false,
+		}),
+	)
+})
+
+var _ = Describe("ValidateCert", func() {
+	rootCA := "test-root"
+	intermediateCA := "test-intermediate"
+	var (
+		rootKeyPair           *KeyPair
+		intermediateCAKeyPair *KeyPair
+		rootCert              *x509.Certificate
+		intermediateCert      *x509.Certificate
+	)
+	BeforeEach(func() {
+		var err error
+		rootKeyPair, err = CreateCA(
+			WithCommonName(rootCA),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		intermediateCAKeyPair, err = CreateCert(
+			rootKeyPair,
+			WithCommonName(intermediateCA),
+			WithDNSNames(intermediateCA),
+			WithKeyUsage(x509.KeyUsageCertSign),
+			WithIsCA(true),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		rootCerts, err := rootKeyPair.Certificates()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rootCerts).To(HaveLen(1))
+		rootCert = rootCerts[0]
+		Expect(rootCert.Subject.CommonName).To(Equal(rootCA))
+		Expect(rootCert.Issuer.CommonName).To(Equal(rootCA))
+
+		intermediateCerts, err := intermediateCAKeyPair.Certificates()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(intermediateCerts).To(HaveLen(1))
+		intermediateCert = intermediateCerts[0]
+		Expect(intermediateCert.Subject.CommonName).To(Equal(intermediateCA))
+		Expect(intermediateCert.Issuer.CommonName).To(Equal(rootCA))
+	})
+
+	DescribeTable("validates a certificate",
+		func(
+			createCertKeyPairFn func() *KeyPair,
+			dnsName string,
+			at time.Time,
+			validateCertFn func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error),
+			wantValid bool,
+			wantErr bool,
+		) {
+			valid, err := validateCertFn(createCertKeyPairFn(), dnsName, at)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Expect(valid).To(Equal(wantValid))
+		},
+		Entry("CA invalid lifetime",
+			func() *KeyPair {
+				return rootKeyPair
+			},
+			rootCA,
+			time.Now().Add(10*365*24*time.Hour), // 10 years in the future
+			ValidateCA,
+			false,
+			true,
+		),
+		Entry("CA invalid DNS name",
+			func() *KeyPair {
+				return rootKeyPair
+			},
+			"foo",
+			time.Now(),
+			ValidateCA,
+			false,
+			true,
+		),
+		Entry("CA valid root",
+			func() *KeyPair {
+				return rootKeyPair
+			},
+			rootCA,
+			time.Now(),
+			ValidateCA,
+			true,
+			false,
+		),
+		Entry("CA valid intermediate",
+			func() *KeyPair {
 				return intermediateCAKeyPair
 			},
-			dnsName:        intermediateCA,
-			at:             time.Now(),
-			validateCertFn: ValidateCA,
-			wantValid:      true,
-			wantErr:        false,
-		},
-		{
-			name: "Cert issued by root valid",
-			createCertKeyPairFn: func() *KeyPair {
+			intermediateCA,
+			time.Now(),
+			ValidateCA,
+			true,
+			false,
+		),
+		Entry("Cert issued by root valid",
+			func() *KeyPair {
 				return mustCreateCert(
-					t,
 					rootKeyPair,
 					WithCommonName("issued-by-root"),
 					WithDNSNames("issued-by-root"),
 				)
 			},
-			dnsName: "issued-by-root",
-			at:      time.Now(),
-			validateCertFn: func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
+			"issued-by-root",
+			time.Now(),
+			func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
 				return ValidateCert(
 					[]*x509.Certificate{
 						rootCert,
@@ -274,22 +319,20 @@ func TestValidateCert(t *testing.T) {
 					at,
 				)
 			},
-			wantValid: true,
-			wantErr:   false,
-		},
-		{
-			name: "Cert issued by root invalid trust chain",
-			createCertKeyPairFn: func() *KeyPair {
+			true,
+			false,
+		),
+		Entry("Cert issued by root invalid trust chain",
+			func() *KeyPair {
 				return mustCreateCert(
-					t,
 					rootKeyPair,
 					WithCommonName("issued-by-root"),
 					WithDNSNames("issued-by-root"),
 				)
 			},
-			dnsName: "issued-by-root",
-			at:      time.Now(),
-			validateCertFn: func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
+			"issued-by-root",
+			time.Now(),
+			func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
 				return ValidateCert(
 					[]*x509.Certificate{
 						intermediateCert,
@@ -299,22 +342,20 @@ func TestValidateCert(t *testing.T) {
 					at,
 				)
 			},
-			wantValid: false,
-			wantErr:   true,
-		},
-		{
-			name: "Cert issued by root invalid lifetime",
-			createCertKeyPairFn: func() *KeyPair {
+			false,
+			true,
+		),
+		Entry("Cert issued by root invalid lifetime",
+			func() *KeyPair {
 				return mustCreateCert(
-					t,
 					rootKeyPair,
 					WithCommonName("issued-by-root"),
 					WithDNSNames("issued-by-root"),
 				)
 			},
-			dnsName: "issued-by-root",
-			at:      time.Now().Add(10 * 365 * 24 * time.Hour), // 10 years in the future
-			validateCertFn: func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
+			"issued-by-root",
+			time.Now().Add(10*365*24*time.Hour), // 10 years in the future
+			func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
 				return ValidateCert(
 					[]*x509.Certificate{
 						rootCert,
@@ -324,22 +365,20 @@ func TestValidateCert(t *testing.T) {
 					at,
 				)
 			},
-			wantValid: false,
-			wantErr:   true,
-		},
-		{
-			name: "Cert issued by root invalid DNS name",
-			createCertKeyPairFn: func() *KeyPair {
+			false,
+			true,
+		),
+		Entry("Cert issued by root invalid DNS name",
+			func() *KeyPair {
 				return mustCreateCert(
-					t,
 					rootKeyPair,
 					WithCommonName("issued-by-root"),
 					WithDNSNames("issued-by-root"),
 				)
 			},
-			dnsName: "foo",
-			at:      time.Now(),
-			validateCertFn: func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
+			"foo",
+			time.Now(),
+			func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
 				return ValidateCert(
 					[]*x509.Certificate{
 						rootCert,
@@ -349,22 +388,20 @@ func TestValidateCert(t *testing.T) {
 					at,
 				)
 			},
-			wantValid: false,
-			wantErr:   true,
-		},
-		{
-			name: "Cert issued by trusted intermediate valid",
-			createCertKeyPairFn: func() *KeyPair {
+			false,
+			true,
+		),
+		Entry("Cert issued by trusted intermediate valid",
+			func() *KeyPair {
 				return mustCreateCert(
-					t,
 					intermediateCAKeyPair,
 					WithCommonName("issued-by-intermediate"),
 					WithDNSNames("issued-by-intermediate"),
 				)
 			},
-			dnsName: "issued-by-intermediate",
-			at:      time.Now(),
-			validateCertFn: func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
+			"issued-by-intermediate",
+			time.Now(),
+			func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
 				return ValidateCert(
 					[]*x509.Certificate{
 						intermediateCert,
@@ -374,22 +411,20 @@ func TestValidateCert(t *testing.T) {
 					at,
 				)
 			},
-			wantValid: true,
-			wantErr:   false,
-		},
-		{
-			name: "Cert issued by untrusted intermediate valid",
-			createCertKeyPairFn: func() *KeyPair {
+			true,
+			false,
+		),
+		Entry("Cert issued by untrusted intermediate valid",
+			func() *KeyPair {
 				return mustCreateCert(
-					t,
 					intermediateCAKeyPair,
 					WithCommonName("issued-by-intermediate"),
 					WithDNSNames("issued-by-intermediate"),
 				)
 			},
-			dnsName: "issued-by-intermediate",
-			at:      time.Now(),
-			validateCertFn: func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
+			"issued-by-intermediate",
+			time.Now(),
+			func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
 				return ValidateCert(
 					[]*x509.Certificate{
 						rootCert,
@@ -400,22 +435,20 @@ func TestValidateCert(t *testing.T) {
 					WithIntermediateCAs(intermediateCert),
 				)
 			},
-			wantValid: true,
-			wantErr:   false,
-		},
-		{
-			name: "Cert issued by untrusted intermediate invalid trust chain",
-			createCertKeyPairFn: func() *KeyPair {
+			true,
+			false,
+		),
+		Entry("Cert issued by untrusted intermediate invalid trust chain",
+			func() *KeyPair {
 				return mustCreateCert(
-					t,
 					intermediateCAKeyPair,
 					WithCommonName("issued-by-intermediate"),
 					WithDNSNames("issued-by-intermediate"),
 				)
 			},
-			dnsName: "issued-by-intermediate",
-			at:      time.Now(),
-			validateCertFn: func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
+			"issued-by-intermediate",
+			time.Now(),
+			func(keyPair *KeyPair, dnsName string, at time.Time) (bool, error) {
 				return ValidateCert(
 					[]*x509.Certificate{
 						rootCert,
@@ -425,41 +458,24 @@ func TestValidateCert(t *testing.T) {
 					at,
 				)
 			},
-			wantValid: false,
-			wantErr:   true,
-		},
-	}
+			false,
+			true,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			valid, err := tt.validateCertFn(tt.createCertKeyPairFn(), tt.dnsName, tt.at)
-			if tt.wantErr && err == nil {
-				t.Fatalf("Expecting error to be non nil for test '%s'", tt.name)
+var _ = Describe("ParseCertificates", func() {
+	DescribeTable("parses certificates",
+		func(certBytes []byte, wantErr bool) {
+			_, err := ParseCertificates(certBytes)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
 			}
-			if !tt.wantErr && err != nil {
-				t.Fatalf("Expecting error to be nil for test '%s'. Got: %v", tt.name, err)
-			}
-			if valid != tt.wantValid {
-				t.Fatalf("Unexpected validation result for test '%s'. Got: %v, want: %v", tt.name, valid, tt.wantValid)
-			}
-		})
-	}
-}
-
-func TestParseCertificates(t *testing.T) {
-	tests := []struct {
-		name      string
-		certBytes []byte
-		wantErr   bool
-	}{
-		{
-			name:      "Invalid cert",
-			certBytes: []byte("foo"),
-			wantErr:   true,
 		},
-		{
-			name: "No block cert",
-			certBytes: []byte(`
+		Entry("Invalid cert", []byte("foo"), true),
+		Entry("No block cert", []byte(`
 MIID3DCCAsSgAwIBAgIBATANBgkqhkiG9w0BAQsFADA2MRkwFwYDVQQKExBtYXJp
 YWRiLW9wZXJhdG9yMRkwFwYDVQQDExBtYXJpYWRiLW9wZXJhdG9yMB4XDTIzMTEw
 NTEwMzAxNVoXDTIzMTEwNTEyMzAxNVowLzEtMCsGA1UEAxMkbWFyaWFkYi1vcGVy
@@ -481,12 +497,8 @@ G1ZUYSKs5sgS0o5oBaPt9opZqnA8WGgwZ1WR1pxRBpLmu/019vDABAUX5tV3iqVp
 qYxy6XmWp5Gc7c2NqlQ9N5xsMXMSfLiUSC8O+2sJGU92GtVSp7Vt4nGg1Qh5ZyHJ
 fK6S3LzTZ/HVm8nXY1e0ZnrG7SZbcJkkZgSPOjsZ9KSikdG4I9+S99FTe8X1Qzn8
 0ER77C84IUS9PEuvnSlWXopwKg5aAdHS5nHp7UFiNt4=
-`),
-			wantErr: true,
-		},
-		{
-			name: "Valid cert",
-			certBytes: []byte(`-----BEGIN CERTIFICATE-----
+`), true),
+		Entry("Valid cert", []byte(`-----BEGIN CERTIFICATE-----
 MIICXzCCAgagAwIBAgIRAIBgotjwHCDFrV2H9FWQrYIwCgYIKoZIzj0EAwIwNjEZ
 MBcGA1UEChMQbWFyaWFkYi1vcGVyYXRvcjEZMBcGA1UEAxMQbWFyaWFkYi1vcGVy
 YXRvcjAeFw0yNDEyMTkxNjI2NTVaFw0yNTEyMTkyMzI2NTVaMC8xLTArBgNVBAMT
@@ -500,13 +512,9 @@ cmlhZGItb3BlcmF0b3Itd2ViaG9vay5kZWZhdWx0LnN2Y4IgbWFyaWFkYi1vcGVy
 YXRvci13ZWJob29rLmRlZmF1bHSCGG1hcmlhZGItb3BlcmF0b3Itd2ViaG9vazAK
 BggqhkjOPQQDAgNHADBEAiBSWY1rVufSE+3i0w553uJGJCC4Fpa6cvRPEti8X3Kp
 1AIgG0qN5IT9EsRZaY4J2vBYsbN5LL+qRI5N0XGYqVWXuD8=
------END CERTIFICATE-----			
-`),
-			wantErr: false,
-		},
-		{
-			name: "Valid cert bundle",
-			certBytes: []byte(`-----BEGIN CERTIFICATE-----
+-----END CERTIFICATE-----
+`), false),
+		Entry("Valid cert bundle", []byte(`-----BEGIN CERTIFICATE-----
 MIICFDCCAX2gAwIBAgIUAKik9DYK3ZWXZYqwYE310UeuqWowDQYJKoZIhvcNAQEL
 BQAwHDEaMBgGA1UEAwwRbWFyaWFkYi1jbGllbnQtY2EwHhcNMjQxMTA4MTcxMTM0
 WhcNMjUxMTA4MTcxMTM0WjAcMRowGAYDVQQDDBFtYXJpYWRiLWNsaWVudC1jYTCB
@@ -534,12 +542,8 @@ jDqaasPK77oFD2eEjSCI3jewj8xYaGfTgohB+YdkM9VWN+s5zsxBakTY19U7GeQJ
 xj8tutwZ3pBj0lLiTnzYb6VnXpl12TiHImapwwAkZEpMZ3W3o0TjK2gyc6F9o2h/
 idE60fGmuV8=
 -----END CERTIFICATE-----
-`),
-			wantErr: false,
-		},
-		{
-			name: "Invalid cert bundle",
-			certBytes: []byte(`-----BEGIN CERTIFICATE-----
+`), false),
+		Entry("Invalid cert bundle", []byte(`-----BEGIN CERTIFICATE-----
 MIICFDCCAX2gAwIBAgIUAKik9DYK3ZWXZYqwYE310UeuqWowDQYJKoZIhvcNAQEL
 BQAwHDEaMBgGA1UEAwwRbWFyaWFkYi1jbGllbnQtY2EwHhcNMjQxMTA4MTcxMTM0
 WhcNMjUxMTA4MTcxMTM0WjAcMRowGAYDVQQDDBFtYXJpYWRiLWNsaWVudC1jYTCB
@@ -570,175 +574,50 @@ idE60fGmuV8=
 -----BEGIN CERTIFICATE-----
 invalid
 -----END CERTIFICATE-----
-`),
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := ParseCertificates(tt.certBytes)
-			if tt.wantErr && err == nil {
-				t.Fatalf("Expecting error to be non nil when parsing '%s'", tt.name)
-			}
-			if !tt.wantErr && err != nil {
-				t.Fatalf("Expecting error to be nil when parsing '%s'. Got: %v", tt.name, err)
-			}
-		})
-	}
-}
+`), true),
+	)
+})
 
-func TestValidateLifetime(t *testing.T) {
+var _ = Describe("validateLifetime", func() {
 	minLifetime := 1 * time.Hour
 	maxLifetime := 5 * 365 * 24 * time.Hour // 5 years
 
-	tests := []struct {
-		name        string
-		notBefore   time.Time
-		notAfter    time.Time
-		minDuration time.Duration
-		maxDuration time.Duration
-		wantErr     bool
-	}{
-		{
-			name:        "Valid lifetime",
-			notBefore:   time.Now(),
-			notAfter:    time.Now().Add(2 * time.Hour),
-			minDuration: minLifetime,
-			maxDuration: maxLifetime,
-			wantErr:     false,
+	DescribeTable("validates a certificate lifetime",
+		func(notBefore, notAfter time.Time, minDuration, maxDuration time.Duration, wantErr bool) {
+			err := validateLifetime(notBefore, notAfter, minDuration, maxDuration)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
 		},
-		{
-			name:        "NotBefore after NotAfter",
-			notBefore:   time.Now().Add(2 * time.Hour),
-			notAfter:    time.Now(),
-			minDuration: minLifetime,
-			maxDuration: maxLifetime,
-			wantErr:     true,
-		},
-		{
-			name:        "Duration less than minimum",
-			notBefore:   time.Now(),
-			notAfter:    time.Now().Add(30 * time.Minute),
-			minDuration: minLifetime,
-			maxDuration: maxLifetime,
-			wantErr:     true,
-		},
-		{
-			name:        "Duration exceeds maximum",
-			notBefore:   time.Now(),
-			notAfter:    time.Now().Add(6 * 365 * 24 * time.Hour), // 6 years
-			minDuration: minLifetime,
-			maxDuration: maxLifetime,
-			wantErr:     true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := validateLifetime(tt.notBefore, tt.notAfter, tt.minDuration, tt.maxDuration)
-			if tt.wantErr && err == nil {
-				t.Fatalf("Expecting error to be non nil for test '%s'", tt.name)
-			}
-			if !tt.wantErr && err != nil {
-				t.Fatalf("Expecting error to be nil for test '%s'. Got: %v", tt.name, err)
-			}
-		})
-	}
-}
-
-type testCaseCreateCert struct {
-	name            string
-	x509Opts        []X509Opt
-	wantErr         bool
-	wantCommonName  string
-	wantIssuer      string
-	wantDNSNames    []string
-	wantKeyUsage    x509.KeyUsage
-	wantExtKeyUsage []x509.ExtKeyUsage
-	wantIsCA        bool
-}
-
-func testCreateCert(
-	t *testing.T,
-	tests []testCaseCreateCert,
-	createCertFn func(...X509Opt) (*KeyPair, error),
-	validateCertFn func(*KeyPair, string, time.Time) (bool, error),
-) {
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			keyPair, err := createCertFn(tt.x509Opts...)
-			if tt.wantErr && err == nil {
-				t.Fatalf("Expecting error to be non nil when creating cert '%s'", tt.name)
-			}
-			if !tt.wantErr && err != nil {
-				t.Fatalf("Expecting error to be nil when creating cert '%s'. Got: %v", tt.name, err)
-			}
-			if tt.wantErr {
-				return
-			}
-
-			cert, err := keyPair.LeafCertificate() // we are only creating certificates with a single leaf cert, therefore only one PEM block
-			if err != nil {
-				t.Fatalf("error getting leaf certificate: %v", err)
-			}
-			commonName := cert.Subject.CommonName
-			notBefore := cert.NotBefore
-
-			if commonName != tt.wantCommonName {
-				t.Fatalf("unexpected common name, got: %v, want: %v", commonName, tt.wantCommonName)
-			}
-			if cert.Issuer.CommonName != tt.wantIssuer {
-				t.Fatalf("unexpected issuer, got: %v, want: %v", cert.Issuer.CommonName, tt.wantIssuer)
-			}
-			if !reflect.DeepEqual(cert.DNSNames, tt.wantDNSNames) {
-				t.Fatalf("unexpected DNS names, got: %v, want: %v", cert.DNSNames, tt.wantDNSNames)
-			}
-			if !reflect.DeepEqual(cert.KeyUsage, tt.wantKeyUsage) {
-				t.Fatalf("unexpected key usage, got: %v, want: %v", cert.KeyUsage, tt.wantKeyUsage)
-			}
-			if !reflect.DeepEqual(cert.ExtKeyUsage, tt.wantExtKeyUsage) {
-				t.Fatalf("unexpected extended key usage, got: %v, want: %v", cert.ExtKeyUsage, tt.wantExtKeyUsage)
-			}
-			if cert.IsCA != tt.wantIsCA {
-				t.Fatalf("unexpected IsCA, got: %v, want: %v", cert.IsCA, tt.wantIsCA)
-			}
-
-			valid, err := validateCertFn(keyPair, commonName, notBefore.Add(-1*time.Hour))
-			if err == nil {
-				t.Fatalf("Cert validation should return an error. Got nil")
-			}
-			if valid {
-				t.Fatal("Expected cert to be invalid")
-			}
-
-			valid, err = validateCertFn(keyPair, "foo", time.Now())
-			if err == nil {
-				t.Fatalf("Cert validation should return an error. Got nil")
-			}
-			if valid {
-				t.Fatal("Expected cert to be invalid")
-			}
-
-			keyPair, err = createCertFn(tt.x509Opts...)
-			if err != nil {
-				t.Fatalf("Certificate renewal should succeed. Got error: %v", err)
-			}
-
-			valid, err = validateCertFn(keyPair, commonName, time.Now())
-			if err != nil {
-				t.Fatalf("Cert validation should succeed after renewal. Got error: %v", err)
-			}
-			if !valid {
-				t.Fatal("Expected cert to be valid")
-			}
-		})
-	}
-}
-
-func mustCreateCert(t *testing.T, caKeyPair *KeyPair, opts ...X509Opt) *KeyPair {
-	keyPair, err := CreateCert(caKeyPair, opts...)
-	if err != nil {
-		t.Fatalf("unexpected error creating cert: %v", err)
-	}
-	return keyPair
-}
+		Entry("Valid lifetime",
+			time.Now(),
+			time.Now().Add(2*time.Hour),
+			minLifetime,
+			maxLifetime,
+			false,
+		),
+		Entry("NotBefore after NotAfter",
+			time.Now().Add(2*time.Hour),
+			time.Now(),
+			minLifetime,
+			maxLifetime,
+			true,
+		),
+		Entry("Duration less than minimum",
+			time.Now(),
+			time.Now().Add(30*time.Minute),
+			minLifetime,
+			maxLifetime,
+			true,
+		),
+		Entry("Duration exceeds maximum",
+			time.Now(),
+			time.Now().Add(6*365*24*time.Hour), // 6 years
+			minLifetime,
+			maxLifetime,
+			true,
+		),
+	)
+})


### PR DESCRIPTION
Migrates `pkg/pki` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `keypair_test.go`, `pem_test.go`, `private_key_test.go`, `renewal_test.go` and `x509_test.go` converted to `DescribeTable`/`It` specs (73 specs total). Entry names match the original `t.Run()` names.

Verified with:
```
go test ./pkg/pki/...
```

Part of #368.
