### PR TITLE
test: migrate pkg/sql tests to Ginkgo

### DIFF
--- a/pkg/sql/sql_test.go
+++ b/pkg/sql/sql_test.go
@@ -1,76 +1,76 @@
 package sql
 
 import (
-	"testing"
-
-	"github.com/google/go-cmp/cmp"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 )
 
-func TestBuildChangeMasterQuery(t *testing.T) {
-	tests := []struct {
-		name      string
-		options   []ChangeMasterOpt
-		wantQuery string
-		wantErr   bool
-	}{
-		{
-			name: "missing host",
-			options: []ChangeMasterOpt{
+var _ = Describe("buildChangeMasterQuery", func() {
+	DescribeTable("builds the CHANGE MASTER query",
+		func(options []ChangeMasterOpt, wantQuery string, wantErr bool) {
+			query, err := buildChangeMasterQuery(options...)
+
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(query).To(Equal(wantQuery))
+		},
+		Entry("missing host",
+			[]ChangeMasterOpt{
 				WithChangeMasterPort(3306),
 				WithChangeMasterCredentials("repl", "password"),
 			},
-			wantQuery: "",
-			wantErr:   true,
-		},
-		{
-			name: "missing credentials",
-			options: []ChangeMasterOpt{
+			"",
+			true,
+		),
+		Entry("missing credentials",
+			[]ChangeMasterOpt{
 				WithChangeMasterHost("127.0.0.1"),
 				WithChangeMasterPort(3306),
 			},
-			wantQuery: "",
-			wantErr:   true,
-		},
-		{
-			name: "valid without SSL",
-			options: []ChangeMasterOpt{
+			"",
+			true,
+		),
+		Entry("valid without SSL",
+			[]ChangeMasterOpt{
 				WithChangeMasterHost("127.0.0.1"),
 				WithChangeMasterPort(3306),
 				WithChangeMasterCredentials("repl", "password"),
 				WithChangeMasterGtid("CurrentPos"),
 			},
-			wantQuery: `CHANGE MASTER  TO
+			`CHANGE MASTER  TO
 MASTER_HOST='127.0.0.1',
 MASTER_PORT=3306,
 MASTER_USER='repl',
 MASTER_PASSWORD='password',
 MASTER_USE_GTID=CurrentPos;
 `,
-			wantErr: false,
-		},
-		{
-			name: "missing SSL paths",
-			options: []ChangeMasterOpt{
+			false,
+		),
+		Entry("missing SSL paths",
+			[]ChangeMasterOpt{
 				WithChangeMasterHost("127.0.0.1"),
 				WithChangeMasterPort(3306),
 				WithChangeMasterCredentials("repl", "password"),
 				WithChangeMasterSSL("", "", ""),
 			},
-			wantQuery: "",
-			wantErr:   true,
-		},
-		{
-			name: "valid with SSL",
-			options: []ChangeMasterOpt{
+			"",
+			true,
+		),
+		Entry("valid with SSL",
+			[]ChangeMasterOpt{
 				WithChangeMasterHost("127.0.0.1"),
 				WithChangeMasterPort(3306),
 				WithChangeMasterCredentials("repl", "password"),
 				WithChangeMasterGtid("CurrentPos"),
 				WithChangeMasterSSL("/etc/pki/client.crt", "/etc/pki/client.key", "/etc/pki/ca.crt"),
 			},
-			wantQuery: `CHANGE MASTER  TO
+			`CHANGE MASTER  TO
 MASTER_SSL=1,
 MASTER_SSL_CERT='/etc/pki/client.crt',
 MASTER_SSL_KEY='/etc/pki/client.key',
@@ -82,18 +82,17 @@ MASTER_USER='repl',
 MASTER_PASSWORD='password',
 MASTER_USE_GTID=CurrentPos;
 `,
-			wantErr: false,
-		},
-		{
-			name: "valid with Retries",
-			options: []ChangeMasterOpt{
+			false,
+		),
+		Entry("valid with Retries",
+			[]ChangeMasterOpt{
 				WithChangeMasterHost("127.0.0.1"),
 				WithChangeMasterPort(3306),
 				WithChangeMasterCredentials("repl", "password"),
 				WithChangeMasterGtid("CurrentPos"),
 				WithChangeMasterRetries(10),
 			},
-			wantQuery: `CHANGE MASTER  TO
+			`CHANGE MASTER  TO
 MASTER_HOST='127.0.0.1',
 MASTER_PORT=3306,
 MASTER_USER='repl',
@@ -101,135 +100,87 @@ MASTER_PASSWORD='password',
 MASTER_CONNECT_RETRY=10,
 MASTER_USE_GTID=CurrentPos;
 `,
-			wantErr: false,
-		},
-		{
-			name: "valid with custom connection",
-			options: []ChangeMasterOpt{
+			false,
+		),
+		Entry("valid with custom connection",
+			[]ChangeMasterOpt{
 				WithChangeMasterConnectionName("replica"),
 				WithChangeMasterHost("127.0.0.1"),
 				WithChangeMasterPort(3306),
 				WithChangeMasterCredentials("repl", "password"),
 				WithChangeMasterGtid("CurrentPos"),
 			},
-			wantQuery: `CHANGE MASTER 'replica' TO
+			`CHANGE MASTER 'replica' TO
 MASTER_HOST='127.0.0.1',
 MASTER_PORT=3306,
 MASTER_USER='repl',
 MASTER_PASSWORD='password',
 MASTER_USE_GTID=CurrentPos;
 `,
-			wantErr: false,
-		},
-	}
+			false,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			query, err := buildChangeMasterQuery(tt.options...)
+var _ = Describe("requireQuery", func() {
+	DescribeTable("builds the REQUIRE query",
+		func(require *mariadbv1alpha1.TLSRequirements, wantQuery string, wantErr bool) {
+			gotQuery, err := requireQuery(require)
 
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error but got nil")
-				}
-				return
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if diff := cmp.Diff(query, tt.wantQuery); diff != "" {
-				t.Errorf("unexpected query (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestRequireQuery(t *testing.T) {
-	tests := []struct {
-		name      string
-		require   *mariadbv1alpha1.TLSRequirements
-		wantQuery string
-		wantErr   bool
-	}{
-		{
-			name:      "nil",
-			require:   nil,
-			wantQuery: "",
-			wantErr:   true,
+			Expect(gotQuery).To(Equal(wantQuery))
 		},
-		{
-			name:      "empty",
-			require:   &mariadbv1alpha1.TLSRequirements{},
-			wantQuery: "",
-			wantErr:   true,
-		},
-		{
-			name: "SSL",
-			require: &mariadbv1alpha1.TLSRequirements{
+		Entry("nil", (*mariadbv1alpha1.TLSRequirements)(nil), "", true),
+		Entry("empty", &mariadbv1alpha1.TLSRequirements{}, "", true),
+		Entry("SSL",
+			&mariadbv1alpha1.TLSRequirements{
 				SSL: ptr.To(true),
 			},
-			wantQuery: "REQUIRE SSL",
-			wantErr:   false,
-		},
-		{
-			name: "X509",
-			require: &mariadbv1alpha1.TLSRequirements{
+			"REQUIRE SSL",
+			false,
+		),
+		Entry("X509",
+			&mariadbv1alpha1.TLSRequirements{
 				X509: ptr.To(true),
 			},
-			wantQuery: "REQUIRE X509",
-			wantErr:   false,
-		},
-		{
-			name: "Issuer",
-			require: &mariadbv1alpha1.TLSRequirements{
+			"REQUIRE X509",
+			false,
+		),
+		Entry("Issuer",
+			&mariadbv1alpha1.TLSRequirements{
 				Issuer: ptr.To("/CN=mariadb-galera-ca"),
 			},
-			wantQuery: "REQUIRE ISSUER '/CN=mariadb-galera-ca'",
-			wantErr:   false,
-		},
-		{
-			name: "Subject",
-			require: &mariadbv1alpha1.TLSRequirements{
+			"REQUIRE ISSUER '/CN=mariadb-galera-ca'",
+			false,
+		),
+		Entry("Subject",
+			&mariadbv1alpha1.TLSRequirements{
 				Subject: ptr.To("/CN=mariadb-galera-client"),
 			},
-			wantQuery: "REQUIRE SUBJECT '/CN=mariadb-galera-client'",
-			wantErr:   false,
-		},
-		{
-			name: "Issuer and Subject",
-			require: &mariadbv1alpha1.TLSRequirements{
+			"REQUIRE SUBJECT '/CN=mariadb-galera-client'",
+			false,
+		),
+		Entry("Issuer and Subject",
+			&mariadbv1alpha1.TLSRequirements{
 				Issuer:  ptr.To("/CN=mariadb-galera-ca"),
 				Subject: ptr.To("/CN=mariadb-galera-client"),
 			},
-			wantQuery: "REQUIRE ISSUER '/CN=mariadb-galera-ca' AND SUBJECT '/CN=mariadb-galera-client'",
-			wantErr:   false,
-		},
-		{
-			name: "Multiple",
-			require: &mariadbv1alpha1.TLSRequirements{
+			"REQUIRE ISSUER '/CN=mariadb-galera-ca' AND SUBJECT '/CN=mariadb-galera-client'",
+			false,
+		),
+		Entry("Multiple",
+			&mariadbv1alpha1.TLSRequirements{
 				SSL:     ptr.To(true),
 				X509:    ptr.To(true),
 				Issuer:  ptr.To("/CN=mariadb-galera-ca"),
 				Subject: ptr.To("/CN=mariadb-galera-client"),
 			},
-			wantQuery: "",
-			wantErr:   true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotQuery, err := requireQuery(tt.require)
-
-			if tt.wantErr && err == nil {
-				t.Error("expect error to have occurred, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("expect error to not have occurred, got: %v", err)
-			}
-			if diff := cmp.Diff(tt.wantQuery, gotQuery); diff != "" {
-				t.Errorf("unexpected bundle content (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
+			"",
+			true,
+		),
+	)
+})

--- a/pkg/sql/suite_test.go
+++ b/pkg/sql/suite_test.go
@@ -1,0 +1,13 @@
+package sql
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSQL(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SQL Suite")
+}


### PR DESCRIPTION
Migrates `pkg/sql` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified relative to the base branch.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `sql_test.go` converted to `Describe` blocks with `DescribeTable` specs (CHANGE MASTER and REQUIRE query builders). Entry/spec names match the original test / `t.Run()` names.

Verified with:
```
go test ./pkg/sql/...
```

Part of #368.
