### PR TITLE
test: migrate pkg/galera/config tests to Ginkgo

### DIFF
--- a/pkg/galera/config/config_test.go
+++ b/pkg/galera/config/config_test.go
@@ -1,27 +1,31 @@
 package config
 
 import (
-	"testing"
-
 	"github.com/go-logr/logr"
-	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/environment"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
-func TestGaleraConfigMarshal(t *testing.T) {
-	tests := []struct {
-		name       string
-		mariadb    *mariadbv1alpha1.MariaDB
-		podEnv     *environment.PodEnvironment
-		wantConfig string
-		wantErr    bool
-	}{
-		{
-			name: "no replicas",
-			mariadb: &mariadbv1alpha1.MariaDB{
+var _ = Describe("Galera config marshal", func() {
+	DescribeTable("marshaling a Galera config",
+		func(mariadb *mariadbv1alpha1.MariaDB, podEnv *environment.PodEnvironment, wantConfig string, wantErr bool) {
+			bytes, err := NewConfigFile(mariadb, logr.Discard()).Marshal(podEnv)
+
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Expect(string(bytes)).To(Equal(wantConfig))
+		},
+		Entry(
+			"no replicas",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -37,17 +41,17 @@ func TestGaleraConfigMarshal(t *testing.T) {
 					Replicas: 0,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-0",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
 			},
-			wantConfig: "",
-			wantErr:    true,
-		},
-		{
-			name: "multicluster all params",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			"",
+			true,
+		),
+		Entry(
+			"multicluster all params",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -69,13 +73,13 @@ func TestGaleraConfigMarshal(t *testing.T) {
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-1",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
 			},
 			//nolint:lll
-			wantConfig: `[mariadb]
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -108,11 +112,11 @@ wsrep_gtid_domain_id=0
 gtid_domain_id=2
 server_id=100
 `,
-			wantErr: false,
-		},
-		{
-			name: "multicluster invalid Pod",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry(
+			"multicluster invalid Pod",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -134,17 +138,17 @@ server_id=100
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "test",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
 			},
-			wantConfig: "",
-			wantErr:    true,
-		},
-		{
-			name: "multicluster missing params",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			"",
+			true,
+		),
+		Entry(
+			"multicluster missing params",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -165,13 +169,13 @@ server_id=100
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-1",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
 			},
 			//nolint:lll
-			wantConfig: `[mariadb]
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -196,11 +200,11 @@ wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="10.244.0.32:4444"
 `,
-			wantErr: false,
-		},
-		{
-			name: "Galera not enabled",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry(
+			"Galera not enabled",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -212,17 +216,17 @@ wsrep_sst_receive_address="10.244.0.32:4444"
 					Replicas: 0,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-0",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
 			},
-			wantConfig: "",
-			wantErr:    true,
-		},
-		{
-			name: "invalid IP",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			"",
+			true,
+		),
+		Entry(
+			"invalid IP",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -234,17 +238,17 @@ wsrep_sst_receive_address="10.244.0.32:4444"
 					Replicas: 0,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-0",
 				PodIP:               "foo",
 				MariadbRootPassword: "mariadb",
 			},
-			wantConfig: "",
-			wantErr:    true,
-		},
-		{
-			name: "rsync",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			"",
+			true,
+		),
+		Entry(
+			"rsync",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -261,13 +265,13 @@ wsrep_sst_receive_address="10.244.0.32:4444"
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-0",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
 			},
 			//nolint:lll
-			wantConfig: `[mariadb]
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -291,11 +295,11 @@ wsrep_provider_options="gmcast.listen_addr=tcp://0.0.0.0:4567;ist.recv_addr=10.2
 wsrep_sst_method="rsync"
 wsrep_sst_receive_address="10.244.0.32:4444"
 `,
-			wantErr: false,
-		},
-		{
-			name: "mariabackup",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry(
+			"mariabackup",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -312,13 +316,13 @@ wsrep_sst_receive_address="10.244.0.32:4444"
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-1",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
 			},
 			//nolint:lll
-			wantConfig: `[mariadb]
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -343,11 +347,11 @@ wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="10.244.0.32:4444"
 `,
-			wantErr: false,
-		},
-		{
-			name: "IPv6",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry(
+			"IPv6",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -364,13 +368,13 @@ wsrep_sst_receive_address="10.244.0.32:4444"
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-1",
 				PodIP:               "2001:db8::a1",
 				MariadbRootPassword: "mariadb",
 			},
 			//nolint:lll
-			wantConfig: `[mariadb]
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -395,11 +399,11 @@ wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="[2001:db8::a1]:4444"
 `,
-			wantErr: false,
-		},
-		{
-			name: "Additional WSREP provider options",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry(
+			"Additional WSREP provider options",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -420,13 +424,13 @@ wsrep_sst_receive_address="[2001:db8::a1]:4444"
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-1",
 				PodIP:               "2001:db8::a1",
 				MariadbRootPassword: "mariadb",
 			},
 			//nolint:lll
-			wantConfig: `[mariadb]
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -451,11 +455,11 @@ wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="[2001:db8::a1]:4444"
 `,
-			wantErr: false,
-		},
-		{
-			name: "TLS",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry(
+			"TLS",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -478,7 +482,7 @@ wsrep_sst_receive_address="[2001:db8::a1]:4444"
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-1",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
@@ -490,7 +494,7 @@ wsrep_sst_receive_address="[2001:db8::a1]:4444"
 				TLSClientKeyPath:    "/etc/pki/client.key",
 			},
 			//nolint:lll
-			wantConfig: `[mariadb]
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -520,11 +524,11 @@ tca=/etc/pki/ca.crt
 tcert=/etc/pki/client.crt
 tkey=/etc/pki/client.key
 `,
-			wantErr: false,
-		},
-		{
-			name: "TLS with Galera SST disabled",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry(
+			"TLS with Galera SST disabled",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -547,7 +551,7 @@ tkey=/etc/pki/client.key
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-1",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
@@ -559,7 +563,7 @@ tkey=/etc/pki/client.key
 				TLSClientKeyPath:    "/etc/pki/client.key",
 			},
 			//nolint:lll
-			wantConfig: `[mariadb]
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -584,11 +588,11 @@ wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="10.244.0.32:4444"
 `,
-			wantErr: false,
-		},
-		{
-			name: "TLS with required disabled",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry(
+			"TLS with required disabled",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: v1.ObjectMeta{
 					Name:      "mariadb-galera",
 					Namespace: "default",
@@ -611,7 +615,7 @@ wsrep_sst_receive_address="10.244.0.32:4444"
 					Replicas: 3,
 				},
 			},
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodName:             "mariadb-galera-1",
 				PodIP:               "10.244.0.32",
 				MariadbRootPassword: "mariadb",
@@ -623,7 +627,7 @@ wsrep_sst_receive_address="10.244.0.32:4444"
 				TLSClientKeyPath:    "/etc/pki/client.key",
 			},
 			//nolint:lll
-			wantConfig: `[mariadb]
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -653,38 +657,25 @@ tca=/etc/pki/ca.crt
 tcert=/etc/pki/client.crt
 tkey=/etc/pki/client.key
 `,
-			wantErr: false,
+			false,
+		),
+	)
+})
+
+var _ = Describe("Galera config update", func() {
+	DescribeTable("updating a Galera config",
+		func(config string, podEnv *environment.PodEnvironment, wantConfig []byte, wantErr bool) {
+			bytes, err := UpdateConfig([]byte(config), podEnv)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Expect(string(bytes)).To(Equal(string(wantConfig)))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bytes, err := NewConfigFile(tt.mariadb, logr.Discard()).Marshal(tt.podEnv)
-
-			if tt.wantErr && err == nil {
-				t.Error("expect error to have occurred, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("expect error to not have occurred, got: %v", err)
-			}
-			if diff := cmp.Diff(tt.wantConfig, string(bytes)); diff != "" {
-				t.Errorf("unexpected config (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestGaleraConfigUpdate(t *testing.T) {
-	tests := []struct {
-		name       string
-		config     string
-		podEnv     *environment.PodEnvironment
-		wantConfig []byte
-		wantErr    bool
-	}{
-		{
-			name: "invalid IP",
-			config: `[mariadb]
+		Entry(
+			"invalid IP",
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -708,15 +699,15 @@ wsrep_provider_options="gmcast.listen_addr=tcp://0.0.0.0:4567;ist.recv_addr=10.2
 wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="10.244.0.32:4444"`,
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodIP: "foo",
 			},
-			wantConfig: nil,
-			wantErr:    true,
-		},
-		{
-			name: "IPv4",
-			config: `[mariadb]
+			nil,
+			true,
+		),
+		Entry(
+			"IPv4",
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -740,10 +731,10 @@ wsrep_provider_options="gmcast.listen_addr=tcp://0.0.0.0:4567;ist.recv_addr=10.2
 wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="10.244.0.32:4444"`,
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodIP: "10.244.0.33",
 			},
-			wantConfig: []byte(`[mariadb]
+			[]byte(`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -767,11 +758,11 @@ wsrep_provider_options="gmcast.listen_addr=tcp://0.0.0.0:4567;ist.recv_addr=10.2
 wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="10.244.0.33:4444"`),
-			wantErr: false,
-		},
-		{
-			name: "IPv6",
-			config: `[mariadb]
+			false,
+		),
+		Entry(
+			"IPv6",
+			`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -795,10 +786,10 @@ wsrep_provider_options="gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp:/
 wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="[2001:db8::a1]:4444"`,
-			podEnv: &environment.PodEnvironment{
+			&environment.PodEnvironment{
 				PodIP: "2001:db8::a2",
 			},
-			wantConfig: []byte(`[mariadb]
+			[]byte(`[mariadb]
 bind_address=*
 default_storage_engine=InnoDB
 binlog_format=row
@@ -822,21 +813,7 @@ wsrep_provider_options="gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp:/
 wsrep_sst_method="mariabackup"
 wsrep_sst_auth="root:mariadb"
 wsrep_sst_receive_address="[2001:db8::a2]:4444"`),
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bytes, err := UpdateConfig([]byte(tt.config), tt.podEnv)
-			if tt.wantErr && err == nil {
-				t.Error("error expected, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("error unexpected, got %v", err)
-			}
-			if diff := cmp.Diff(string(tt.wantConfig), string(bytes)); diff != "" {
-				t.Errorf("unexpected config (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
+			false,
+		),
+	)
+})

--- a/pkg/galera/config/kv_option_test.go
+++ b/pkg/galera/config/kv_option_test.go
@@ -1,119 +1,100 @@
 package config
 
 import (
-	"reflect"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestKvOptionMarshal(t *testing.T) {
-	tests := []struct {
-		name       string
-		kvOpt      *kvOption
-		wantString string
-	}{
-		{
-			name:       "unquoted",
-			kvOpt:      newKvOption("gmcast.listen_addr", "tcp://0.0.0.0:4567", false),
-			wantString: "gmcast.listen_addr=tcp://0.0.0.0:4567",
+var _ = Describe("kvOption marshal", func() {
+	DescribeTable("marshaling a kvOption",
+		func(kvOpt *kvOption, wantString string) {
+			gotString := kvOpt.marshal()
+			Expect(gotString).To(Equal(wantString))
 		},
-		{
-			name:       "unquoted with multiple values",
-			kvOpt:      newKvOption("wsrep_provider_options", "gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568", false),
-			wantString: "wsrep_provider_options=gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568",
-		},
-		{
-			name:       "quoted",
-			kvOpt:      newKvOption("wsrep_node_address", "10.244.0.33", true),
-			wantString: "wsrep_node_address=\"10.244.0.33\"",
-		},
-		{
-			name:       "quoted with multiple values",
-			kvOpt:      newKvOption("wsrep_provider_options", "gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568", true),
-			wantString: "wsrep_provider_options=\"gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568\"",
-		},
-	}
+		Entry(
+			"unquoted",
+			newKvOption("gmcast.listen_addr", "tcp://0.0.0.0:4567", false),
+			"gmcast.listen_addr=tcp://0.0.0.0:4567",
+		),
+		Entry(
+			"unquoted with multiple values",
+			newKvOption("wsrep_provider_options", "gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568", false),
+			"wsrep_provider_options=gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568",
+		),
+		Entry(
+			"quoted",
+			newKvOption("wsrep_node_address", "10.244.0.33", true),
+			"wsrep_node_address=\"10.244.0.33\"",
+		),
+		Entry(
+			"quoted with multiple values",
+			newKvOption("wsrep_provider_options", "gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568", true),
+			"wsrep_provider_options=\"gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568\"",
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotString := tt.kvOpt.marshal()
-			if tt.wantString != gotString {
-				t.Errorf("unexpected result:\nexpected:\n%s\ngot:\n%s\n", tt.wantString, gotString)
+var _ = Describe("kvOption unmarshal", func() {
+	DescribeTable("unmarshaling a kvOption",
+		func(rawKvOpt string, wantKvOpt kvOption, wantErr bool) {
+			var kvOpt kvOption
+			err := kvOpt.unmarshal(rawKvOpt)
+			if !wantErr {
+				Expect(err).NotTo(HaveOccurred())
 			}
-		})
-	}
-}
-
-func TestKvOptionUnmarshal(t *testing.T) {
-	tests := []struct {
-		name      string
-		rawKvOpt  string
-		wantKvOpt kvOption
-		wantErr   bool
-	}{
-		{
-			name:      "empty",
-			rawKvOpt:  " ",
-			wantKvOpt: kvOption{},
-			wantErr:   true,
+			Expect(kvOpt).To(Equal(wantKvOpt))
 		},
-		{
-			name:      "invalid",
-			rawKvOpt:  "wsrep_node_address: 2001:db8::a2",
-			wantKvOpt: kvOption{},
-			wantErr:   true,
-		},
-		{
-			name:     "unquoted",
-			rawKvOpt: "wsrep_cluster_name=mariadb-operator",
-			wantKvOpt: kvOption{
+		Entry(
+			"empty",
+			" ",
+			kvOption{},
+			true,
+		),
+		Entry(
+			"invalid",
+			"wsrep_node_address: 2001:db8::a2",
+			kvOption{},
+			true,
+		),
+		Entry(
+			"unquoted",
+			"wsrep_cluster_name=mariadb-operator",
+			kvOption{
 				key:    "wsrep_cluster_name",
 				value:  "mariadb-operator",
 				quoted: false,
 			},
-			wantErr: false,
-		},
-		{
-			name:     "quoted with multiple values",
-			rawKvOpt: "wsrep_provider_options=gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568",
-			wantKvOpt: kvOption{
+			false,
+		),
+		Entry(
+			"quoted with multiple values",
+			"wsrep_provider_options=gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568",
+			kvOption{
 				key:    "wsrep_provider_options",
 				value:  "gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568",
 				quoted: false,
 			},
-			wantErr: false,
-		},
-		{
-			name:     "quoted",
-			rawKvOpt: "wsrep_sst_receive_address=\"[2001:db8::a2]:4444\"",
-			wantKvOpt: kvOption{
+			false,
+		),
+		Entry(
+			"quoted",
+			"wsrep_sst_receive_address=\"[2001:db8::a2]:4444\"",
+			kvOption{
 				key:    "wsrep_sst_receive_address",
 				value:  "[2001:db8::a2]:4444",
 				quoted: true,
 			},
-			wantErr: false,
-		},
-		{
-			name:     "quoted with multiple values",
-			rawKvOpt: "wsrep_provider_options=\"gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568\"",
-			wantKvOpt: kvOption{
+			false,
+		),
+		Entry(
+			"quoted with multiple values",
+			"wsrep_provider_options=\"gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568\"",
+			kvOption{
 				key:    "wsrep_provider_options",
 				value:  "gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568",
 				quoted: true,
 			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var kvOpt kvOption
-			err := kvOpt.unmarshal(tt.rawKvOpt)
-			if !tt.wantErr && err != nil {
-				t.Errorf("error unexpected, got %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantKvOpt, kvOpt) {
-				t.Errorf("unexpected result:\nexpected:\n%v\ngot:\n%v\n", tt.wantKvOpt, kvOpt)
-			}
-		})
-	}
-}
+			false,
+		),
+	)
+})

--- a/pkg/galera/config/provider_options_test.go
+++ b/pkg/galera/config/provider_options_test.go
@@ -1,102 +1,96 @@
 package config
 
 import (
-	"reflect"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func TestProviderOptsMarshal(t *testing.T) {
-	tests := []struct {
-		name         string
-		providerOpts *providerOptions
-		wantString   string
-	}{
-		{
-			name:         "empty",
-			providerOpts: newProviderOptions(map[string]string{}),
-			wantString:   "",
+var _ = Describe("providerOptions marshal", func() {
+	DescribeTable("marshaling providerOptions",
+		func(providerOpts *providerOptions, wantString string) {
+			gotString := providerOpts.marshal()
+			Expect(gotString).To(Equal(wantString))
 		},
-		{
-			name: "single option",
-			providerOpts: newProviderOptions(map[string]string{
+		Entry(
+			"empty",
+			newProviderOptions(map[string]string{}),
+			"",
+		),
+		Entry(
+			"single option",
+			newProviderOptions(map[string]string{
 				"gmcast.listen_addr": "tcp://0.0.0.0:4567",
 			}),
-			wantString: "gmcast.listen_addr=tcp://0.0.0.0:4567",
-		},
-		{
-			name: "multiple options",
-			providerOpts: newProviderOptions(map[string]string{
+			"gmcast.listen_addr=tcp://0.0.0.0:4567",
+		),
+		Entry(
+			"multiple options",
+			newProviderOptions(map[string]string{
 				"gcache.size":   "1G",
 				"gcs.fc_limit":  "128",
 				"ist.recv_addr": "[2001:db8::a1]:4568",
 			}),
-			wantString: "gcache.size=1G;gcs.fc_limit=128;ist.recv_addr=[2001:db8::a1]:4568",
-		},
-	}
+			"gcache.size=1G;gcs.fc_limit=128;ist.recv_addr=[2001:db8::a1]:4568",
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotString := tt.providerOpts.marshal()
-			if tt.wantString != gotString {
-				t.Errorf("unexpected result:\nexpected:\n%s\ngot:\n%s\n", tt.wantString, gotString)
+var _ = Describe("providerOptions unmarshal", func() {
+	DescribeTable("unmarshaling providerOptions",
+		func(rawProviderOpts string, wantProviderOpts providerOptions, wantErr bool) {
+			var providerOpts providerOptions
+			err := providerOpts.unmarshal(rawProviderOpts)
+			if !wantErr {
+				Expect(err).NotTo(HaveOccurred())
 			}
-		})
-	}
-}
-
-func TestProviderOptsUnmarshal(t *testing.T) {
-	tests := []struct {
-		name             string
-		rawProviderOpts  string
-		wantProviderOpts providerOptions
-		wantErr          bool
-	}{
-		{
-			name:             "empty",
-			rawProviderOpts:  " ",
-			wantProviderOpts: providerOptions{},
-			wantErr:          true,
+			Expect(providerOpts).To(Equal(wantProviderOpts))
 		},
-		{
-			name:            "single invalid option",
-			rawProviderOpts: "gmcast.listen_addr",
-			wantProviderOpts: providerOptions{
+		Entry(
+			"empty",
+			" ",
+			providerOptions{},
+			true,
+		),
+		Entry(
+			"single invalid option",
+			"gmcast.listen_addr",
+			providerOptions{
 				make(map[string]string, 0),
 			},
-			wantErr: true,
-		},
-		{
-			name:            "multiple invalid options",
-			rawProviderOpts: "gmcast.listen_addr;ist.recv_addr",
-			wantProviderOpts: providerOptions{
+			true,
+		),
+		Entry(
+			"multiple invalid options",
+			"gmcast.listen_addr;ist.recv_addr",
+			providerOptions{
 				make(map[string]string, 0),
 			},
-			wantErr: true,
-		},
-		{
-			name:            "some invalid options",
-			rawProviderOpts: "gmcast.listen_addr=tcp://[::]:4567;gcs.fc_limit;ist.recv_addr",
-			wantProviderOpts: providerOptions{
+			true,
+		),
+		Entry(
+			"some invalid options",
+			"gmcast.listen_addr=tcp://[::]:4567;gcs.fc_limit;ist.recv_addr",
+			providerOptions{
 				opts: map[string]string{
 					"gmcast.listen_addr": "tcp://[::]:4567",
 				},
 			},
-			wantErr: true,
-		},
-		{
-			name:            "single option",
-			rawProviderOpts: "gmcast.listen_addr=tcp://[::]:4567",
-			wantProviderOpts: providerOptions{
+			true,
+		),
+		Entry(
+			"single option",
+			"gmcast.listen_addr=tcp://[::]:4567",
+			providerOptions{
 				opts: map[string]string{
 					"gmcast.listen_addr": "tcp://[::]:4567",
 				},
 			},
-			wantErr: false,
-		},
-		{
-			name:            "multiple options",
-			rawProviderOpts: "gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568",
-			wantProviderOpts: providerOptions{
+			false,
+		),
+		Entry(
+			"multiple options",
+			"gcache.size=1G;gcs.fc_limit=128;gmcast.listen_addr=tcp://[::]:4567;ist.recv_addr=[2001:db8::a1]:4568",
+			providerOptions{
 				opts: map[string]string{
 					"gcache.size":        "1G",
 					"gcs.fc_limit":       "128",
@@ -104,20 +98,7 @@ func TestProviderOptsUnmarshal(t *testing.T) {
 					"ist.recv_addr":      "[2001:db8::a1]:4568",
 				},
 			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var providerOpts providerOptions
-			err := providerOpts.unmarshal(tt.rawProviderOpts)
-			if !tt.wantErr && err != nil {
-				t.Errorf("error unexpected, got %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantProviderOpts, providerOpts) {
-				t.Errorf("unexpected result:\nexpected:\n%v\ngot:\n%v\n", tt.wantProviderOpts, providerOpts)
-			}
-		})
-	}
-}
+			false,
+		),
+	)
+})

--- a/pkg/galera/config/suite_test.go
+++ b/pkg/galera/config/suite_test.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGaleraConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Galera Config Suite")
+}


### PR DESCRIPTION
Migrates `pkg/galera/config` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified relative to the base branch.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `config_test.go`, `kv_option_test.go` and `provider_options_test.go` converted to `Describe` blocks with `DescribeTable` specs. Entry/spec names match the original test / `t.Run()` names.

Verified with:
```
go test ./pkg/galera/config/...
```

Part of #368.
