### PR TITLE
test: migrate pkg/command tests to Ginkgo

### DIFF
--- a/pkg/command/backup_test.go
+++ b/pkg/command/backup_test.go
@@ -2,115 +2,110 @@ package command
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	builderpki "github.com/mariadb-operator/mariadb-operator/v26/pkg/builder/pki"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/replication"
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
 
-func TestNewBackupCommand(t *testing.T) {
-	tests := []struct {
-		name    string
-		opts    []BackupOpt
-		wantErr bool
-	}{
-		{
-			name: "missing path",
-			opts: []BackupOpt{
+var (
+	startGtid  = mustParseGtid("0-10-1")
+	targetTime = time.Now()
+
+	mdbObjectMeta = metav1.ObjectMeta{
+		Name:      "test",
+		Namespace: "test",
+	}
+	mdbFlags = "--user=${test} --password=${test} --host=test-primary.test.svc.cluster.local --port=3306"
+	tlsFlags = "--ssl --ssl-ca /etc/pki/ca.crt --ssl-cert /etc/pki/client.crt --ssl-key /etc/pki/client.key --ssl-verify-server-cert"
+)
+
+var _ = Describe("NewBackupCommand", func() {
+	DescribeTable("validates options",
+		func(opts []BackupOpt, wantErr bool) {
+			cmd, err := NewBackupCommand(opts...)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+				Expect(cmd).To(BeNil())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cmd).NotTo(BeNil())
+			}
+		},
+		Entry("missing path",
+			[]BackupOpt{
 				WithPath("", "/target/file", "/backup/full"),
 				WithUserEnv("USER_ENV"),
 				WithPasswordEnv("PASS_ENV"),
 			},
-			wantErr: true,
-		},
-		{
-			name: "missing target file",
-			opts: []BackupOpt{
+			true,
+		),
+		Entry("missing target file",
+			[]BackupOpt{
 				WithPath("/backups", "", "/backup/full"),
 				WithUserEnv("USER_ENV"),
 				WithPasswordEnv("PASS_ENV"),
 			},
-			wantErr: true,
-		},
-		{
-			name: "missing backup full dir",
-			opts: []BackupOpt{
+			true,
+		),
+		Entry("missing backup full dir",
+			[]BackupOpt{
 				WithPath("/backups", "/target/file", ""),
 				WithUserEnv("USER_ENV"),
 				WithPasswordEnv("PASS_ENV"),
 			},
-			wantErr: true,
-		},
-		{
-			name: "missing user env",
-			opts: []BackupOpt{
+			true,
+		),
+		Entry("missing user env",
+			[]BackupOpt{
 				WithPath("/backups", "/target/file", "/backup/full"),
 				WithPasswordEnv("PASS_ENV"),
 			},
-			wantErr: true,
-		},
-		{
-			name: "missing password env",
-			opts: []BackupOpt{
+			true,
+		),
+		Entry("missing password env",
+			[]BackupOpt{
 				WithPath("/backups", "/target/file", "/backup/full"),
 				WithUserEnv("USER_ENV"),
 			},
-			wantErr: true,
-		},
-		{
-			name: "omit credentials skips user/password check",
-			opts: []BackupOpt{
+			true,
+		),
+		Entry("omit credentials skips user/password check",
+			[]BackupOpt{
 				WithPath("/backups", "/target/file", "/backup/full"),
 				WithOmitCredentials(true),
 			},
-			wantErr: false,
+			false,
+		),
+	)
+})
+
+var _ = Describe("mariadbDumpArgs", func() {
+	DescribeTable("builds mariadb-dump args",
+		func(backupCmd *BackupCommand, backup *mariadbv1alpha1.Backup, mariadb *mariadbv1alpha1.MariaDB, wantArgs []string) {
+			args := backupCmd.mariadbDumpArgs(backup, mariadb)
+			Expect(args).To(Equal(wantArgs))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := NewBackupCommand(tt.opts...)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, cmd)
-			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, cmd)
-			}
-		})
-	}
-}
-
-func TestMariadbDumpArgs(t *testing.T) {
-	tests := []struct {
-		name      string
-		backupCmd *BackupCommand
-		backup    *mariadbv1alpha1.Backup
-		mariadb   *mariadbv1alpha1.MariaDB
-		wantArgs  []string
-	}{
-		{
-			name:      "empty",
-			backupCmd: &BackupCommand{},
-			backup:    &mariadbv1alpha1.Backup{},
-			mariadb:   &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+		Entry("empty",
+			&BackupCommand{},
+			&mariadbv1alpha1.Backup{},
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
 				"--all-databases",
 			},
-		},
-		{
-			name: "extra args",
-			backupCmd: &BackupCommand{
+		),
+		Entry("extra args",
+			&BackupCommand{
 				BackupOpts{
 					ExtraOpts: []string{
 						"--verbose",
@@ -118,9 +113,9 @@ func TestMariadbDumpArgs(t *testing.T) {
 					},
 				},
 			},
-			backup:  &mariadbv1alpha1.Backup{},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.Backup{},
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
@@ -128,38 +123,36 @@ func TestMariadbDumpArgs(t *testing.T) {
 				"--verbose",
 				"--add-drop-table",
 			},
-		},
-		{
-			name:      "Galera",
-			backupCmd: &BackupCommand{},
-			backup:    &mariadbv1alpha1.Backup{},
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("Galera",
+			&BackupCommand{},
+			&mariadbv1alpha1.Backup{},
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
 				"--all-databases",
 				"--skip-add-locks",
 			},
-		},
-		{
-			name:      "TLS",
-			backupCmd: &BackupCommand{},
-			backup:    &mariadbv1alpha1.Backup{},
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("TLS",
+			&BackupCommand{},
+			&mariadbv1alpha1.Backup{},
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					TLS: &mariadbv1alpha1.TLS{
 						Enabled: true,
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
@@ -173,27 +166,25 @@ func TestMariadbDumpArgs(t *testing.T) {
 				builderpki.ClientKeyPath,
 				"--ssl-verify-server-cert",
 			},
-		},
-		{
-			name:      "ignore mysql.global_priv",
-			backupCmd: &BackupCommand{},
-			backup: &mariadbv1alpha1.Backup{
+		),
+		Entry("ignore mysql.global_priv",
+			&BackupCommand{},
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					IgnoreGlobalPriv: ptr.To(true),
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
 				"--all-databases",
 				"--ignore-table=mysql.global_priv",
 			},
-		},
-		{
-			name: "duplicated args",
-			backupCmd: &BackupCommand{
+		),
+		Entry("duplicated args",
+			&BackupCommand{
 				BackupOpts{
 					ExtraOpts: []string{
 						"--events",
@@ -205,15 +196,15 @@ func TestMariadbDumpArgs(t *testing.T) {
 					},
 				},
 			},
-			backup: &mariadbv1alpha1.Backup{},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.Backup{},
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
@@ -223,29 +214,27 @@ func TestMariadbDumpArgs(t *testing.T) {
 				"--verbose",
 				"--add-drop-table",
 			},
-		},
-		{
-			name: "databases via args",
-			backupCmd: &BackupCommand{
+		),
+		Entry("databases via args",
+			&BackupCommand{
 				BackupOpts{
 					ExtraOpts: []string{
 						"--databases db1 db2 db3",
 					},
 				},
 			},
-			backup:  &mariadbv1alpha1.Backup{},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.Backup{},
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
 				"--databases db1 db2 db3",
 			},
-		},
-		{
-			name:      "databases via spec.databases",
-			backupCmd: &BackupCommand{},
-			backup: &mariadbv1alpha1.Backup{
+		),
+		Entry("databases via spec.databases",
+			&BackupCommand{},
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					Databases: []string{
 						"db1",
@@ -254,24 +243,23 @@ func TestMariadbDumpArgs(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
 				"--databases db1 db2 db3",
 			},
-		},
-		{
-			name: "override databases via args with spec.databases",
-			backupCmd: &BackupCommand{
+		),
+		Entry("override databases via args with spec.databases",
+			&BackupCommand{
 				BackupOpts{
 					ExtraOpts: []string{
 						"--databases foo bar",
 					},
 				},
 			},
-			backup: &mariadbv1alpha1.Backup{
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					Databases: []string{
 						"db1",
@@ -280,24 +268,23 @@ func TestMariadbDumpArgs(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
 				"--databases db1 db2 db3",
 			},
-		},
-		{
-			name: "override malformed databases via args with spec.databases",
-			backupCmd: &BackupCommand{
+		),
+		Entry("override malformed databases via args with spec.databases",
+			&BackupCommand{
 				BackupOpts{
 					ExtraOpts: []string{
 						"      --databases    foo bar",
 					},
 				},
 			},
-			backup: &mariadbv1alpha1.Backup{
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					Databases: []string{
 						"db1",
@@ -306,17 +293,16 @@ func TestMariadbDumpArgs(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
 				"--databases db1 db2 db3",
 			},
-		},
-		{
-			name: "all",
-			backupCmd: &BackupCommand{
+		),
+		Entry("all",
+			&BackupCommand{
 				BackupOpts{
 					ExtraOpts: []string{
 						"--databases foo bar",
@@ -325,7 +311,7 @@ func TestMariadbDumpArgs(t *testing.T) {
 					},
 				},
 			},
-			backup: &mariadbv1alpha1.Backup{
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					Databases: []string{
 						"db1",
@@ -335,14 +321,14 @@ func TestMariadbDumpArgs(t *testing.T) {
 					IgnoreGlobalPriv: ptr.To(true),
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"--single-transaction",
 				"--events",
 				"--routines",
@@ -352,65 +338,51 @@ func TestMariadbDumpArgs(t *testing.T) {
 				"--verbose",
 				"--add-drop-table",
 			},
+		),
+	)
+})
+
+var _ = Describe("mariadbBackupArgs", func() {
+	DescribeTable("builds mariadb-backup args",
+		func(backupCmd *BackupCommand, mariadb *mariadbv1alpha1.MariaDB, targetPodIndex int, wantArgs []string) {
+			args := backupCmd.mariadbBackupArgs(mariadb, targetPodIndex)
+			Expect(args).To(Equal(wantArgs))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			args := tt.backupCmd.mariadbDumpArgs(tt.backup, tt.mariadb)
-			if diff := cmp.Diff(args, tt.wantArgs); diff != "" {
-				t.Errorf("unexpected args (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestMariadbBackupArgs(t *testing.T) {
-	tests := []struct {
-		name           string
-		backupCmd      *BackupCommand
-		mariadb        *mariadbv1alpha1.MariaDB
-		targetPodIndex int
-		wantArgs       []string
-	}{
-		{
-			name:           "default",
-			backupCmd:      &BackupCommand{},
-			mariadb:        &mariadbv1alpha1.MariaDB{},
-			targetPodIndex: 0,
-			wantArgs: []string{
+		Entry("default",
+			&BackupCommand{},
+			&mariadbv1alpha1.MariaDB{},
+			0,
+			[]string{
 				"--backup",
 				"--stream=xbstream",
 				"--databases-exclude='lost+found'",
 			},
-		},
-		{
-			name: "with extra opts",
-			backupCmd: &BackupCommand{
+		),
+		Entry("with extra opts",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					ExtraOpts: []string{"--compress", "--parallel=2"},
 				},
 			},
-			mariadb:        &mariadbv1alpha1.MariaDB{},
-			targetPodIndex: 0,
-			wantArgs: []string{
+			&mariadbv1alpha1.MariaDB{},
+			0,
+			[]string{
 				"--backup",
 				"--stream=xbstream",
 				"--databases-exclude='lost+found'",
 				"--compress",
 				"--parallel=2",
 			},
-		},
-		{
-			name:      "with TLS",
-			backupCmd: &BackupCommand{},
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("with TLS",
+			&BackupCommand{},
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					TLS: &mariadbv1alpha1.TLS{Enabled: true},
 				},
 			},
-			targetPodIndex: 0,
-			wantArgs: []string{
+			0,
+			[]string{
 				"--backup",
 				"--stream=xbstream",
 				"--databases-exclude='lost+found'",
@@ -423,21 +395,20 @@ func TestMariadbBackupArgs(t *testing.T) {
 				builderpki.ClientKeyPath,
 				"--ssl-verify-server-cert",
 			},
-		},
-		{
-			name: "with TLS and extra opts",
-			backupCmd: &BackupCommand{
+		),
+		Entry("with TLS and extra opts",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					ExtraOpts: []string{"--compress", "--parallel=2"},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					TLS: &mariadbv1alpha1.TLS{Enabled: true},
 				},
 			},
-			targetPodIndex: 0,
-			wantArgs: []string{
+			0,
+			[]string{
 				"--backup",
 				"--stream=xbstream",
 				"--databases-exclude='lost+found'",
@@ -452,27 +423,25 @@ func TestMariadbBackupArgs(t *testing.T) {
 				"--compress",
 				"--parallel=2",
 			},
-		},
-		{
-			name: "duplicate extra opts",
-			backupCmd: &BackupCommand{
+		),
+		Entry("duplicate extra opts",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					ExtraOpts: []string{"--compress", "--compress"},
 				},
 			},
-			mariadb:        &mariadbv1alpha1.MariaDB{},
-			targetPodIndex: 0,
-			wantArgs: []string{
+			&mariadbv1alpha1.MariaDB{},
+			0,
+			[]string{
 				"--backup",
 				"--stream=xbstream",
 				"--databases-exclude='lost+found'",
 				"--compress",
 			},
-		},
-		{
-			name:      "replication",
-			backupCmd: &BackupCommand{},
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("replication",
+			&BackupCommand{},
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -482,36 +451,27 @@ func TestMariadbBackupArgs(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(1),
 				},
 			},
-			targetPodIndex: 0,
-			wantArgs: []string{
+			0,
+			[]string{
 				"--backup",
 				"--stream=xbstream",
 				"--databases-exclude='lost+found'",
 				"--slave-info",
 				"--safe-slave-backup",
 			},
+		),
+	)
+})
+
+var _ = Describe("MariadbOperatorBackup", func() {
+	DescribeTable("builds operator backup args",
+		func(backupCmd *BackupCommand, wantArgs []string) {
+			command, err := backupCmd.MariadbOperatorBackup()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(command.Args).To(Equal(wantArgs))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			args := tt.backupCmd.mariadbBackupArgs(tt.mariadb, tt.targetPodIndex)
-			if diff := cmp.Diff(args, tt.wantArgs); diff != "" {
-				t.Errorf("unexpected args (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestMariadbOperatorBackup(t *testing.T) {
-	tests := []struct {
-		name      string
-		backupCmd *BackupCommand
-		wantArgs  []string
-	}{
-		{
-			name: "logical no S3 no cleanupTargetFile",
-			backupCmd: &BackupCommand{
+		Entry("logical no S3 no cleanupTargetFile",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					Path:                 "/backups",
 					BackupContentType:    mariadbv1alpha1.BackupContentTypeLogical,
@@ -521,7 +481,7 @@ func TestMariadbOperatorBackup(t *testing.T) {
 					LogLevel:             "info",
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"backup",
 				"--path",
 				"/backups",
@@ -536,10 +496,9 @@ func TestMariadbOperatorBackup(t *testing.T) {
 				"--log-level",
 				"info",
 			},
-		},
-		{
-			name: "physical no S3 no cleanupTargetFile",
-			backupCmd: &BackupCommand{
+		),
+		Entry("physical no S3 no cleanupTargetFile",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					Path:                 "/backups",
 					TargetFilePath:       "/backups/0-backup-target.txt",
@@ -549,7 +508,7 @@ func TestMariadbOperatorBackup(t *testing.T) {
 					LogLevel:             "info",
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"backup",
 				"--path",
 				"/backups",
@@ -564,10 +523,9 @@ func TestMariadbOperatorBackup(t *testing.T) {
 				"--log-level",
 				"info",
 			},
-		},
-		{
-			name: "logical S3",
-			backupCmd: &BackupCommand{
+		),
+		Entry("logical S3",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					Path:                 "/backups",
 					TargetFilePath:       "/backups/0-backup-target.txt",
@@ -584,7 +542,7 @@ func TestMariadbOperatorBackup(t *testing.T) {
 					S3Prefix:             "mariadb",
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"backup",
 				"--path",
 				"/backups",
@@ -611,10 +569,9 @@ func TestMariadbOperatorBackup(t *testing.T) {
 				"--s3-prefix",
 				"mariadb",
 			},
-		},
-		{
-			name: "physical S3",
-			backupCmd: &BackupCommand{
+		),
+		Entry("physical S3",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					Path:                 "/backups",
 					TargetFilePath:       "/backups/0-backup-target.txt",
@@ -631,7 +588,7 @@ func TestMariadbOperatorBackup(t *testing.T) {
 					S3Prefix:             "mariadb",
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"backup",
 				"--path",
 				"/backups",
@@ -658,10 +615,9 @@ func TestMariadbOperatorBackup(t *testing.T) {
 				"--s3-prefix",
 				"mariadb",
 			},
-		},
-		{
-			name: "logical S3 and cleanup target file",
-			backupCmd: &BackupCommand{
+		),
+		Entry("logical S3 and cleanup target file",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					Path:                 "/backups",
 					TargetFilePath:       "/backups/0-backup-target.txt",
@@ -679,7 +635,7 @@ func TestMariadbOperatorBackup(t *testing.T) {
 					CleanupTargetFile:    true,
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"backup",
 				"--path",
 				"/backups",
@@ -707,10 +663,9 @@ func TestMariadbOperatorBackup(t *testing.T) {
 				"mariadb",
 				"--cleanup-target-file",
 			},
-		},
-		{
-			name: "physical S3 and cleanup target file",
-			backupCmd: &BackupCommand{
+		),
+		Entry("physical S3 and cleanup target file",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					Path:                 "/backups",
 					TargetFilePath:       "/backups/0-backup-target.txt",
@@ -728,7 +683,7 @@ func TestMariadbOperatorBackup(t *testing.T) {
 					CleanupTargetFile:    true,
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"backup",
 				"--path",
 				"/backups",
@@ -756,10 +711,9 @@ func TestMariadbOperatorBackup(t *testing.T) {
 				"mariadb",
 				"--cleanup-target-file",
 			},
-		},
-		{
-			name: "physical S3 and meta",
-			backupCmd: &BackupCommand{
+		),
+		Entry("physical S3 and meta",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					Path:               "/backups",
 					TargetFilePath:     "/backups/0-backup-target.txt",
@@ -783,7 +737,7 @@ func TestMariadbOperatorBackup(t *testing.T) {
 					CleanupTargetFile:    true,
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"backup",
 				"--path",
 				"/backups",
@@ -818,40 +772,24 @@ func TestMariadbOperatorBackup(t *testing.T) {
 				"--physical-backup-namespace",
 				"test",
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			command, err := tt.backupCmd.MariadbOperatorBackup()
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if diff := cmp.Diff(command.Args, tt.wantArgs); diff != "" {
-				t.Errorf("unexpected args (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestMariadbRestoreArgs(t *testing.T) {
-	tests := []struct {
-		name      string
-		backupCmd *BackupCommand
-		restore   *mariadbv1alpha1.Restore
-		mariadb   *mariadbv1alpha1.MariaDB
-		wantArgs  []string
-	}{
-		{
-			name:      "empty",
-			backupCmd: &BackupCommand{},
-			restore:   &mariadbv1alpha1.Restore{},
-			mariadb:   &mariadbv1alpha1.MariaDB{},
-			wantArgs:  nil,
+var _ = Describe("mariadbRestoreArgs", func() {
+	DescribeTable("builds restore args",
+		func(backupCmd *BackupCommand, restore *mariadbv1alpha1.Restore, mariadb *mariadbv1alpha1.MariaDB, wantArgs []string) {
+			args := backupCmd.mariadbRestoreArgs(restore, mariadb)
+			Expect(args).To(Equal(wantArgs))
 		},
-		{
-			name: "args",
-			backupCmd: &BackupCommand{
+		Entry("empty",
+			&BackupCommand{},
+			&mariadbv1alpha1.Restore{},
+			&mariadbv1alpha1.MariaDB{},
+			nil,
+		),
+		Entry("args",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					ExtraOpts: []string{
 						"--verbose",
@@ -859,16 +797,15 @@ func TestMariadbRestoreArgs(t *testing.T) {
 					},
 				},
 			},
-			restore: &mariadbv1alpha1.Restore{},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.Restore{},
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--verbose",
 				"--one-database db1",
 			},
-		},
-		{
-			name: "duplicate args",
-			backupCmd: &BackupCommand{
+		),
+		Entry("duplicate args",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					ExtraOpts: []string{
 						"--verbose",
@@ -877,58 +814,55 @@ func TestMariadbRestoreArgs(t *testing.T) {
 					},
 				},
 			},
-			restore: &mariadbv1alpha1.Restore{},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.Restore{},
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--verbose",
 				"--one-database db1",
 			},
-		},
-		{
-			name:      "database",
-			backupCmd: &BackupCommand{},
-			restore: &mariadbv1alpha1.Restore{
+		),
+		Entry("database",
+			&BackupCommand{},
+			&mariadbv1alpha1.Restore{
 				Spec: mariadbv1alpha1.RestoreSpec{
 					Database: "db1",
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--one-database db1",
 			},
-		},
-		{
-			name: "database and args",
-			backupCmd: &BackupCommand{
+		),
+		Entry("database and args",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					ExtraOpts: []string{
 						"--verbose",
 					},
 				},
 			},
-			restore: &mariadbv1alpha1.Restore{
+			&mariadbv1alpha1.Restore{
 				Spec: mariadbv1alpha1.RestoreSpec{
 					Database: "db1",
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantArgs: []string{
+			&mariadbv1alpha1.MariaDB{},
+			[]string{
 				"--verbose",
 				"--one-database db1",
 			},
-		},
-		{
-			name:      "TLS",
-			backupCmd: &BackupCommand{},
-			restore:   &mariadbv1alpha1.Restore{},
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("TLS",
+			&BackupCommand{},
+			&mariadbv1alpha1.Restore{},
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					TLS: &mariadbv1alpha1.TLS{
 						Enabled: true,
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"--ssl",
 				"--ssl-ca",
 				builderpki.CACertPath,
@@ -938,31 +872,36 @@ func TestMariadbRestoreArgs(t *testing.T) {
 				builderpki.ClientKeyPath,
 				"--ssl-verify-server-cert",
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			args := tt.backupCmd.mariadbRestoreArgs(tt.restore, tt.mariadb)
-			if diff := cmp.Diff(args, tt.wantArgs); diff != "" {
-				t.Errorf("unexpected args (-want +got):\n%s", diff)
+var _ = Describe("MariadbBackupRestore", func() {
+	DescribeTable("builds restore command",
+		func(backupCmd *BackupCommand, mariadb *mariadbv1alpha1.MariaDB, restoreOpts []MariaDBBackupRestoreOpt, wantErr, wantCleanup bool) {
+			cmd, err := backupCmd.MariadbBackupRestore(
+				mariadb,
+				"/var/lib/mysql",
+				restoreOpts...,
+			)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+				Expect(cmd).To(BeNil())
+				return
 			}
-		})
-	}
-}
 
-func TestMariadbBackupRestore(t *testing.T) {
-	tests := []struct {
-		name        string
-		backupCmd   *BackupCommand
-		mariadb     *mariadbv1alpha1.MariaDB
-		restoreOpts []MariaDBBackupRestoreOpt
-		wantErr     bool
-		wantCleanup bool
-	}{
-		{
-			name: "with database option (should error)",
-			backupCmd: &BackupCommand{
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cmd).NotTo(BeNil())
+			Expect(cmd.Args).NotTo(BeEmpty())
+			script := cmd.Args[0] // NewBashCommand puts the whole script here
+			if wantCleanup {
+				Expect(script).To(ContainSubstring("rm -rf /var/lib/mysql/*"))
+			} else {
+				Expect(script).NotTo(ContainSubstring("rm -rf /var/lib/mysql/*"))
+			}
+		},
+		Entry("with database option (should error)",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					CommandOpts: CommandOpts{
 						Database: ptr.To("somedb"),
@@ -971,86 +910,67 @@ func TestMariadbBackupRestore(t *testing.T) {
 					BackupFullDirPath: "/backup/full",
 				},
 			},
-			mariadb:     &mariadbv1alpha1.MariaDB{},
-			restoreOpts: nil,
-			wantErr:     true,
-			wantCleanup: false,
-		},
-		{
-			name: "basic physical restore",
-			backupCmd: &BackupCommand{
+			&mariadbv1alpha1.MariaDB{},
+			nil,
+			true,
+			false,
+		),
+		Entry("basic physical restore",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					TargetFilePath:    "/backups/target.sql",
 					BackupFullDirPath: "/backup/full",
 				},
 			},
-			mariadb:     &mariadbv1alpha1.MariaDB{},
-			restoreOpts: nil,
-			wantErr:     false,
-			wantCleanup: false,
-		},
-		{
-			name: "with cleanup data dir (should include cleanup command)",
-			backupCmd: &BackupCommand{
+			&mariadbv1alpha1.MariaDB{},
+			nil,
+			false,
+			false,
+		),
+		Entry("with cleanup data dir (should include cleanup command)",
+			&BackupCommand{
 				BackupOpts: BackupOpts{
 					TargetFilePath:    "/backups/target.sql",
 					BackupFullDirPath: "/backup/full",
 				},
 			},
-			mariadb:     &mariadbv1alpha1.MariaDB{},
-			restoreOpts: []MariaDBBackupRestoreOpt{WithCleanupDataDir(true)},
-			wantErr:     false,
-			wantCleanup: true,
-		},
-	}
+			&mariadbv1alpha1.MariaDB{},
+			[]MariaDBBackupRestoreOpt{WithCleanupDataDir(true)},
+			false,
+			true,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			cmd, err := tt.backupCmd.MariadbBackupRestore(
-				tt.mariadb,
-				"/var/lib/mysql",
-				tt.restoreOpts...,
-			)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, cmd)
+var _ = Describe("MariadbOperatorPITR", func() {
+	DescribeTable("builds PITR command",
+		func(opts []BackupOpt, strictMode, wantErr bool, wantArgs []string) {
+			allOpts := []BackupOpt{
+				WithUserEnv("test"),
+				WithPasswordEnv("test"),
+			}
+			allOpts = append(allOpts, opts...)
+			b, err := NewBackupCommand(allOpts...)
+			Expect(err).NotTo(HaveOccurred())
+
+			cmd, err := b.MariadbOperatorPITR(strictMode)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
 				return
 			}
+			Expect(err).NotTo(HaveOccurred())
 
-			assert.NoError(t, err)
-			if assert.NotNil(t, cmd) {
-				if len(cmd.Args) == 0 {
-					t.Error("Expected command to return args")
-				}
-				script := cmd.Args[0] // NewBashCommand puts the whole script here
-				if tt.wantCleanup {
-					assert.Contains(t, script, "rm -rf /var/lib/mysql/*")
-				} else {
-					assert.NotContains(t, script, "rm -rf /var/lib/mysql/*")
-				}
-			}
-		})
-	}
-}
-
-func TestMariadbOperatorPITR(t *testing.T) {
-	startGtid := mustParseGtid(t, "0-10-1")
-	targetTime := time.Now()
-	tests := []struct {
-		name       string
-		opts       []BackupOpt
-		strictMode bool
-		wantErr    bool
-		wantArgs   []string
-	}{
-		{
-			name: "basic PITR without S3",
-			opts: []BackupOpt{
+			Expect(cmd.Args).To(Equal(wantArgs))
+		},
+		Entry("basic PITR without S3",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithStartGtid(startGtid),
 				WithTargetTime(targetTime),
 			},
-			wantArgs: []string{
+			false,
+			false,
+			[]string{
 				"pitr",
 				"--path",
 				"/binlogs",
@@ -1061,10 +981,9 @@ func TestMariadbOperatorPITR(t *testing.T) {
 				"--target-time",
 				targetTime.Format(time.RFC3339),
 			},
-		},
-		{
-			name: "PITR with S3",
-			opts: []BackupOpt{
+		),
+		Entry("PITR with S3",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithStartGtid(startGtid),
 				WithTargetTime(targetTime),
@@ -1072,7 +991,9 @@ func TestMariadbOperatorPITR(t *testing.T) {
 				WithS3TLS(true),
 				WithS3CACertPath("/ca/cert"),
 			},
-			wantArgs: []string{
+			false,
+			false,
+			[]string{
 				"pitr",
 				"--path",
 				"/binlogs",
@@ -1095,16 +1016,17 @@ func TestMariadbOperatorPITR(t *testing.T) {
 				"--s3-prefix",
 				"prefix/",
 			},
-		},
-		{
-			name: "PITR with compression",
-			opts: []BackupOpt{
+		),
+		Entry("PITR with compression",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithStartGtid(startGtid),
 				WithTargetTime(targetTime),
 				WithCompression(mariadbv1alpha1.CompressGzip),
 			},
-			wantArgs: []string{
+			false,
+			false,
+			[]string{
 				"pitr",
 				"--path",
 				"/binlogs",
@@ -1117,16 +1039,17 @@ func TestMariadbOperatorPITR(t *testing.T) {
 				"--compression",
 				"gzip",
 			},
-		},
-		{
-			name: "PITR with log level",
-			opts: []BackupOpt{
+		),
+		Entry("PITR with log level",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithStartGtid(startGtid),
 				WithTargetTime(targetTime),
 				WithLogLevel("debug"),
 			},
-			wantArgs: []string{
+			false,
+			false,
+			[]string{
 				"pitr",
 				"--path",
 				"/binlogs",
@@ -1139,16 +1062,16 @@ func TestMariadbOperatorPITR(t *testing.T) {
 				"--log-level",
 				"debug",
 			},
-		},
-		{
-			name: "PITR with strict mode",
-			opts: []BackupOpt{
+		),
+		Entry("PITR with strict mode",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithStartGtid(startGtid),
 				WithTargetTime(targetTime),
 			},
-			strictMode: true,
-			wantArgs: []string{
+			true,
+			false,
+			[]string{
 				"pitr",
 				"--path",
 				"/binlogs",
@@ -1160,10 +1083,9 @@ func TestMariadbOperatorPITR(t *testing.T) {
 				targetTime.Format(time.RFC3339),
 				"--strict-mode",
 			},
-		},
-		{
-			name: "PITR with all options",
-			opts: []BackupOpt{
+		),
+		Entry("PITR with all options",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithMaxRetention(30 * 24 * time.Hour),
 				WithStartGtid(startGtid),
@@ -1174,8 +1096,9 @@ func TestMariadbOperatorPITR(t *testing.T) {
 				WithCompression(mariadbv1alpha1.CompressBzip2),
 				WithLogLevel("info"),
 			},
-			strictMode: true,
-			wantArgs: []string{
+			true,
+			false,
+			[]string{
 				"pitr",
 				"--path",
 				"/binlogs",
@@ -1203,73 +1126,43 @@ func TestMariadbOperatorPITR(t *testing.T) {
 				"--log-level",
 				"info",
 			},
-		},
-		{
-			name: "PITR without startGtid",
-			opts: []BackupOpt{
+		),
+		Entry("PITR without startGtid",
+			[]BackupOpt{
 				WithPath("/backup", "/target/file", "/backup/full"),
 				WithTargetTime(targetTime),
 			},
-			wantErr: true,
-		},
-	}
+			false,
+			true,
+			nil,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			opts := []BackupOpt{
-				WithUserEnv("test"),
-				WithPasswordEnv("test"),
-			}
-			opts = append(opts, tt.opts...)
+var _ = Describe("mariadbBinlogArgs", func() {
+	DescribeTable("builds binlog restore args",
+		func(opts []BackupOpt, mariadb *mariadbv1alpha1.MariaDB, wantArgs []string, wantErr bool) {
 			b, err := NewBackupCommand(opts...)
-			if err != nil {
-				t.Fatalf("NewBackupCommand() error = %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
 
-			cmd, err := b.MariadbOperatorPITR(tt.strictMode)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("MariadbOperatorPITR() error = nil, wantErr = true")
-				}
+			args, err := b.mariadbBinlogArgs(mariadb)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
 				return
 			}
-			if err != nil {
-				t.Fatalf("MariadbOperatorPITR() error = %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(args).NotTo(BeNil())
 
-			if diff := cmp.Diff(tt.wantArgs, cmd.Args); diff != "" {
-				t.Errorf("unexpected probe (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestMariadbBinlogArgs(t *testing.T) {
-	mdbObjectMeta := metav1.ObjectMeta{
-		Name:      "test",
-		Namespace: "test",
-	}
-	startGtid := mustParseGtid(t, "0-10-1")
-	targetTime := time.Now()
-	mdbFlags := "--user=${test} --password=${test} --host=test-primary.test.svc.cluster.local --port=3306"
-	tlsFlags := "--ssl --ssl-ca /etc/pki/ca.crt --ssl-cert /etc/pki/client.crt --ssl-key /etc/pki/client.key --ssl-verify-server-cert"
-
-	tests := []struct {
-		name     string
-		opts     []BackupOpt
-		mariadb  *mariadbv1alpha1.MariaDB
-		wantArgs []string
-		wantErr  bool
-	}{
-		{
-			name: "error when StartGtid is nil",
-			opts: []BackupOpt{
+			Expect(args).To(Equal(wantArgs))
+		},
+		Entry("error when StartGtid is nil",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithTargetTime(targetTime),
 				WithUserEnv("test"),
 				WithPasswordEnv("test"),
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mdbObjectMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
@@ -1278,18 +1171,18 @@ func TestMariadbBinlogArgs(t *testing.T) {
 					Port: 3306,
 				},
 			},
-			wantErr: true,
-		},
-		{
-			name: "valid",
-			opts: []BackupOpt{
+			nil,
+			true,
+		),
+		Entry("valid",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithStartGtid(startGtid),
 				WithTargetTime(targetTime),
 				WithUserEnv("test"),
 				WithPasswordEnv("test"),
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mdbObjectMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
@@ -1298,7 +1191,7 @@ func TestMariadbBinlogArgs(t *testing.T) {
 					Port: 3306,
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"set -euo pipefail",
 				"echo 💾 Restoring binlogs",
 				fmt.Sprintf(
@@ -1308,18 +1201,17 @@ func TestMariadbBinlogArgs(t *testing.T) {
 					mdbFlags,
 				),
 			},
-			wantErr: false,
-		},
-		{
-			name: "valid with TLS",
-			opts: []BackupOpt{
+			false,
+		),
+		Entry("valid with TLS",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithStartGtid(startGtid),
 				WithTargetTime(targetTime),
 				WithUserEnv("test"),
 				WithPasswordEnv("test"),
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mdbObjectMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
@@ -1331,7 +1223,7 @@ func TestMariadbBinlogArgs(t *testing.T) {
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"set -euo pipefail",
 				"echo 💾 Restoring binlogs",
 				fmt.Sprintf(
@@ -1342,11 +1234,10 @@ func TestMariadbBinlogArgs(t *testing.T) {
 					tlsFlags,
 				),
 			},
-			wantErr: false,
-		},
-		{
-			name: "valid with extra args",
-			opts: []BackupOpt{
+			false,
+		),
+		Entry("valid with extra args",
+			[]BackupOpt{
 				WithPath("/binlogs", "/binlogs/file", "/backup/full"),
 				WithStartGtid(startGtid),
 				WithTargetTime(targetTime),
@@ -1356,7 +1247,7 @@ func TestMariadbBinlogArgs(t *testing.T) {
 					"--log-level=debug",
 				}),
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mdbObjectMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
@@ -1365,7 +1256,7 @@ func TestMariadbBinlogArgs(t *testing.T) {
 					Port: 3306,
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"set -euo pipefail",
 				"echo 💾 Restoring binlogs",
 				fmt.Sprintf(
@@ -1375,70 +1266,52 @@ func TestMariadbBinlogArgs(t *testing.T) {
 					mdbFlags,
 				),
 			},
-			wantErr: false,
+			false,
+		),
+	)
+})
+
+var _ = Describe("physicalBackupArgs", func() {
+	DescribeTable("builds physical backup args",
+		func(backupContentType mariadbv1alpha1.BackupContentType, backupFullDirPath string,
+			physicalBackupMeta bool, physicalBackupKey *types.NamespacedName, wantArgs []string) {
+			b := &BackupCommand{
+				BackupOpts: BackupOpts{
+					BackupContentType:  backupContentType,
+					BackupFullDirPath:  backupFullDirPath,
+					PhysicalBackupMeta: physicalBackupMeta,
+					PhysicalBackupKey:  physicalBackupKey,
+				},
+			}
+
+			Expect(b.physicalBackupArgs()).To(Equal(wantArgs))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			b, err := NewBackupCommand(tt.opts...)
-			if err != nil {
-				t.Fatalf("NewBackupCommand() error = %v", err)
-			}
-
-			args, err := b.mariadbBinlogArgs(tt.mariadb)
-			if tt.wantErr {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-			assert.NotNil(t, args)
-
-			if diff := cmp.Diff(tt.wantArgs, args); diff != "" {
-				t.Errorf("unexpected args (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestPhysicalBackupArgs(t *testing.T) {
-	tests := []struct {
-		name               string
-		backupContentType  mariadbv1alpha1.BackupContentType
-		backupFullDirPath  string
-		physicalBackupMeta bool
-		physicalBackupKey  *types.NamespacedName
-		wantArgs           []string
-	}{
-		{
-			name:               "Non-physical backup content type",
-			backupContentType:  mariadbv1alpha1.BackupContentTypeLogical,
-			backupFullDirPath:  "/backup/dir",
-			physicalBackupMeta: false,
-			physicalBackupKey:  nil,
-			wantArgs:           nil,
-		},
-		{
-			name:               "Physical backup with directory path",
-			backupContentType:  mariadbv1alpha1.BackupContentTypePhysical,
-			backupFullDirPath:  "/backup/dir",
-			physicalBackupMeta: false,
-			physicalBackupKey:  nil,
-			wantArgs: []string{
+		Entry("Non-physical backup content type",
+			mariadbv1alpha1.BackupContentTypeLogical,
+			"/backup/dir",
+			false,
+			(*types.NamespacedName)(nil),
+			nil,
+		),
+		Entry("Physical backup with directory path",
+			mariadbv1alpha1.BackupContentTypePhysical,
+			"/backup/dir",
+			false,
+			(*types.NamespacedName)(nil),
+			[]string{
 				"--physical-backup-dir-path",
 				"/backup/dir",
 			},
-		},
-		{
-			name:               "Physical backup with meta and key",
-			backupContentType:  mariadbv1alpha1.BackupContentTypePhysical,
-			backupFullDirPath:  "/backup/dir",
-			physicalBackupMeta: true,
-			physicalBackupKey: &types.NamespacedName{
+		),
+		Entry("Physical backup with meta and key",
+			mariadbv1alpha1.BackupContentTypePhysical,
+			"/backup/dir",
+			true,
+			&types.NamespacedName{
 				Name:      "test-backup",
 				Namespace: "test-namespace",
 			},
-			wantArgs: []string{
+			[]string{
 				"--physical-backup-dir-path",
 				"/backup/dir",
 				"--physical-backup-meta",
@@ -1447,42 +1320,24 @@ func TestPhysicalBackupArgs(t *testing.T) {
 				"--physical-backup-namespace",
 				"test-namespace",
 			},
-		},
-		{
-			name:               "Physical backup with directory and meta but no key",
-			backupContentType:  mariadbv1alpha1.BackupContentTypePhysical,
-			backupFullDirPath:  "/backup/dir",
-			physicalBackupMeta: true,
-			physicalBackupKey:  nil,
-			wantArgs: []string{
+		),
+		Entry("Physical backup with directory and meta but no key",
+			mariadbv1alpha1.BackupContentTypePhysical,
+			"/backup/dir",
+			true,
+			(*types.NamespacedName)(nil),
+			[]string{
 				"--physical-backup-dir-path",
 				"/backup/dir",
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			b := &BackupCommand{
-				BackupOpts: BackupOpts{
-					BackupContentType:  tt.backupContentType,
-					BackupFullDirPath:  tt.backupFullDirPath,
-					PhysicalBackupMeta: tt.physicalBackupMeta,
-					PhysicalBackupKey:  tt.physicalBackupKey,
-				},
-			}
-
-			if diff := cmp.Diff(b.physicalBackupArgs(), tt.wantArgs); diff != "" {
-				t.Errorf("unexpected args (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func mustParseGtid(t *testing.T, rawGtid string) *replication.Gtid {
+func mustParseGtid(rawGtid string) *replication.Gtid {
 	gtid, err := replication.ParseGtid(rawGtid)
 	if err != nil {
-		t.Fatalf("unexpected error parsing GTID: %v", err)
+		panic(fmt.Sprintf("unexpected error parsing GTID: %v", err))
 	}
 	return gtid
 }

--- a/pkg/command/command_test.go
+++ b/pkg/command/command_test.go
@@ -2,122 +2,114 @@ package command
 
 import (
 	"errors"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
-func TestConnectionFlags(t *testing.T) {
-	tests := []struct {
-		name     string
-		opts     *CommandOpts
-		mariadb  *mariadbv1alpha1.MariaDB
-		flagOpts []ConnectionFlagOpt
-		want     string
-		wantErr  error
-	}{
-		{
-			name:    "missing UserEnv",
-			opts:    &CommandOpts{PasswordEnv: "PASS"},
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantErr: errors.New("UserEnv must be set"),
-		},
-		{
-			name: "missing PasswordEnv",
-			opts: &CommandOpts{UserEnv: "USER"},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-			},
-			wantErr: errors.New("PasswordEnv must be set"),
-		},
-		{
-			name: "basic flags with standalone",
-			opts: &CommandOpts{UserEnv: "USER", PasswordEnv: "PASS"},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Port: 3306,
-				},
-			},
-			want: "--user=${USER} --password=${PASS} --host=test.default.svc.cluster.local --port=3306",
-		},
-		{
-			name: "basic flags with Galera",
-			opts: &CommandOpts{UserEnv: "USER", PasswordEnv: "PASS"},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Port: 3306,
-					Galera: &mariadbv1alpha1.Galera{
-						Enabled: true,
-					},
-				},
-			},
-			want: "--user=${USER} --password=${PASS} --host=test-primary.default.svc.cluster.local --port=3306",
-		},
-		{
-			name: "with database",
-			opts: &CommandOpts{UserEnv: "USER", PasswordEnv: "PASS", Database: ptr.To("test")},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Port: 3306,
-					Galera: &mariadbv1alpha1.Galera{
-						Enabled: true,
-					},
-				},
-			},
-			want: "--user=${USER} --password=${PASS} --host=test-primary.default.svc.cluster.local --port=3306 --database=test",
-		},
-		{
-			name: "with host override",
-			opts: &CommandOpts{UserEnv: "USER", PasswordEnv: "PASS"},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test",
-					Namespace: "default",
-				},
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Port: 3306,
-					Galera: &mariadbv1alpha1.Galera{
-						Enabled: true,
-					},
-				},
-			},
-			flagOpts: []ConnectionFlagOpt{WithHostConnectionFlag("custom-host")},
-			want:     "--user=${USER} --password=${PASS} --host=custom-host --port=3306",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ConnectionFlags(tt.opts, tt.mariadb, tt.flagOpts...)
-			if tt.wantErr != nil {
-				if err == nil || err.Error() != tt.wantErr.Error() {
-					t.Errorf("expected error %v, got %v", tt.wantErr, err)
-				}
+var _ = Describe("ConnectionFlags", func() {
+	DescribeTable("builds connection flags",
+		func(opts *CommandOpts, mariadb *mariadbv1alpha1.MariaDB, flagOpts []ConnectionFlagOpt, want string, wantErr error) {
+			got, err := ConnectionFlags(opts, mariadb, flagOpts...)
+			if wantErr != nil {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal(wantErr.Error()))
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if got != tt.want {
-				t.Errorf("expected %q, got %q", tt.want, got)
-			}
-		})
-	}
-}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got).To(Equal(want))
+		},
+		Entry("missing UserEnv",
+			&CommandOpts{PasswordEnv: "PASS"},
+			&mariadbv1alpha1.MariaDB{},
+			nil,
+			"",
+			errors.New("UserEnv must be set"),
+		),
+		Entry("missing PasswordEnv",
+			&CommandOpts{UserEnv: "USER"},
+			&mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+			},
+			nil,
+			"",
+			errors.New("PasswordEnv must be set"),
+		),
+		Entry("basic flags with standalone",
+			&CommandOpts{UserEnv: "USER", PasswordEnv: "PASS"},
+			&mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+				},
+			},
+			nil,
+			"--user=${USER} --password=${PASS} --host=test.default.svc.cluster.local --port=3306",
+			nil,
+		),
+		Entry("basic flags with Galera",
+			&CommandOpts{UserEnv: "USER", PasswordEnv: "PASS"},
+			&mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+					Galera: &mariadbv1alpha1.Galera{
+						Enabled: true,
+					},
+				},
+			},
+			nil,
+			"--user=${USER} --password=${PASS} --host=test-primary.default.svc.cluster.local --port=3306",
+			nil,
+		),
+		Entry("with database",
+			&CommandOpts{UserEnv: "USER", PasswordEnv: "PASS", Database: ptr.To("test")},
+			&mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+					Galera: &mariadbv1alpha1.Galera{
+						Enabled: true,
+					},
+				},
+			},
+			nil,
+			"--user=${USER} --password=${PASS} --host=test-primary.default.svc.cluster.local --port=3306 --database=test",
+			nil,
+		),
+		Entry("with host override",
+			&CommandOpts{UserEnv: "USER", PasswordEnv: "PASS"},
+			&mariadbv1alpha1.MariaDB{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+					Galera: &mariadbv1alpha1.Galera{
+						Enabled: true,
+					},
+				},
+			},
+			[]ConnectionFlagOpt{WithHostConnectionFlag("custom-host")},
+			"--user=${USER} --password=${PASS} --host=custom-host --port=3306",
+			nil,
+		),
+	)
+})

--- a/pkg/command/suite_test.go
+++ b/pkg/command/suite_test.go
@@ -1,0 +1,13 @@
+package command
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCommand(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Command Suite")
+}


### PR DESCRIPTION
Migrates `pkg/command` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified relative to the base branch.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `backup_test.go` and `command_test.go` converted to `Describe` blocks with `DescribeTable` specs. Entry/spec names match the original test / `t.Run()` names.

Verified with:
```
go test ./pkg/command/...
```

Part of #368.
