### PR TITLE
test: migrate pkg/controller/replication tests to Ginkgo

### DIFF
--- a/pkg/controller/replication/config_test.go
+++ b/pkg/controller/replication/config_test.go
@@ -2,112 +2,118 @@ package replication
 
 import (
 	"strings"
-	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	env "github.com/mariadb-operator/mariadb-operator/v26/pkg/environment"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 )
 
-func TestNewReplicationConfig(t *testing.T) {
-	tests := []struct {
-		name       string
-		env        *env.PodEnvironment
-		wantConfig string
-		wantErr    bool
-	}{
-		{
-			name: "replication disabled",
-			env: &env.PodEnvironment{
+var _ = Describe("NewReplicationConfig", func() {
+	DescribeTable("builds the replication config",
+		func(podEnv *env.PodEnvironment, wantConfig string, wantErr bool) {
+			config, err := NewReplicationConfig(podEnv)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			// Compare as normalized strings (avoids surprises with newlines/whitespace)
+			got := strings.TrimSpace(string(config))
+			want := strings.TrimSpace(wantConfig)
+
+			Expect(got).To(Equal(want))
+		},
+		Entry("replication disabled",
+			&env.PodEnvironment{
 				PodName:            "mariadb-0",
 				MariadbName:        "mariadb",
 				MariaDBReplEnabled: "foo",
 			},
-			wantErr: true,
-		},
-		{
-			name: "invalid GTID strict mode",
-			env: &env.PodEnvironment{
+			"",
+			true,
+		),
+		Entry("invalid GTID strict mode",
+			&env.PodEnvironment{
 				PodName:                   "mariadb-0",
 				MariadbName:               "mariadb",
 				MariaDBReplEnabled:        "true",
 				MariaDBReplGtidStrictMode: "foo",
 			},
-			wantErr: true,
-		},
-		{
-			name: "invalid semi-sync enabled",
-			env: &env.PodEnvironment{
+			"",
+			true,
+		),
+		Entry("invalid semi-sync enabled",
+			&env.PodEnvironment{
 				PodName:                    "mariadb-0",
 				MariadbName:                "mariadb",
 				MariaDBReplEnabled:         "true",
 				MariaDBReplSemiSyncEnabled: "foo",
 			},
-			wantErr: true,
-		},
-		{
-			name: "invalid semi-sync master timeout",
-			env: &env.PodEnvironment{
+			"",
+			true,
+		),
+		Entry("invalid semi-sync master timeout",
+			&env.PodEnvironment{
 				PodName:                          "mariadb-0",
 				MariadbName:                      "mariadb",
 				MariaDBReplEnabled:               "true",
 				MariaDBReplSemiSyncMasterTimeout: "foo",
 			},
-			wantErr: true,
-		},
-		{
-			name: "invalid server ID",
-			env: &env.PodEnvironment{
+			"",
+			true,
+		),
+		Entry("invalid server ID",
+			&env.PodEnvironment{
 				PodName:            "foo",
 				MariadbName:        "mariadb",
 				MariaDBReplEnabled: "true",
 			},
-			wantErr: true,
-		},
-		{
-			name: "invalid master sync binlog",
-			env: &env.PodEnvironment{
+			"",
+			true,
+		),
+		Entry("invalid master sync binlog",
+			&env.PodEnvironment{
 				PodName:                     "mariadb-0",
 				MariadbName:                 "mariadb",
 				MariaDBReplEnabled:          "true",
 				MariaDBReplMasterSyncBinlog: "foo",
 			},
-			wantErr: true,
-		},
-		{
-			name: "minimal replication enabled",
-			env: &env.PodEnvironment{
+			"",
+			true,
+		),
+		Entry("minimal replication enabled",
+			&env.PodEnvironment{
 				PodName:            "mariadb-0",
 				MariadbName:        "mariadb",
 				MariaDBReplEnabled: "true",
 			},
-			wantConfig: `[mariadb]
+			`[mariadb]
 log_bin
 log_basename=mariadb
 server_id=10
 `,
-			wantErr: false,
-		},
-		{
-			name: "minimal semi-sync replication enabled",
-			env: &env.PodEnvironment{
+			false,
+		),
+		Entry("minimal semi-sync replication enabled",
+			&env.PodEnvironment{
 				PodName:                    "mariadb-0",
 				MariadbName:                "mariadb",
 				MariaDBReplEnabled:         "true",
 				MariaDBReplSemiSyncEnabled: "true",
 			},
-			wantConfig: `[mariadb]
+			`[mariadb]
 log_bin
 log_basename=mariadb
 rpl_semi_sync_master_enabled=ON
 rpl_semi_sync_slave_enabled=ON
 server_id=10
 `,
-			wantErr: false,
-		},
-		{
-			name: "missing semi-sync master timeout",
-			env: &env.PodEnvironment{
+			false,
+		),
+		Entry("missing semi-sync master timeout",
+			&env.PodEnvironment{
 				PodName:                            "mariadb-0",
 				MariadbName:                        "mariadb",
 				MariaDBReplEnabled:                 "true",
@@ -116,7 +122,7 @@ server_id=10
 				MariaDBReplSemiSyncMasterWaitPoint: "AFTER_SYNC",
 				MariaDBReplMasterSyncBinlog:        "1",
 			},
-			wantConfig: `[mariadb]
+			`[mariadb]
 log_bin
 log_basename=mariadb
 gtid_strict_mode
@@ -126,11 +132,10 @@ rpl_semi_sync_master_wait_point=AFTER_SYNC
 server_id=10
 sync_binlog=1
 `,
-			wantErr: false,
-		},
-		{
-			name: "missing semi-sync master wait point",
-			env: &env.PodEnvironment{
+			false,
+		),
+		Entry("missing semi-sync master wait point",
+			&env.PodEnvironment{
 				PodName:                          "mariadb-0",
 				MariadbName:                      "mariadb",
 				MariaDBReplEnabled:               "true",
@@ -139,7 +144,7 @@ sync_binlog=1
 				MariaDBReplSemiSyncMasterTimeout: "5000",
 				MariaDBReplMasterSyncBinlog:      "1",
 			},
-			wantConfig: `[mariadb]
+			`[mariadb]
 log_bin
 log_basename=mariadb
 gtid_strict_mode
@@ -149,42 +154,39 @@ rpl_semi_sync_master_timeout=5000
 server_id=10
 sync_binlog=1
 `,
-			wantErr: false,
-		},
-		{
-			name: "with custom GTID domain ID",
-			env: &env.PodEnvironment{
+			false,
+		),
+		Entry("with custom GTID domain ID",
+			&env.PodEnvironment{
 				PodName:                 "mariadb-0",
 				MariadbName:             "mariadb",
 				MariaDBReplEnabled:      "true",
 				MariaDBReplGtidDomainID: "1",
 			},
-			wantConfig: `[mariadb]
+			`[mariadb]
 log_bin
 log_basename=mariadb
 gtid_domain_id=1
 server_id=10
 `,
-			wantErr: false,
-		},
-		{
-			name: "with custom server ID start index",
-			env: &env.PodEnvironment{
+			false,
+		),
+		Entry("with custom server ID start index",
+			&env.PodEnvironment{
 				PodName:                       "mariadb-2",
 				MariadbName:                   "mariadb",
 				MariaDBReplEnabled:            "true",
 				MariaDBReplServerIDStartIndex: "100",
 			},
-			wantConfig: `[mariadb]
+			`[mariadb]
 log_bin
 log_basename=mariadb
 server_id=102
 `,
-			wantErr: false,
-		},
-		{
-			name: "all values present",
-			env: &env.PodEnvironment{
+			false,
+		),
+		Entry("all values present",
+			&env.PodEnvironment{
 				PodName:                            "mariadb-0",
 				MariadbName:                        "mariadb",
 				MariaDBReplEnabled:                 "true",
@@ -196,7 +198,7 @@ server_id=102
 				MariaDBReplSemiSyncMasterWaitPoint: "AFTER_SYNC",
 				MariaDBReplMasterSyncBinlog:        "1",
 			},
-			wantConfig: `[mariadb]
+			`[mariadb]
 log_bin
 log_basename=mariadb
 gtid_strict_mode
@@ -208,275 +210,176 @@ rpl_semi_sync_master_wait_point=AFTER_SYNC
 server_id=100
 sync_binlog=1
 `,
-			wantErr: false,
-		},
-	}
+			false,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			config, err := NewReplicationConfig(tt.env)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
+var _ = Describe("GtidDomainID", func() {
+	DescribeTable("parses the GTID domain ID",
+		func(rawGtidDomain string, want *int, wantErr bool) {
+			got, err := gtidDomainID(rawGtidDomain)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
 
-			// Compare as normalized strings (avoids surprises with newlines/whitespace)
-			got := strings.TrimSpace(string(config))
-			want := strings.TrimSpace(tt.wantConfig)
+			Expect(got).To(Equal(want))
+		},
+		Entry("empty string returns nil",
+			"",
+			nil,
+			false,
+		),
+		Entry("valid GTID domain ID zero",
+			"0",
+			ptr.To(0),
+			false,
+		),
+		Entry("valid GTID domain ID",
+			"42",
+			ptr.To(42),
+			false,
+		),
+		Entry("valid GTID domain ID large",
+			"999999",
+			ptr.To(999999),
+			false,
+		),
+		Entry("invalid string",
+			"foo",
+			nil,
+			true,
+		),
+		Entry("invalid float",
+			"3.14",
+			nil,
+			true,
+		),
+		Entry("invalid with whitespace",
+			" 42 ",
+			nil,
+			true,
+		),
+	)
+})
 
-			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("unexpected config (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestGtidDomainID(t *testing.T) {
-	tests := []struct {
-		name          string
-		rawGtidDomain string
-		want          *int
-		wantErr       bool
-	}{
-		{
-			name:          "empty string returns nil",
-			rawGtidDomain: "",
-			want:          nil,
-			wantErr:       false,
-		},
-		{
-			name:          "valid GTID domain ID zero",
-			rawGtidDomain: "0",
-			want:          ptr.To(0),
-			wantErr:       false,
-		},
-		{
-			name:          "valid GTID domain ID",
-			rawGtidDomain: "42",
-			want:          ptr.To(42),
-			wantErr:       false,
-		},
-		{
-			name:          "valid GTID domain ID large",
-			rawGtidDomain: "999999",
-			want:          ptr.To(999999),
-			wantErr:       false,
-		},
-		{
-			name:          "invalid string",
-			rawGtidDomain: "foo",
-			want:          nil,
-			wantErr:       true,
-		},
-		{
-			name:          "invalid float",
-			rawGtidDomain: "3.14",
-			want:          nil,
-			wantErr:       true,
-		},
-		{
-			name:          "invalid with whitespace",
-			rawGtidDomain: " 42 ",
-			want:          nil,
-			wantErr:       true,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := gtidDomainID(tt.rawGtidDomain)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
+var _ = Describe("ServerIDStartIndex", func() {
+	DescribeTable("parses the server ID start index",
+		func(rawStartIndex string, want int, wantErr bool) {
+			got, err := serverIDStartIndex(rawStartIndex)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
 
-			if tt.want == nil && got != nil {
-				t.Fatalf("expected nil, got %v", *got)
-			}
-			if tt.want != nil && got == nil {
-				t.Fatalf("expected %v, got nil", *tt.want)
-			}
-			if tt.want != nil && got != nil && *tt.want != *got {
-				t.Errorf("expected %v, got %v", *tt.want, *got)
-			}
-		})
-	}
-}
+			Expect(got).To(Equal(want))
+		},
+		Entry("empty string returns default",
+			"",
+			10,
+			false,
+		),
+		Entry("valid start index zero",
+			"0",
+			0,
+			false,
+		),
+		Entry("valid start index",
+			"100",
+			100,
+			false,
+		),
+		Entry("valid start index large",
+			"999999",
+			999999,
+			false,
+		),
+		Entry("invalid string",
+			"foo",
+			0,
+			true,
+		),
+		Entry("invalid float",
+			"3.14",
+			0,
+			true,
+		),
+		Entry("invalid with whitespace",
+			" 10 ",
+			0,
+			true,
+		),
+	)
+})
 
-func TestServerIDStartIndex(t *testing.T) {
-	tests := []struct {
-		name          string
-		rawStartIndex string
-		want          int
-		wantErr       bool
-	}{
-		{
-			name:          "empty string returns default",
-			rawStartIndex: "",
-			want:          10,
-			wantErr:       false,
-		},
-		{
-			name:          "valid start index zero",
-			rawStartIndex: "0",
-			want:          0,
-			wantErr:       false,
-		},
-		{
-			name:          "valid start index",
-			rawStartIndex: "100",
-			want:          100,
-			wantErr:       false,
-		},
-		{
-			name:          "valid start index large",
-			rawStartIndex: "999999",
-			want:          999999,
-			wantErr:       false,
-		},
-		{
-			name:          "invalid string",
-			rawStartIndex: "foo",
-			want:          0,
-			wantErr:       true,
-		},
-		{
-			name:          "invalid float",
-			rawStartIndex: "3.14",
-			want:          0,
-			wantErr:       true,
-		},
-		{
-			name:          "invalid with whitespace",
-			rawStartIndex: " 10 ",
-			want:          0,
-			wantErr:       true,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := serverIDStartIndex(tt.rawStartIndex)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
+var _ = Describe("ServerID", func() {
+	DescribeTable("computes the server ID",
+		func(podName string, startIndex int, want int, wantErr bool) {
+			got, err := serverId(podName, startIndex)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
 
-			if got != tt.want {
-				t.Errorf("expected %d, got %d", tt.want, got)
-			}
-		})
-	}
-}
-
-func TestServerID(t *testing.T) {
-	tests := []struct {
-		name       string
-		podName    string
-		startIndex int
-		want       int
-		wantErr    bool
-	}{
-		{
-			name:       "first pod with default start index",
-			podName:    "mariadb-0",
-			startIndex: 10,
-			want:       10,
-			wantErr:    false,
+			Expect(got).To(Equal(want))
 		},
-		{
-			name:       "second pod with default start index",
-			podName:    "mariadb-1",
-			startIndex: 10,
-			want:       11,
-			wantErr:    false,
-		},
-		{
-			name:       "third pod with default start index",
-			podName:    "mariadb-2",
-			startIndex: 10,
-			want:       12,
-			wantErr:    false,
-		},
-		{
-			name:       "first pod with custom start index",
-			podName:    "mariadb-0",
-			startIndex: 100,
-			want:       100,
-			wantErr:    false,
-		},
-		{
-			name:       "second pod with custom start index",
-			podName:    "mariadb-1",
-			startIndex: 100,
-			want:       101,
-			wantErr:    false,
-		},
-		{
-			name:       "pod with zero start index",
-			podName:    "mariadb-5",
-			startIndex: 0,
-			want:       5,
-			wantErr:    false,
-		},
-		{
-			name:       "pod with large index",
-			podName:    "mariadb-99",
-			startIndex: 10,
-			want:       109,
-			wantErr:    false,
-		},
-		{
-			name:       "invalid pod name",
-			podName:    "foo",
-			startIndex: 10,
-			want:       0,
-			wantErr:    true,
-		},
-		{
-			name:       "pod name without number",
-			podName:    "mariadb",
-			startIndex: 10,
-			want:       0,
-			wantErr:    true,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := serverId(tt.podName, tt.startIndex)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if got != tt.want {
-				t.Errorf("expected %d, got %d", tt.want, got)
-			}
-		})
-	}
-}
+		Entry("first pod with default start index",
+			"mariadb-0",
+			10,
+			10,
+			false,
+		),
+		Entry("second pod with default start index",
+			"mariadb-1",
+			10,
+			11,
+			false,
+		),
+		Entry("third pod with default start index",
+			"mariadb-2",
+			10,
+			12,
+			false,
+		),
+		Entry("first pod with custom start index",
+			"mariadb-0",
+			100,
+			100,
+			false,
+		),
+		Entry("second pod with custom start index",
+			"mariadb-1",
+			100,
+			101,
+			false,
+		),
+		Entry("pod with zero start index",
+			"mariadb-5",
+			0,
+			5,
+			false,
+		),
+		Entry("pod with large index",
+			"mariadb-99",
+			10,
+			109,
+			false,
+		),
+		Entry("invalid pod name",
+			"foo",
+			10,
+			0,
+			true,
+		),
+		Entry("pod name without number",
+			"mariadb",
+			10,
+			0,
+			true,
+		),
+	)
+})

--- a/pkg/controller/replication/suite_test.go
+++ b/pkg/controller/replication/suite_test.go
@@ -1,0 +1,13 @@
+package replication
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReplicationController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Replication Controller Suite")
+}


### PR DESCRIPTION
Migrates `pkg/controller/replication` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified relative to the base branch.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `config_test.go` converted to 4 `Describe` blocks with `DescribeTable` specs (36 entries). Entry/spec names match the original test / `t.Run()` names.

Verified with:
```
go test ./pkg/controller/replication/...
```

Part of #368.
