### PR TITLE
test: migrate pkg/docker tests to Ginkgo

### DIFF
--- a/pkg/docker/reference_test.go
+++ b/pkg/docker/reference_test.go
@@ -1,300 +1,148 @@
 package docker
 
-import "testing"
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
 
-// nolint:lll
-func TestGetTag(t *testing.T) {
-	tests := []struct {
-		name    string
-		image   string
-		wantTag string
-		wantErr bool
-	}{
-		{
-			name:    "invalid image",
-			image:   "foo",
-			wantTag: "",
-			wantErr: true,
+var _ = Describe("GetTag", func() {
+	// nolint:lll
+	DescribeTable("returns the tag of an image",
+		func(image string, wantTag string, wantErr bool) {
+			tag, err := GetTag(image)
+			Expect(tag).To(Equal(wantTag))
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
 		},
-		{
-			name:    "empty tag",
-			image:   "mariadb:",
-			wantTag: "",
-			wantErr: true,
-		},
-		{
-			name:    "image",
-			image:   "mariadb:10.6",
-			wantTag: "10.6",
-			wantErr: false,
-		},
-		{
-			name:    "image with namespace",
-			image:   "mariadb/maxscale:23.08.5",
-			wantTag: "23.08.5",
-			wantErr: false,
-		},
-		{
-			name:    "image with namespace and host",
-			image:   "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			wantTag: "v0.0.1",
-			wantErr: false,
-		},
-		{
-			name:    "digest",
-			image:   "ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
-			wantTag: "",
-			wantErr: true,
-		},
-	}
+		Entry("invalid image", "foo", "", true),
+		Entry("empty tag", "mariadb:", "", true),
+		Entry("image", "mariadb:10.6", "10.6", false),
+		Entry("image with namespace", "mariadb/maxscale:23.08.5", "23.08.5", false),
+		Entry("image with namespace and host",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1", "v0.0.1", false),
+		Entry("digest",
+			"ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
+			"", true),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tag, err := GetTag(tt.image)
-			if tt.wantTag != tag {
-				t.Errorf("unexpected image, expected: %v got: %v", tt.wantTag, tag)
+var _ = Describe("SetTagOrDigest", func() {
+	// nolint:lll
+	DescribeTable("sets the tag or digest of the target image from the source image",
+		func(sourceImage string, targetImage string, wantImage string, wantErr bool) {
+			image, err := SetTagOrDigest(sourceImage, targetImage)
+			Expect(image).To(Equal(wantImage))
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
 			}
-			if tt.wantErr && err == nil {
-				t.Error("expect error to have occurred, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("expect error to not have occurred, got: %v", err)
-			}
-		})
-	}
-}
+		},
+		Entry("invalid source",
+			"foo",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"", true),
+		Entry("invalid source tag",
+			"ghcr.io/mariadb-operator/mariadb-operator:",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"", true),
+		Entry("invalid source digest",
+			"ghcr.io/mariadb-operator/mariadb-operator@sha256:foo",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"", true),
+		Entry("invalid target",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"foo",
+			"", true),
+		Entry("invalid target tag",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"ghcr.io/mariadb-operator/mariadb-operator:",
+			"", true),
+		Entry("invalid target digest",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"ghcr.io/mariadb-operator/mariadb-operator@sha256:foo",
+			"", true),
+		Entry("no tag nor digest in source",
+			"ghcr.io/mariadb-operator/mariadb-operator",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"", true),
+		Entry("no tag nor digest in target",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"ghcr.io/mariadb-operator/mariadb-operator",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1", false),
+		Entry("tag source, tag target",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.2", false),
+		Entry("digest source, tag target",
+			"ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
+			false),
+		Entry("tag source, digest target",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
+			"ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.2", false),
+		Entry("digest source, digest target",
+			"ghcr.io/mariadb-operator/mariadb-operator@sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3",
+			"ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
+			"ghcr.io/mariadb-operator/mariadb-operator@sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3",
+			false),
+		Entry("different host",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
+			"registry.mycorp.io/mariadb-operator/mariadb-operator:v0.0.1",
+			"registry.mycorp.io/mariadb-operator/mariadb-operator:v0.0.2", false),
+		Entry("different host, namespace and image",
+			"ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
+			"registry.mycorp.io/mdb-op/mdb-op:v0.0.1",
+			"registry.mycorp.io/mdb-op/mdb-op:v0.0.2", false),
+	)
+})
 
-// nolint:lll
-func TestSetTagOrDigest(t *testing.T) {
-	tests := []struct {
-		name        string
-		sourceImage string
-		targetImage string
-		wantImage   string
-		wantErr     bool
-	}{
-		{
-			name:        "invalid source",
-			sourceImage: "foo",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			wantImage:   "",
-			wantErr:     true,
+var _ = Describe("GetDigest", func() {
+	// nolint:lll
+	DescribeTable("returns the digest of an image",
+		func(image string, wantDig string, wantErr bool) {
+			dig, err := GetDigest(image)
+			Expect(dig).To(Equal(wantDig))
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
 		},
-		{
-			name:        "invalid source tag",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator:",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			wantImage:   "",
-			wantErr:     true,
-		},
-		{
-			name:        "invalid source digest",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator@sha256:foo",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			wantImage:   "",
-			wantErr:     true,
-		},
-		{
-			name:        "invalid target",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			targetImage: "foo",
-			wantImage:   "",
-			wantErr:     true,
-		},
-		{
-			name:        "invalid target tag",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator:",
-			wantImage:   "",
-			wantErr:     true,
-		},
-		{
-			name:        "invalid target digest",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator@sha256:foo",
-			wantImage:   "",
-			wantErr:     true,
-		},
-		{
-			name:        "no tag nor digest in source",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			wantImage:   "",
-			wantErr:     true,
-		},
-		{
-			name:        "no tag nor digest in target",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator",
-			wantImage:   "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			wantErr:     false,
-		},
-		{
-			name:        "tag source, tag target",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			wantImage:   "ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
-			wantErr:     false,
-		},
-		{
-			name:        "digest source, tag target",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.1",
-			wantImage:   "ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
-			wantErr:     false,
-		},
-		{
-			name:        "tag source, digest target",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
-			wantImage:   "ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
-			wantErr:     false,
-		},
-		{
-			name:        "digest source, digest target",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator@sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3",
-			targetImage: "ghcr.io/mariadb-operator/mariadb-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
-			wantImage:   "ghcr.io/mariadb-operator/mariadb-operator@sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3",
-			wantErr:     false,
-		},
-		{
-			name:        "different host",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
-			targetImage: "registry.mycorp.io/mariadb-operator/mariadb-operator:v0.0.1",
-			wantImage:   "registry.mycorp.io/mariadb-operator/mariadb-operator:v0.0.2",
-			wantErr:     false,
-		},
-		{
-			name:        "different host, namespace and image",
-			sourceImage: "ghcr.io/mariadb-operator/mariadb-operator:v0.0.2",
-			targetImage: "registry.mycorp.io/mdb-op/mdb-op:v0.0.1",
-			wantImage:   "registry.mycorp.io/mdb-op/mdb-op:v0.0.2",
-			wantErr:     false,
-		},
-	}
+		Entry("invalid image", "foo", "", true),
+		Entry("empty digest", "mariadb@", "", true),
+		Entry("digest",
+			"docker.mariadb.com/enterprise-server@sha256:32ba72a21a2875b783887ecd4dcd7fd575a34cf253295e2bfa5ecd751545be37",
+			"sha256:32ba72a21a2875b783887ecd4dcd7fd575a34cf253295e2bfa5ecd751545be37", false),
+		Entry("tag", "docker.mariadb.com/enterprise-server:11.8.3-1", "", true),
+		Entry("image with host and digest",
+			"registry.mycorp.io/ns/img@sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3",
+			"sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3", false),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			image, err := SetTagOrDigest(tt.sourceImage, tt.targetImage)
-			if tt.wantImage != image {
-				t.Errorf("unexpected image, expected: %v got: %v", tt.wantImage, image)
-			}
-			if tt.wantErr && err == nil {
-				t.Error("expect error to have occurred, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("expect error to not have occurred, got: %v", err)
-			}
-		})
-	}
-}
-
-// nolint:lll
-func TestGetDigest(t *testing.T) {
-	tests := []struct {
-		name    string
-		image   string
-		wantDig string
-		wantErr bool
-	}{
-		{
-			name:    "invalid image",
-			image:   "foo",
-			wantDig: "",
-			wantErr: true,
+var _ = Describe("HasTagOrDigest", func() {
+	// nolint:lll
+	DescribeTable("returns whether an image has a tag or digest",
+		func(image string, want bool) {
+			ok := HasTagOrDigest(image)
+			Expect(ok).To(Equal(want))
 		},
-		{
-			name:    "empty digest",
-			image:   "mariadb@",
-			wantDig: "",
-			wantErr: true,
-		},
-		{
-			name:    "digest",
-			image:   "docker.mariadb.com/enterprise-server@sha256:32ba72a21a2875b783887ecd4dcd7fd575a34cf253295e2bfa5ecd751545be37",
-			wantDig: "sha256:32ba72a21a2875b783887ecd4dcd7fd575a34cf253295e2bfa5ecd751545be37",
-			wantErr: false,
-		},
-		{
-			name:    "tag",
-			image:   "docker.mariadb.com/enterprise-server:11.8.3-1",
-			wantDig: "",
-			wantErr: true,
-		},
-		{
-			name:    "image with host and digest",
-			image:   "registry.mycorp.io/ns/img@sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3",
-			wantDig: "sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3",
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dig, err := GetDigest(tt.image)
-			if tt.wantDig != dig {
-				t.Errorf("unexpected digest, expected: %v got: %v", tt.wantDig, dig)
-			}
-			if tt.wantErr && err == nil {
-				t.Error("expect error to have occurred, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("expect error to not have occurred, got: %v", err)
-			}
-		})
-	}
-}
-
-// nolint:lll
-func TestHasTagOrDigest(t *testing.T) {
-	tests := []struct {
-		name  string
-		image string
-		want  bool
-	}{
-		{
-			name:  "invalid image",
-			image: "foo",
-			want:  false,
-		},
-		{
-			name:  "plain image",
-			image: "mariadb",
-			want:  false,
-		},
-		{
-			name:  "tagged image",
-			image: "docker.mariadb.com/enterprise-server:11.8.3-1",
-			want:  true,
-		},
-		{
-			name:  "digested image",
-			image: "docker-registry3.mariadb.com/mariadb-enterprise-operator/mariadb-enterprise-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
-			want:  true,
-		},
-		{
-			name:  "empty tag",
-			image: "mariadb:",
-			want:  false,
-		},
-		{
-			name:  "empty digest",
-			image: "mariadb@",
-			want:  false,
-		},
-		{
-			name:  "tag and digest",
-			image: "registry.mycorp.io/ns/img:1.2@sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3",
-			want:  true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ok := HasTagOrDigest(tt.image)
-			if tt.want != ok {
-				t.Errorf("unexpected result, expected: %v got: %v", tt.want, ok)
-			}
-		})
-	}
-}
+		Entry("invalid image", "foo", false),
+		Entry("plain image", "mariadb", false),
+		Entry("tagged image", "docker.mariadb.com/enterprise-server:11.8.3-1", true),
+		Entry("digested image",
+			"ghcr.io/mariadb-enterprise-operator/mariadb-enterprise-operator@sha256:3f48454b6a33e094af6d23ced54645ec0533cb11854d07738920852ca48e390d",
+			true),
+		Entry("empty tag", "mariadb:", false),
+		Entry("empty digest", "mariadb@", false),
+		Entry("tag and digest",
+			"registry.mycorp.io/ns/img:1.2@sha256:5e3d39d26829673c7b4f6f21fb1d57902c9bb64367a76dc2b74e5909027f25a3",
+			true),
+	)
+})

--- a/pkg/docker/suite_test.go
+++ b/pkg/docker/suite_test.go
@@ -1,0 +1,13 @@
+package docker
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDocker(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Docker Suite")
+}


### PR DESCRIPTION
Migrates `pkg/docker` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified relative to the base branch.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `reference_test.go` converted to a `Describe` block with `DescribeTable` specs. Entry/spec names match the original test / `t.Run()` names.

Verified with:
```
go test ./pkg/docker/...
```

Part of #368.
