### PR TITLE
test: migrate pkg/minio tests to Ginkgo

### DIFF
--- a/pkg/minio/minio_test.go
+++ b/pkg/minio/minio_test.go
@@ -2,260 +2,208 @@ package minio
 
 import (
 	"encoding/base64"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestPrefixedFile(t *testing.T) {
-	tests := []struct {
-		name         string
-		client       *Client
-		fileName     string
-		wantFileName string
-	}{
-		{
-			name:         "no prefix",
-			client:       &Client{},
-			fileName:     "backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
+var _ = Describe("PrefixedFileName", func() {
+	DescribeTable("returns the prefixed S3 file name",
+		func(client *Client, fileName string, wantFileName string) {
+			Expect(client.PrefixedFileName(fileName)).To(Equal(wantFileName))
 		},
-		{
-			name:         "no prefix with file path",
-			client:       &Client{},
-			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "prefix",
-			client: &Client{
+		Entry("no prefix",
+			&Client{},
+			"backup.2023-12-18T16:14:00Z.sql",
+			"backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("no prefix with file path",
+			&Client{},
+			"backup/backup.2023-12-18T16:14:00Z.sql",
+			"backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("prefix",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb",
 				},
 			},
-			fileName:     "backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "mariadb/backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "prefix with file path",
-			client: &Client{
+			"backup.2023-12-18T16:14:00Z.sql",
+			"mariadb/backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("prefix with file path",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb",
 				},
 			},
-			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "mariadb/backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "prefix with trailing slash",
-			client: &Client{
+			"backup/backup.2023-12-18T16:14:00Z.sql",
+			"mariadb/backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("prefix with trailing slash",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb/",
 				},
 			},
-			fileName:     "backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "mariadb/backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "prefix with trailing slash and file path",
-			client: &Client{
+			"backup.2023-12-18T16:14:00Z.sql",
+			"mariadb/backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("prefix with trailing slash and file path",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb/",
 				},
 			},
-			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "mariadb/backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "nested prefix",
-			client: &Client{
+			"backup/backup.2023-12-18T16:14:00Z.sql",
+			"mariadb/backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("nested prefix",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "backups/production/mariadb",
 				},
 			},
-			fileName:     "backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backups/production/mariadb/backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "nested prefix with file path",
-			client: &Client{
+			"backup.2023-12-18T16:14:00Z.sql",
+			"backups/production/mariadb/backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("nested prefix with file path",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "backups/production/mariadb",
 				},
 			},
-			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backups/production/mariadb/backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "already prefixed",
-			client: &Client{
+			"backup/backup.2023-12-18T16:14:00Z.sql",
+			"backups/production/mariadb/backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("already prefixed",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb",
 				},
 			},
-			fileName:     "mariadb/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "mariadb/backup.2023-12-18T16:14:00Z.sql",
-		},
-	}
+			"mariadb/backup.2023-12-18T16:14:00Z.sql",
+			"mariadb/backup.2023-12-18T16:14:00Z.sql",
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fileName := tt.client.PrefixedFileName(tt.fileName)
-			if fileName != tt.wantFileName {
-				t.Errorf("unexpected S3 file name, got: %s want: %s", fileName, tt.wantFileName)
-			}
-		})
-	}
-}
-
-func TestUnprefixedFile(t *testing.T) {
-	tests := []struct {
-		name         string
-		client       *Client
-		fileName     string
-		wantFileName string
-	}{
-		{
-			name:         "no prefix",
-			client:       &Client{},
-			fileName:     "backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
+var _ = Describe("UnprefixedFilename", func() {
+	DescribeTable("returns the unprefixed S3 file name",
+		func(client *Client, fileName string, wantFileName string) {
+			Expect(client.UnprefixedFilename(fileName)).To(Equal(wantFileName))
 		},
-		{
-			name:         "no prefix with file path",
-			client:       &Client{},
-			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "prefix",
-			client: &Client{
+		Entry("no prefix",
+			&Client{},
+			"backup.2023-12-18T16:14:00Z.sql",
+			"backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("no prefix with file path",
+			&Client{},
+			"backup/backup.2023-12-18T16:14:00Z.sql",
+			"backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("prefix",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb",
 				},
 			},
-			fileName:     "mariadb/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "prefix with file path",
-			client: &Client{
+			"mariadb/backup.2023-12-18T16:14:00Z.sql",
+			"backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("prefix with file path",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb",
 				},
 			},
-			fileName:     "backup/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "prefix with trailing slash",
-			client: &Client{
+			"backup/backup.2023-12-18T16:14:00Z.sql",
+			"backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("prefix with trailing slash",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb/",
 				},
 			},
-			fileName:     "mariadb/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "nested prefix",
-			client: &Client{
+			"mariadb/backup.2023-12-18T16:14:00Z.sql",
+			"backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("nested prefix",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "backups/production/mariadb",
 				},
 			},
-			fileName:     "backups/production/mariadb/backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
-		},
-		{
-			name: "already unprefixed",
-			client: &Client{
+			"backups/production/mariadb/backup.2023-12-18T16:14:00Z.sql",
+			"backup.2023-12-18T16:14:00Z.sql",
+		),
+		Entry("already unprefixed",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb",
 				},
 			},
-			fileName:     "backup.2023-12-18T16:14:00Z.sql",
-			wantFileName: "backup.2023-12-18T16:14:00Z.sql",
-		},
-	}
+			"backup.2023-12-18T16:14:00Z.sql",
+			"backup.2023-12-18T16:14:00Z.sql",
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fileName := tt.client.UnprefixedFilename(tt.fileName)
-			if fileName != tt.wantFileName {
-				t.Errorf("unexpected S3 file name, got: %s want: %s", fileName, tt.wantFileName)
-			}
-		})
-	}
-}
-
-func TestPrefix(t *testing.T) {
-	tests := []struct {
-		name       string
-		client     *Client
-		wantPrefix string
-	}{
-		{
-			name:       "no prefix",
-			client:     &Client{},
-			wantPrefix: "",
+var _ = Describe("GetPrefix", func() {
+	DescribeTable("returns the normalized S3 prefix",
+		func(client *Client, wantPrefix string) {
+			Expect(client.GetPrefix()).To(Equal(wantPrefix))
 		},
-		{
-			name: "root",
-			client: &Client{
+		Entry("no prefix",
+			&Client{},
+			"",
+		),
+		Entry("root",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "/",
 				},
 			},
-			wantPrefix: "",
-		},
-		{
-			name: "no trailing slash",
-			client: &Client{
+			"",
+		),
+		Entry("no trailing slash",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb",
 				},
 			},
-			wantPrefix: "mariadb/",
-		},
-		{
-			name: "trailing slash",
-			client: &Client{
+			"mariadb/",
+		),
+		Entry("trailing slash",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "mariadb/",
 				},
 			},
-			wantPrefix: "mariadb/",
-		},
-		{
-			name: "nested without trailing slash",
-			client: &Client{
+			"mariadb/",
+		),
+		Entry("nested without trailing slash",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "backups/production/mariadb",
 				},
 			},
-			wantPrefix: "backups/production/mariadb/",
-		},
-		{
-			name: "nested with trailing slash",
-			client: &Client{
+			"backups/production/mariadb/",
+		),
+		Entry("nested with trailing slash",
+			&Client{
 				MinioOpts: MinioOpts{
 					Prefix: "backups/production/mariadb/",
 				},
 			},
-			wantPrefix: "backups/production/mariadb/",
-		},
-	}
+			"backups/production/mariadb/",
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			prefix := tt.client.GetPrefix()
-			if prefix != tt.wantPrefix {
-				t.Errorf("unexpected S3 prefix, got: %s want: %s", prefix, tt.wantPrefix)
-			}
-		})
-	}
-}
-
-func TestS3GetSSEC(t *testing.T) {
+var _ = Describe("getSSEC", func() {
 	// Valid 32-byte key for AES-256
 	validKey := make([]byte, 32)
 	for i := range validKey {
@@ -267,85 +215,63 @@ func TestS3GetSSEC(t *testing.T) {
 	invalidKey := make([]byte, 16)
 	invalidKeyBase64 := base64.StdEncoding.EncodeToString(invalidKey)
 
-	tests := []struct {
-		name    string
-		client  *Client
-		wantNil bool
-		wantErr bool
-	}{
-		{
-			name:    "no SSE-C key",
-			client:  &Client{},
-			wantNil: true,
-			wantErr: false,
+	DescribeTable("returns the SSE-C configuration",
+		func(client *Client, wantNil bool, wantErr bool) {
+			sse, err := client.getSSEC()
+
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+
+			Expect(err).NotTo(HaveOccurred())
+
+			if wantNil {
+				Expect(sse).To(BeNil())
+			} else {
+				Expect(sse).NotTo(BeNil())
+			}
 		},
-		{
-			name: "empty SSE-C key",
-			client: &Client{
+		Entry("no SSE-C key",
+			&Client{},
+			true,
+			false,
+		),
+		Entry("empty SSE-C key",
+			&Client{
 				MinioOpts: MinioOpts{
 					SSECCustomerKey: "",
 				},
 			},
-			wantNil: true,
-			wantErr: false,
-		},
-		{
-			name: "valid SSE-C key",
-			client: &Client{
+			true,
+			false,
+		),
+		Entry("valid SSE-C key",
+			&Client{
 				MinioOpts: MinioOpts{
 					SSECCustomerKey: validKeyBase64,
 				},
 			},
-			wantNil: false,
-			wantErr: false,
-		},
-		{
-			name: "invalid base64",
-			client: &Client{
+			false,
+			false,
+		),
+		Entry("invalid base64",
+			&Client{
 				MinioOpts: MinioOpts{
 					SSECCustomerKey: invalidKeyBase64,
 				},
 			},
-			wantNil: true,
-			wantErr: true,
-		},
-		{
-			name: "invalid base64 (not 32 bytes)",
-			client: &Client{
+			true,
+			true,
+		),
+		Entry("invalid base64 (not 32 bytes)",
+			&Client{
 				MinioOpts: MinioOpts{
 					SSECCustomerKey: "not-valid-base64!!!",
 				},
 			},
-			wantNil: true,
-			wantErr: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sse, err := tt.client.getSSEC()
-
-			if tt.wantErr {
-				if err == nil {
-					t.Error("expected error, got nil")
-				}
-				return
-			}
-
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-				return
-			}
-
-			if tt.wantNil {
-				if sse != nil {
-					t.Error("expected nil SSE-C, got non-nil")
-				}
-			} else {
-				if sse == nil {
-					t.Error("expected non-nil SSE-C, got nil")
-				}
-			}
-		})
-	}
-}
+			true,
+			true,
+		),
+	)
+})

--- a/pkg/minio/suite_test.go
+++ b/pkg/minio/suite_test.go
@@ -1,0 +1,13 @@
+package minio
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMinio(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Minio Suite")
+}


### PR DESCRIPTION
Migrates `pkg/minio` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `minio_test.go` converted to `DescribeTable` specs (27 entries total). Entry names match the original `t.Run()` names.

Verified with:
```
go test ./pkg/minio/...
```

Part of #368.
