### PR TITLE
test: migrate internal/helmtest tests to Ginkgo

### DIFF
--- a/internal/helmtest/mariadb_cluster_test.go
+++ b/internal/helmtest/mariadb_cluster_test.go
@@ -3,12 +3,12 @@ package test
 import (
 	"fmt"
 	"strconv"
-	"testing"
 	"time"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/gruntwork-io/terratest/modules/k8s"
 	"github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -23,401 +23,390 @@ var kubectlopts = &k8s.KubectlOptions{
 	Namespace: "default",
 }
 
-func TestClusterHelmMariaDB(t *testing.T) {
-	RegisterTestingT(t)
+var _ = Describe("MariaDB cluster Helm chart", func() {
+	It("renders the MariaDB resource", func() {
+		replicas := 3
+		storageSize := "1Gi"
+		rootPasswordSecretKeyRefKey := "root"
+		rootPasswordSecretKeyRefName := "mariadb"
 
-	replicas := 3
-	storageSize := "1Gi"
-	rootPasswordSecretKeyRefKey := "root"
-	rootPasswordSecretKeyRefName := "mariadb"
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"mariadb.galera.enabled":                "true",
+				"mariadb.metrics.enabled":               "true",
+				"mariadb.replicas":                      strconv.Itoa(replicas),
+				"mariadb.storage.size":                  storageSize,
+				"mariadb.rootPasswordSecretKeyRef.key":  rootPasswordSecretKeyRefKey,
+				"mariadb.rootPasswordSecretKeyRef.name": rootPasswordSecretKeyRefName,
+			},
+			KubectlOptions: kubectlopts,
+		}
 
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"mariadb.galera.enabled":                "true",
-			"mariadb.metrics.enabled":               "true",
-			"mariadb.replicas":                      strconv.Itoa(replicas),
-			"mariadb.storage.size":                  storageSize,
-			"mariadb.rootPasswordSecretKeyRef.key":  rootPasswordSecretKeyRefKey,
-			"mariadb.rootPasswordSecretKeyRef.name": rootPasswordSecretKeyRefName,
-		},
-		KubectlOptions: kubectlopts,
-	}
+		renderedData := helm.RenderTemplate(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/mariadb.yaml"})
+		var mariadb v1alpha1.MariaDB
+		helm.UnmarshalK8SYaml(GinkgoT(), renderedData, &mariadb)
 
-	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/mariadb.yaml"})
-	var mariadb v1alpha1.MariaDB
-	helm.UnmarshalK8SYaml(t, renderedData, &mariadb)
+		Expect(mariadb.Name).To(Equal(clusterHelmReleaseName))
+		Expect(mariadb.Namespace).To(Equal(kubectlopts.Namespace))
+		Expect(mariadb.Spec.Galera.Enabled).To(BeTrue())
+		Expect(mariadb.Spec.Metrics.Enabled).To(BeTrue())
+		Expect(mariadb.Spec.Replicas).To(Equal(int32(replicas)))
+		Expect(mariadb.Spec.Storage.Size.String()).To(Equal(storageSize))
+		Expect(mariadb.Spec.RootPasswordSecretKeyRef.Key).To(Equal(rootPasswordSecretKeyRefKey))
+		Expect(mariadb.Spec.RootPasswordSecretKeyRef.Name).To(Equal(rootPasswordSecretKeyRefName))
+	})
 
-	Expect(mariadb.Name).To(Equal(clusterHelmReleaseName))
-	Expect(mariadb.Namespace).To(Equal(kubectlopts.Namespace))
-	Expect(mariadb.Spec.Galera.Enabled).To(BeTrue())
-	Expect(mariadb.Spec.Metrics.Enabled).To(BeTrue())
-	Expect(mariadb.Spec.Replicas).To(Equal(int32(replicas)))
-	Expect(mariadb.Spec.Storage.Size.String()).To(Equal(storageSize))
-	Expect(mariadb.Spec.RootPasswordSecretKeyRef.Key).To(Equal(rootPasswordSecretKeyRefKey))
-	Expect(mariadb.Spec.RootPasswordSecretKeyRef.Name).To(Equal(rootPasswordSecretKeyRefName))
-}
+	It("renders the MariaDB resource with no secret key ref name", func() {
+		rootPasswordSecretKeyRefKey := "root"
+		passwordSecretKeyRefKey := "mariadb-1"
+		passwordHashSecretKeyRefKey := "mariadb-2"
 
-func TestClusterHelmMariaDBNoSecretKeyRefName(t *testing.T) {
-	RegisterTestingT(t)
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"mariadb.rootPasswordSecretKeyRef.key":  rootPasswordSecretKeyRefKey,
+				"mariadb.rootPasswordSecretKeyRef.name": "",
+				"mariadb.passwordSecretKeyRef.key":      passwordSecretKeyRefKey,
+				"mariadb.passwordSecretKeyRef.name":     "",
+				"mariadb.passwordHashSecretKeyRef.key":  passwordHashSecretKeyRefKey,
+				"mariadb.passwordHashSecretKeyRef.name": "",
+			},
+			KubectlOptions: kubectlopts,
+		}
 
-	rootPasswordSecretKeyRefKey := "root"
-	passwordSecretKeyRefKey := "mariadb-1"
-	passwordHashSecretKeyRefKey := "mariadb-2"
+		renderedData := helm.RenderTemplate(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/mariadb.yaml"})
+		var mariadb v1alpha1.MariaDB
+		helm.UnmarshalK8SYaml(GinkgoT(), renderedData, &mariadb)
 
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"mariadb.rootPasswordSecretKeyRef.key":  rootPasswordSecretKeyRefKey,
-			"mariadb.rootPasswordSecretKeyRef.name": "",
-			"mariadb.passwordSecretKeyRef.key":      passwordSecretKeyRefKey,
-			"mariadb.passwordSecretKeyRef.name":     "",
-			"mariadb.passwordHashSecretKeyRef.key":  passwordHashSecretKeyRefKey,
-			"mariadb.passwordHashSecretKeyRef.name": "",
-		},
-		KubectlOptions: kubectlopts,
-	}
+		Expect(mariadb.Spec.RootPasswordSecretKeyRef.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, rootPasswordSecretKeyRefKey)))
+		Expect(mariadb.Spec.PasswordSecretKeyRef.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, passwordSecretKeyRefKey)))
+		Expect(mariadb.Spec.PasswordHashSecretKeyRef.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, passwordHashSecretKeyRefKey)))
+	})
 
-	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/mariadb.yaml"})
-	var mariadb v1alpha1.MariaDB
-	helm.UnmarshalK8SYaml(t, renderedData, &mariadb)
+	It("renders the Database resource", func() {
+		name := "mariadb"
+		namespace := "database"
+		waitForit := false
+		characterSet := "utf8"
+		cleanupPolicy := "Delete"
+		collate := "utf8_general_ci"
+		requeueInterval := "10h"
+		retryInterval := "30s"
 
-	Expect(mariadb.Spec.RootPasswordSecretKeyRef.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, rootPasswordSecretKeyRefKey)))
-	Expect(mariadb.Spec.PasswordSecretKeyRef.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, passwordSecretKeyRefKey)))
-	Expect(mariadb.Spec.PasswordHashSecretKeyRef.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, passwordHashSecretKeyRefKey)))
-}
+		durationInterval, _ := time.ParseDuration(requeueInterval)
+		durationRetry, _ := time.ParseDuration(retryInterval)
+		requeueIntervalDuration := &v1.Duration{Duration: durationInterval}
+		retryIntervalDuration := &v1.Duration{Duration: durationRetry}
 
-func TestClusterHelmDatabase(t *testing.T) {
-	RegisterTestingT(t)
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"databases[0].name":                 name,
+				"databases[0].namespace":            namespace,
+				"databases[0].waitForIt":            strconv.FormatBool(waitForit),
+				"databases[0].characterSet":         characterSet,
+				"databases[0].cleanupPolicy":        cleanupPolicy,
+				"databases[0].collate":              collate,
+				"databases[0].requeueInterval":      requeueInterval,
+				"databases[0].retryInterval":        retryInterval,
+				"databases[0].mariaDBRef.name":      "cluster",
+				"databases[0].mariaDBRef.namespace": "namespace",
+			},
+			KubectlOptions: kubectlopts,
+		}
 
-	name := "mariadb"
-	namespace := "database"
-	waitForit := false
-	characterSet := "utf8"
-	cleanupPolicy := "Delete"
-	collate := "utf8_general_ci"
-	requeueInterval := "10h"
-	retryInterval := "30s"
+		renderedData := helm.RenderTemplate(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/database.yaml"})
+		var database v1alpha1.Database
+		helm.UnmarshalK8SYaml(GinkgoT(), renderedData, &database)
 
-	durationInterval, _ := time.ParseDuration(requeueInterval)
-	durationRetry, _ := time.ParseDuration(retryInterval)
-	requeueIntervalDuration := &v1.Duration{Duration: durationInterval}
-	retryIntervalDuration := &v1.Duration{Duration: durationRetry}
+		Expect(database.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
+		Expect(database.Namespace).To(Equal(namespace))
+		Expect(database.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
+		Expect(database.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
+		Expect(database.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
+		Expect(database.Spec.CharacterSet).To(Equal(characterSet))
+		Expect(*database.Spec.CleanupPolicy).To(Equal(v1alpha1.CleanupPolicy(cleanupPolicy)))
+		Expect(database.Spec.Collate).To(Equal(collate))
+		Expect(database.Spec.Name).To(Equal(name))
+		Expect(database.Spec.RequeueInterval).To(Equal(requeueIntervalDuration))
+		Expect(database.Spec.RetryInterval).To(Equal(retryIntervalDuration))
 
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"databases[0].name":                 name,
-			"databases[0].namespace":            namespace,
-			"databases[0].waitForIt":            strconv.FormatBool(waitForit),
-			"databases[0].characterSet":         characterSet,
-			"databases[0].cleanupPolicy":        cleanupPolicy,
-			"databases[0].collate":              collate,
-			"databases[0].requeueInterval":      requeueInterval,
-			"databases[0].retryInterval":        retryInterval,
-			"databases[0].mariaDBRef.name":      "cluster",
-			"databases[0].mariaDBRef.namespace": "namespace",
-		},
-		KubectlOptions: kubectlopts,
-	}
+		delete(opts.SetValues, "databases[0].name")
+		_, err := helm.RenderTemplateE(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/database.yaml"})
+		Expect(err).To(HaveOccurred())
+	})
 
-	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/database.yaml"})
-	var database v1alpha1.Database
-	helm.UnmarshalK8SYaml(t, renderedData, &database)
+	It("renders the User resource", func() {
+		name := "mariadb"
+		namespace := "database"
+		waitForit := false
+		cleanupPolicy := "Delete"
+		host := "%"
+		maxUserConnections := 100
+		passwordSecretKeyRefKey := "root"
+		passwordSecretKeyRefName := "mariadb"
+		requeueInterval := "10h"
+		retryInterval := "30s"
 
-	Expect(database.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
-	Expect(database.Namespace).To(Equal(namespace))
-	Expect(database.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
-	Expect(database.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
-	Expect(database.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
-	Expect(database.Spec.CharacterSet).To(Equal(characterSet))
-	Expect(*database.Spec.CleanupPolicy).To(Equal(v1alpha1.CleanupPolicy(cleanupPolicy)))
-	Expect(database.Spec.Collate).To(Equal(collate))
-	Expect(database.Spec.Name).To(Equal(name))
-	Expect(database.Spec.RequeueInterval).To(Equal(requeueIntervalDuration))
-	Expect(database.Spec.RetryInterval).To(Equal(retryIntervalDuration))
+		durationInterval, _ := time.ParseDuration(requeueInterval)
+		durationRetry, _ := time.ParseDuration(retryInterval)
+		requeueIntervalDuration := &v1.Duration{Duration: durationInterval}
+		retryIntervalDuration := &v1.Duration{Duration: durationRetry}
 
-	delete(opts.SetValues, "databases[0].name")
-	_, err := helm.RenderTemplateE(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/database.yaml"})
-	Expect(err).To(HaveOccurred())
-}
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"users[0].name":                      name,
+				"users[0].namespace":                 namespace,
+				"users[0].waitForIt":                 strconv.FormatBool(waitForit),
+				"users[0].cleanupPolicy":             cleanupPolicy,
+				"users[0].host":                      host,
+				"users[0].maxUserConnections":        strconv.Itoa(maxUserConnections),
+				"users[0].passwordSecretKeyRef.key":  passwordSecretKeyRefKey,
+				"users[0].passwordSecretKeyRef.name": passwordSecretKeyRefName,
+				"users[0].requeueInterval":           requeueInterval,
+				"users[0].retryInterval":             retryInterval,
+				"users[0].mariaDBRef.name":           "cluster",
+				"users[0].mariaDBRef.namespace":      "namespace",
+			},
+			KubectlOptions: kubectlopts,
+		}
 
-func TestClusterHelmUser(t *testing.T) {
-	RegisterTestingT(t)
+		renderedData := helm.RenderTemplate(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/user.yaml"})
+		var user v1alpha1.User
+		helm.UnmarshalK8SYaml(GinkgoT(), renderedData, &user)
 
-	name := "mariadb"
-	namespace := "database"
-	waitForit := false
-	cleanupPolicy := "Delete"
-	host := "%"
-	maxUserConnections := 100
-	passwordSecretKeyRefKey := "root"
-	passwordSecretKeyRefName := "mariadb"
-	requeueInterval := "10h"
-	retryInterval := "30s"
+		Expect(user.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
+		Expect(user.Namespace).To(Equal(namespace))
+		Expect(user.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
+		Expect(user.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
+		Expect(user.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
+		Expect(*user.Spec.CleanupPolicy).To(Equal(v1alpha1.CleanupPolicy(cleanupPolicy)))
+		Expect(user.Spec.Host).To(Equal(host))
+		Expect(user.Spec.MaxUserConnections).To(Equal(int32(maxUserConnections)))
+		Expect(user.Spec.Name).To(Equal(name))
+		Expect(user.Spec.PasswordSecretKeyRef.Key).To(Equal(passwordSecretKeyRefKey))
+		Expect(user.Spec.PasswordSecretKeyRef.Name).To(Equal(passwordSecretKeyRefName))
+		Expect(user.Spec.RequeueInterval).To(Equal(requeueIntervalDuration))
+		Expect(user.Spec.RetryInterval).To(Equal(retryIntervalDuration))
 
-	durationInterval, _ := time.ParseDuration(requeueInterval)
-	durationRetry, _ := time.ParseDuration(retryInterval)
-	requeueIntervalDuration := &v1.Duration{Duration: durationInterval}
-	retryIntervalDuration := &v1.Duration{Duration: durationRetry}
+		delete(opts.SetValues, "users[0].name")
+		_, err := helm.RenderTemplateE(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/user.yaml"})
+		Expect(err).To(HaveOccurred())
+	})
 
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"users[0].name":                      name,
-			"users[0].namespace":                 namespace,
-			"users[0].waitForIt":                 strconv.FormatBool(waitForit),
-			"users[0].cleanupPolicy":             cleanupPolicy,
-			"users[0].host":                      host,
-			"users[0].maxUserConnections":        strconv.Itoa(maxUserConnections),
-			"users[0].passwordSecretKeyRef.key":  passwordSecretKeyRefKey,
-			"users[0].passwordSecretKeyRef.name": passwordSecretKeyRefName,
-			"users[0].requeueInterval":           requeueInterval,
-			"users[0].retryInterval":             retryInterval,
-			"users[0].mariaDBRef.name":           "cluster",
-			"users[0].mariaDBRef.namespace":      "namespace",
-		},
-		KubectlOptions: kubectlopts,
-	}
+	It("renders the Grant resource", func() {
+		name := "mariadb"
+		namespace := "database"
+		waitForit := false
+		cleanupPolicy := "Delete"
+		database := "mariadb"
+		host := "%"
+		username := "mariadb"
+		privilegeSelect := "SELECT"
+		privilegeProcess := "PROCESS"
+		requeueInterval := "1h"
+		retryInterval := "3m"
+		table := "*"
 
-	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/user.yaml"})
-	var user v1alpha1.User
-	helm.UnmarshalK8SYaml(t, renderedData, &user)
+		durationInterval, _ := time.ParseDuration(requeueInterval)
+		durationRetry, _ := time.ParseDuration(retryInterval)
+		requeueIntervalDuration := &v1.Duration{Duration: durationInterval}
+		retryIntervalDuration := &v1.Duration{Duration: durationRetry}
 
-	Expect(user.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
-	Expect(user.Namespace).To(Equal(namespace))
-	Expect(user.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
-	Expect(user.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
-	Expect(user.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
-	Expect(*user.Spec.CleanupPolicy).To(Equal(v1alpha1.CleanupPolicy(cleanupPolicy)))
-	Expect(user.Spec.Host).To(Equal(host))
-	Expect(user.Spec.MaxUserConnections).To(Equal(int32(maxUserConnections)))
-	Expect(user.Spec.Name).To(Equal(name))
-	Expect(user.Spec.PasswordSecretKeyRef.Key).To(Equal(passwordSecretKeyRefKey))
-	Expect(user.Spec.PasswordSecretKeyRef.Name).To(Equal(passwordSecretKeyRefName))
-	Expect(user.Spec.RequeueInterval).To(Equal(requeueIntervalDuration))
-	Expect(user.Spec.RetryInterval).To(Equal(retryIntervalDuration))
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"grants[0].name":                 name,
+				"grants[0].namespace":            namespace,
+				"grants[0].waitForIt":            strconv.FormatBool(waitForit),
+				"grants[0].cleanupPolicy":        cleanupPolicy,
+				"grants[0].database":             database,
+				"grants[0].host":                 host,
+				"grants[0].grantOption":          "false",
+				"grants[0].username":             username,
+				"grants[0].privileges[0]":        privilegeSelect,
+				"grants[0].privileges[1]":        privilegeProcess,
+				"grants[0].requeueInterval":      requeueInterval,
+				"grants[0].retryInterval":        retryInterval,
+				"grants[0].table":                table,
+				"grants[0].mariaDBRef.name":      "cluster",
+				"grants[0].mariaDBRef.namespace": "namespace",
+			},
+			KubectlOptions: kubectlopts,
+		}
 
-	delete(opts.SetValues, "users[0].name")
-	_, err := helm.RenderTemplateE(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/user.yaml"})
-	Expect(err).To(HaveOccurred())
-}
+		renderedData := helm.RenderTemplate(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/grant.yaml"})
+		var grant v1alpha1.Grant
+		helm.UnmarshalK8SYaml(GinkgoT(), renderedData, &grant)
 
-func TestClusterHelmGrant(t *testing.T) {
-	RegisterTestingT(t)
+		Expect(grant.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, username)))
+		Expect(grant.Namespace).To(Equal(namespace))
+		Expect(grant.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
+		Expect(grant.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
+		Expect(grant.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
+		Expect(*grant.Spec.CleanupPolicy).To(Equal(v1alpha1.CleanupPolicy(cleanupPolicy)))
+		Expect(grant.Spec.Database).To(Equal(database))
+		Expect(*grant.Spec.Host).To(Equal(host))
+		Expect(grant.Spec.GrantOption).To(BeFalse())
+		Expect(grant.Spec.Username).To(Equal(username))
+		Expect(grant.Spec.Privileges[0]).To(Equal(privilegeSelect))
+		Expect(grant.Spec.Privileges[1]).To(Equal(privilegeProcess))
+		Expect(grant.Spec.RequeueInterval).To(Equal(requeueIntervalDuration))
+		Expect(grant.Spec.RetryInterval).To(Equal(retryIntervalDuration))
+		Expect(grant.Spec.Table).To(Equal(table))
 
-	name := "mariadb"
-	namespace := "database"
-	waitForit := false
-	cleanupPolicy := "Delete"
-	database := "mariadb"
-	host := "%"
-	username := "mariadb"
-	privilegeSelect := "SELECT"
-	privilegeProcess := "PROCESS"
-	requeueInterval := "1h"
-	retryInterval := "3m"
-	table := "*"
+		delete(opts.SetValues, "grants[0].name")
+		_, err := helm.RenderTemplateE(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/grant.yaml"})
+		Expect(err).To(HaveOccurred())
+	})
 
-	durationInterval, _ := time.ParseDuration(requeueInterval)
-	durationRetry, _ := time.ParseDuration(retryInterval)
-	requeueIntervalDuration := &v1.Duration{Duration: durationInterval}
-	retryIntervalDuration := &v1.Duration{Duration: durationRetry}
+	It("renders the Backup resource", func() {
+		name := "backup"
+		namespace := "database"
+		waitForit := false
+		maxRetention := "720h"
+		compression := "gzip"
+		bucket := "backups"
+		endpoint := "minio.minio.svc.cluster.local:9000"
+		region := "us-east-1"
+		prefix := "mariadb-cluster"
+		accessKeyIdSecretKeyRefKey := "access-key-id"
+		accessKeyIdSecretKeyRefName := "minio"
+		secretAccessKeySecretKeyRefKey := "secret-access-key"
+		secretAccessKeySecretKeyRefName := "minio"
+		cron := "0 0 * * *"
 
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"grants[0].name":                 name,
-			"grants[0].namespace":            namespace,
-			"grants[0].waitForIt":            strconv.FormatBool(waitForit),
-			"grants[0].cleanupPolicy":        cleanupPolicy,
-			"grants[0].database":             database,
-			"grants[0].host":                 host,
-			"grants[0].grantOption":          "false",
-			"grants[0].username":             username,
-			"grants[0].privileges[0]":        privilegeSelect,
-			"grants[0].privileges[1]":        privilegeProcess,
-			"grants[0].requeueInterval":      requeueInterval,
-			"grants[0].retryInterval":        retryInterval,
-			"grants[0].table":                table,
-			"grants[0].mariaDBRef.name":      "cluster",
-			"grants[0].mariaDBRef.namespace": "namespace",
-		},
-		KubectlOptions: kubectlopts,
-	}
+		durationMaxRetention, _ := time.ParseDuration(maxRetention)
+		durationMaxRetentionDuration := &v1.Duration{Duration: durationMaxRetention}
 
-	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/grant.yaml"})
-	var grant v1alpha1.Grant
-	helm.UnmarshalK8SYaml(t, renderedData, &grant)
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"backups[0].name":                                        name,
+				"backups[0].namespace":                                   namespace,
+				"backups[0].waitForIt":                                   strconv.FormatBool(waitForit),
+				"backups[0].maxRetention":                                maxRetention,
+				"backups[0].compression":                                 compression,
+				"backups[0].storage.s3.bucket":                           bucket,
+				"backups[0].storage.s3.prefix":                           prefix,
+				"backups[0].storage.s3.endpoint":                         endpoint,
+				"backups[0].storage.s3.region":                           region,
+				"backups[0].storage.s3.accessKeyIdSecretKeyRef.key":      accessKeyIdSecretKeyRefKey,
+				"backups[0].storage.s3.accessKeyIdSecretKeyRef.name":     accessKeyIdSecretKeyRefName,
+				"backups[0].storage.s3.secretAccessKeySecretKeyRef.key":  secretAccessKeySecretKeyRefKey,
+				"backups[0].storage.s3.secretAccessKeySecretKeyRef.name": secretAccessKeySecretKeyRefName,
+				"backups[0].schedule.cron":                               cron,
+				"backups[0].mariaDBRef.name":                             "cluster",
+				"backups[0].mariaDBRef.namespace":                        "namespace",
+			},
+			KubectlOptions: kubectlopts,
+		}
 
-	Expect(grant.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, username)))
-	Expect(grant.Namespace).To(Equal(namespace))
-	Expect(grant.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
-	Expect(grant.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
-	Expect(grant.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
-	Expect(*grant.Spec.CleanupPolicy).To(Equal(v1alpha1.CleanupPolicy(cleanupPolicy)))
-	Expect(grant.Spec.Database).To(Equal(database))
-	Expect(*grant.Spec.Host).To(Equal(host))
-	Expect(grant.Spec.GrantOption).To(BeFalse())
-	Expect(grant.Spec.Username).To(Equal(username))
-	Expect(grant.Spec.Privileges[0]).To(Equal(privilegeSelect))
-	Expect(grant.Spec.Privileges[1]).To(Equal(privilegeProcess))
-	Expect(grant.Spec.RequeueInterval).To(Equal(requeueIntervalDuration))
-	Expect(grant.Spec.RetryInterval).To(Equal(retryIntervalDuration))
-	Expect(grant.Spec.Table).To(Equal(table))
+		renderedData := helm.RenderTemplate(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/backup.yaml"})
+		var backup v1alpha1.Backup
+		helm.UnmarshalK8SYaml(GinkgoT(), renderedData, &backup)
 
-	delete(opts.SetValues, "grants[0].name")
-	_, err := helm.RenderTemplateE(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/grant.yaml"})
-	Expect(err).To(HaveOccurred())
-}
+		Expect(backup.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
+		Expect(backup.Namespace).To(Equal(namespace))
+		Expect(backup.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
+		Expect(backup.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
+		Expect(backup.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
+		Expect(&backup.Spec.MaxRetention).To(Equal(durationMaxRetentionDuration))
+		Expect(backup.Spec.Compression).To(Equal(v1alpha1.CompressAlgorithm(compression)))
+		Expect(backup.Spec.Storage.S3.Bucket).To(Equal(bucket))
+		Expect(backup.Spec.Storage.S3.Prefix).To(Equal(prefix))
+		Expect(backup.Spec.Storage.S3.Endpoint).To(Equal(endpoint))
+		Expect(backup.Spec.Storage.S3.Region).To(Equal(region))
+		Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Key).To(Equal(accessKeyIdSecretKeyRefKey))
+		Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Name).To(Equal(accessKeyIdSecretKeyRefName))
+		Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Key).To(Equal(secretAccessKeySecretKeyRefKey))
+		Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Name).To(Equal(secretAccessKeySecretKeyRefName))
+		Expect(backup.Spec.Schedule.Cron).To(Equal(cron))
 
-func TestClusterHelmBackup(t *testing.T) {
-	RegisterTestingT(t)
+		delete(opts.SetValues, "backups[0].name")
+		delete(opts.SetValues, "backups[0].storage.s3.bucket")
+		delete(opts.SetValues, "backups[0].storage.s3.prefix")
+		delete(opts.SetValues, "backups[0].storage.s3.endpoint")
+		delete(opts.SetValues, "backups[0].storage.s3.region")
+		delete(opts.SetValues, "backups[0].storage.s3.accessKeyIdSecretKeyRef.key")
+		delete(opts.SetValues, "backups[0].storage.s3.accessKeyIdSecretKeyRef.name")
+		delete(opts.SetValues, "backups[0].storage.s3.secretAccessKeySecretKeyRef.key")
+		delete(opts.SetValues, "backups[0].storage.s3.secretAccessKeySecretKeyRef.name")
 
-	name := "backup"
-	namespace := "database"
-	waitForit := false
-	maxRetention := "720h"
-	compression := "gzip"
-	bucket := "backups"
-	endpoint := "minio.minio.svc.cluster.local:9000"
-	region := "us-east-1"
-	prefix := "mariadb-cluster"
-	accessKeyIdSecretKeyRefKey := "access-key-id"
-	accessKeyIdSecretKeyRefName := "minio"
-	secretAccessKeySecretKeyRefKey := "secret-access-key"
-	secretAccessKeySecretKeyRefName := "minio"
-	cron := "0 0 * * *"
+		_, err := helm.RenderTemplateE(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/backup.yaml"})
+		Expect(err).To(HaveOccurred())
+	})
 
-	durationMaxRetention, _ := time.ParseDuration(maxRetention)
-	durationMaxRetentionDuration := &v1.Duration{Duration: durationMaxRetention}
+	It("renders the PhysicalBackup resource", func() {
+		name := "physicalbackup"
+		namespace := "database"
+		waitForit := false
+		maxRetention := "720h"
+		compression := "gzip"
+		bucket := "backups"
+		endpoint := "minio.minio.svc.cluster.local:9000"
+		region := "us-east-1"
+		prefix := "mariadb-cluster"
+		accessKeyIdSecretKeyRefKey := "access-key-id"
+		accessKeyIdSecretKeyRefName := "minio"
+		secretAccessKeySecretKeyRefKey := "secret-access-key"
+		secretAccessKeySecretKeyRefName := "minio"
+		cron := "0 0 * * *"
 
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"backups[0].name":                                        name,
-			"backups[0].namespace":                                   namespace,
-			"backups[0].waitForIt":                                   strconv.FormatBool(waitForit),
-			"backups[0].maxRetention":                                maxRetention,
-			"backups[0].compression":                                 compression,
-			"backups[0].storage.s3.bucket":                           bucket,
-			"backups[0].storage.s3.prefix":                           prefix,
-			"backups[0].storage.s3.endpoint":                         endpoint,
-			"backups[0].storage.s3.region":                           region,
-			"backups[0].storage.s3.accessKeyIdSecretKeyRef.key":      accessKeyIdSecretKeyRefKey,
-			"backups[0].storage.s3.accessKeyIdSecretKeyRef.name":     accessKeyIdSecretKeyRefName,
-			"backups[0].storage.s3.secretAccessKeySecretKeyRef.key":  secretAccessKeySecretKeyRefKey,
-			"backups[0].storage.s3.secretAccessKeySecretKeyRef.name": secretAccessKeySecretKeyRefName,
-			"backups[0].schedule.cron":                               cron,
-			"backups[0].mariaDBRef.name":                             "cluster",
-			"backups[0].mariaDBRef.namespace":                        "namespace",
-		},
-		KubectlOptions: kubectlopts,
-	}
+		durationMaxRetention, _ := time.ParseDuration(maxRetention)
+		durationMaxRetentionDuration := &v1.Duration{Duration: durationMaxRetention}
 
-	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/backup.yaml"})
-	var backup v1alpha1.Backup
-	helm.UnmarshalK8SYaml(t, renderedData, &backup)
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"physicalBackups[0].name":                                        name,
+				"physicalBackups[0].namespace":                                   namespace,
+				"physicalBackups[0].waitForIt":                                   strconv.FormatBool(waitForit),
+				"physicalBackups[0].maxRetention":                                maxRetention,
+				"physicalBackups[0].compression":                                 compression,
+				"physicalBackups[0].storage.s3.bucket":                           bucket,
+				"physicalBackups[0].storage.s3.prefix":                           prefix,
+				"physicalBackups[0].storage.s3.endpoint":                         endpoint,
+				"physicalBackups[0].storage.s3.region":                           region,
+				"physicalBackups[0].storage.s3.accessKeyIdSecretKeyRef.key":      accessKeyIdSecretKeyRefKey,
+				"physicalBackups[0].storage.s3.accessKeyIdSecretKeyRef.name":     accessKeyIdSecretKeyRefName,
+				"physicalBackups[0].storage.s3.secretAccessKeySecretKeyRef.key":  secretAccessKeySecretKeyRefKey,
+				"physicalBackups[0].storage.s3.secretAccessKeySecretKeyRef.name": secretAccessKeySecretKeyRefName,
+				"physicalBackups[0].schedule.cron":                               cron,
+				"physicalBackups[0].mariaDBRef.name":                             "cluster",
+				"physicalBackups[0].mariaDBRef.namespace":                        "namespace",
+			},
+			KubectlOptions: kubectlopts,
+		}
 
-	Expect(backup.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
-	Expect(backup.Namespace).To(Equal(namespace))
-	Expect(backup.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
-	Expect(backup.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
-	Expect(backup.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
-	Expect(&backup.Spec.MaxRetention).To(Equal(durationMaxRetentionDuration))
-	Expect(backup.Spec.Compression).To(Equal(v1alpha1.CompressAlgorithm(compression)))
-	Expect(backup.Spec.Storage.S3.Bucket).To(Equal(bucket))
-	Expect(backup.Spec.Storage.S3.Prefix).To(Equal(prefix))
-	Expect(backup.Spec.Storage.S3.Endpoint).To(Equal(endpoint))
-	Expect(backup.Spec.Storage.S3.Region).To(Equal(region))
-	Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Key).To(Equal(accessKeyIdSecretKeyRefKey))
-	Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Name).To(Equal(accessKeyIdSecretKeyRefName))
-	Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Key).To(Equal(secretAccessKeySecretKeyRefKey))
-	Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Name).To(Equal(secretAccessKeySecretKeyRefName))
-	Expect(backup.Spec.Schedule.Cron).To(Equal(cron))
+		renderedData := helm.RenderTemplate(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName,
+			[]string{"templates/physicalbackup.yaml"})
+		var backup v1alpha1.Backup
+		helm.UnmarshalK8SYaml(GinkgoT(), renderedData, &backup)
 
-	delete(opts.SetValues, "backups[0].name")
-	delete(opts.SetValues, "backups[0].storage.s3.bucket")
-	delete(opts.SetValues, "backups[0].storage.s3.prefix")
-	delete(opts.SetValues, "backups[0].storage.s3.endpoint")
-	delete(opts.SetValues, "backups[0].storage.s3.region")
-	delete(opts.SetValues, "backups[0].storage.s3.accessKeyIdSecretKeyRef.key")
-	delete(opts.SetValues, "backups[0].storage.s3.accessKeyIdSecretKeyRef.name")
-	delete(opts.SetValues, "backups[0].storage.s3.secretAccessKeySecretKeyRef.key")
-	delete(opts.SetValues, "backups[0].storage.s3.secretAccessKeySecretKeyRef.name")
+		Expect(backup.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
+		Expect(backup.Namespace).To(Equal(namespace))
+		Expect(backup.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
+		Expect(backup.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
+		Expect(backup.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
+		Expect(&backup.Spec.MaxRetention).To(Equal(durationMaxRetentionDuration))
+		Expect(backup.Spec.Compression).To(Equal(v1alpha1.CompressAlgorithm(compression)))
+		Expect(backup.Spec.Storage.S3.Bucket).To(Equal(bucket))
+		Expect(backup.Spec.Storage.S3.Prefix).To(Equal(prefix))
+		Expect(backup.Spec.Storage.S3.Endpoint).To(Equal(endpoint))
+		Expect(backup.Spec.Storage.S3.Region).To(Equal(region))
+		Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Key).To(Equal(accessKeyIdSecretKeyRefKey))
+		Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Name).To(Equal(accessKeyIdSecretKeyRefName))
+		Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Key).To(Equal(secretAccessKeySecretKeyRefKey))
+		Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Name).To(Equal(secretAccessKeySecretKeyRefName))
+		Expect(backup.Spec.Schedule.Cron).To(Equal(cron))
 
-	_, err := helm.RenderTemplateE(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/backup.yaml"})
-	Expect(err).To(HaveOccurred())
-}
+		delete(opts.SetValues, "physicalBackups[0].name")
+		delete(opts.SetValues, "physicalBackups[0].storage.s3.bucket")
+		delete(opts.SetValues, "physicalBackups[0].storage.s3.prefix")
+		delete(opts.SetValues, "physicalBackups[0].storage.s3.endpoint")
+		delete(opts.SetValues, "physicalBackups[0].storage.s3.region")
+		delete(opts.SetValues, "physicalBackups[0].storage.s3.accessKeyIdSecretKeyRef.key")
+		delete(opts.SetValues, "physicalBackups[0].storage.s3.accessKeyIdSecretKeyRef.name")
+		delete(opts.SetValues, "physicalBackups[0].storage.s3.secretAccessKeySecretKeyRef.key")
+		delete(opts.SetValues, "physicalBackups[0].storage.s3.secretAccessKeySecretKeyRef.name")
 
-func TestClusterHelmPhysicalBackup(t *testing.T) {
-	RegisterTestingT(t)
-
-	name := "physicalbackup"
-	namespace := "database"
-	waitForit := false
-	maxRetention := "720h"
-	compression := "gzip"
-	bucket := "backups"
-	endpoint := "minio.minio.svc.cluster.local:9000"
-	region := "us-east-1"
-	prefix := "mariadb-cluster"
-	accessKeyIdSecretKeyRefKey := "access-key-id"
-	accessKeyIdSecretKeyRefName := "minio"
-	secretAccessKeySecretKeyRefKey := "secret-access-key"
-	secretAccessKeySecretKeyRefName := "minio"
-	cron := "0 0 * * *"
-
-	durationMaxRetention, _ := time.ParseDuration(maxRetention)
-	durationMaxRetentionDuration := &v1.Duration{Duration: durationMaxRetention}
-
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"physicalBackups[0].name":                                        name,
-			"physicalBackups[0].namespace":                                   namespace,
-			"physicalBackups[0].waitForIt":                                   strconv.FormatBool(waitForit),
-			"physicalBackups[0].maxRetention":                                maxRetention,
-			"physicalBackups[0].compression":                                 compression,
-			"physicalBackups[0].storage.s3.bucket":                           bucket,
-			"physicalBackups[0].storage.s3.prefix":                           prefix,
-			"physicalBackups[0].storage.s3.endpoint":                         endpoint,
-			"physicalBackups[0].storage.s3.region":                           region,
-			"physicalBackups[0].storage.s3.accessKeyIdSecretKeyRef.key":      accessKeyIdSecretKeyRefKey,
-			"physicalBackups[0].storage.s3.accessKeyIdSecretKeyRef.name":     accessKeyIdSecretKeyRefName,
-			"physicalBackups[0].storage.s3.secretAccessKeySecretKeyRef.key":  secretAccessKeySecretKeyRefKey,
-			"physicalBackups[0].storage.s3.secretAccessKeySecretKeyRef.name": secretAccessKeySecretKeyRefName,
-			"physicalBackups[0].schedule.cron":                               cron,
-			"physicalBackups[0].mariaDBRef.name":                             "cluster",
-			"physicalBackups[0].mariaDBRef.namespace":                        "namespace",
-		},
-		KubectlOptions: kubectlopts,
-	}
-
-	renderedData := helm.RenderTemplate(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/physicalbackup.yaml"})
-	var backup v1alpha1.Backup
-	helm.UnmarshalK8SYaml(t, renderedData, &backup)
-
-	Expect(backup.Name).To(Equal(fmt.Sprintf("%s-%s", clusterHelmReleaseName, name)))
-	Expect(backup.Namespace).To(Equal(namespace))
-	Expect(backup.Spec.MariaDBRef.Name).To(Equal(clusterHelmReleaseName))
-	Expect(backup.Spec.MariaDBRef.Namespace).To(Equal(clusterHelmNamespace))
-	Expect(backup.Spec.MariaDBRef.WaitForIt).To(Equal(waitForit))
-	Expect(&backup.Spec.MaxRetention).To(Equal(durationMaxRetentionDuration))
-	Expect(backup.Spec.Compression).To(Equal(v1alpha1.CompressAlgorithm(compression)))
-	Expect(backup.Spec.Storage.S3.Bucket).To(Equal(bucket))
-	Expect(backup.Spec.Storage.S3.Prefix).To(Equal(prefix))
-	Expect(backup.Spec.Storage.S3.Endpoint).To(Equal(endpoint))
-	Expect(backup.Spec.Storage.S3.Region).To(Equal(region))
-	Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Key).To(Equal(accessKeyIdSecretKeyRefKey))
-	Expect(backup.Spec.Storage.S3.AccessKeyIdSecretKeyRef.Name).To(Equal(accessKeyIdSecretKeyRefName))
-	Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Key).To(Equal(secretAccessKeySecretKeyRefKey))
-	Expect(backup.Spec.Storage.S3.SecretAccessKeySecretKeyRef.Name).To(Equal(secretAccessKeySecretKeyRefName))
-	Expect(backup.Spec.Schedule.Cron).To(Equal(cron))
-
-	delete(opts.SetValues, "physicalBackups[0].name")
-	delete(opts.SetValues, "physicalBackups[0].storage.s3.bucket")
-	delete(opts.SetValues, "physicalBackups[0].storage.s3.prefix")
-	delete(opts.SetValues, "physicalBackups[0].storage.s3.endpoint")
-	delete(opts.SetValues, "physicalBackups[0].storage.s3.region")
-	delete(opts.SetValues, "physicalBackups[0].storage.s3.accessKeyIdSecretKeyRef.key")
-	delete(opts.SetValues, "physicalBackups[0].storage.s3.accessKeyIdSecretKeyRef.name")
-	delete(opts.SetValues, "physicalBackups[0].storage.s3.secretAccessKeySecretKeyRef.key")
-	delete(opts.SetValues, "physicalBackups[0].storage.s3.secretAccessKeySecretKeyRef.name")
-
-	_, err := helm.RenderTemplateE(t, opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/physicalbackup.yaml"})
-	Expect(err).To(HaveOccurred())
-}
+		_, err := helm.RenderTemplateE(GinkgoT(), opts, clusterHelmChartPath, clusterHelmReleaseName, []string{"templates/physicalbackup.yaml"})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/internal/helmtest/mariadb_operator_test.go
+++ b/internal/helmtest/mariadb_operator_test.go
@@ -1,8 +1,7 @@
 package test
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/gruntwork-io/terratest/modules/helm"
@@ -18,612 +17,596 @@ var (
 	operatorTestNamespace   = "test"
 )
 
-func TestOperatorHelmExtraEnvFrom(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		// see https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set
-		SetValues: map[string]string{
-			"extraEnvFrom[0].configMapRef.name": `env-extra-configmap`,
-			"extraEnvFrom[1].secretRef.name":    `env-extra-secret`,
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
-
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
-
-	container := deployment.Spec.Template.Spec.Containers[0]
-	Expect(container.Name).To(Equal("controller"))
-
-	configMapEnvFrom := corev1.EnvFromSource{
-		ConfigMapRef: &corev1.ConfigMapEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "env-extra-configmap",
-			},
-		},
-	}
-	Expect(container.EnvFrom).To(ContainElement(configMapEnvFrom))
-
-	secretEnvFrom := corev1.EnvFromSource{
-		SecretRef: &corev1.SecretEnvSource{
-			LocalObjectReference: corev1.LocalObjectReference{
-				Name: "env-extra-secret",
-			},
-		},
-	}
-	Expect(container.EnvFrom).To(ContainElement(secretEnvFrom))
-}
-
-func TestOperatorHelmCurrentNamespaceOnly(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"currentNamespaceOnly": `true`,
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
-
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
-
-	container := deployment.Spec.Template.Spec.Containers[0]
-	Expect(container.Name).To(Equal("controller"))
-
-	env := corev1.EnvVar{
-		Name:  "WATCH_NAMESPACE",
-		Value: operatorTestNamespace,
-	}
-	Expect(container.Env).To(ContainElement(env))
-
-	expectedTemplates := []string{
-		"templates/operator/rbac-namespace.yaml",
-	}
-	unexpectedTemplates := []string{
-		"templates/cert-controller/deployment.yaml",
-		"templates/cert-controller/rbac.yaml",
-		"templates/cert-controller/serviceaccount.yaml",
-		"templates/cert-controller/servicemonitor.yaml",
-		"templates/operator/rbac-user.yaml",
-		"templates/operator/rbac.yaml",
-		"templates/webhook/certificate.yaml",
-		"templates/webhook/config.yaml",
-		"templates/webhook/deployment.yaml",
-		"templates/webhook/service.yaml",
-		"templates/webhook/serviceaccount.yaml",
-		"templates/webhook/servicemonitor.yaml",
-	}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
-}
-
-func TestOperatorHelmClusterWide(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"webhook.cert.certManager.enabled": `true`,
-			"metrics.enabled":                  `true`,
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
-
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
-
-	container := deployment.Spec.Template.Spec.Containers[0]
-	Expect(container.Name).To(Equal("controller"))
-
-	env := corev1.EnvVar{
-		Name:  "WATCH_NAMESPACE",
-		Value: operatorTestNamespace,
-	}
-	Expect(container.Env).ToNot(ContainElement(env))
-
-	expectedTemplates := []string{
-		"templates/operator/rbac-user.yaml",
-		"templates/operator/rbac.yaml",
-		"templates/webhook/certificate.yaml",
-		"templates/webhook/config.yaml",
-		"templates/webhook/deployment.yaml",
-		"templates/webhook/service.yaml",
-		"templates/webhook/serviceaccount.yaml",
-	}
-	unexpectedTemplates := []string{
-		"templates/operator/rbac-namespace.yaml",
-	}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
-}
-
-func TestOperatorHelmCertManager(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"webhook.cert.certManager.enabled": `true`,
-		},
-	}
-
-	expectedTemplates := []string{
-		"templates/webhook/certificate.yaml",
-	}
-	unexpectedTemplates := []string{
-		"templates/cert-controller/deployment.yaml",
-		"templates/cert-controller/rbac.yaml",
-		"templates/cert-controller/serviceaccount.yaml",
-	}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
-}
-
-func TestOperatorHelmMetrics(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"metrics.enabled": `true`,
-		},
-	}
-
-	expectedTemplates := []string{
-		"templates/cert-controller/servicemonitor.yaml",
-		"templates/webhook/servicemonitor.yaml",
-	}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, nil)
-}
-
-func TestOperatorHelmWebhook(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"webhook.enabled": `true`,
-		},
-	}
-	expectedTemplates := []string{
-		"templates/webhook/config.yaml",
-		"templates/webhook/deployment.yaml",
-		"templates/webhook/service.yaml",
-		"templates/webhook/serviceaccount.yaml",
-	}
-	unexpectedTemplates := []string{}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
-
-	opts = &helm.Options{
-		SetValues: map[string]string{
-			"webhook.enabled": `false`,
-		},
-	}
-	expectedTemplates = []string{}
-	unexpectedTemplates = []string{
-		"templates/webhook/config.yaml",
-		"templates/webhook/deployment.yaml",
-		"templates/webhook/service.yaml",
-		"templates/webhook/serviceaccount.yaml",
-		"templates/webhook/pdb.yaml",
-	}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
-}
-
-func TestOperatorHelmCertController(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"certController.enabled": `true`,
-		},
-	}
-	expectedTemplates := []string{
-		"templates/cert-controller/deployment.yaml",
-		"templates/cert-controller/rbac.yaml",
-		"templates/cert-controller/serviceaccount.yaml",
-	}
-	unexpectedTemplates := []string{}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
-
-	opts = &helm.Options{
-		SetValues: map[string]string{
-			"certController.enabled": `false`,
-		},
-	}
-	expectedTemplates = []string{}
-	unexpectedTemplates = []string{
-		"templates/cert-controller/deployment.yaml",
-		"templates/cert-controller/rbac.yaml",
-		"templates/cert-controller/serviceaccount.yaml",
-		"templates/cert-controller/pdb.yaml",
-	}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
-}
-
-func TestOperatorHelmHaEnabled(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"ha.enabled": `true`,
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
-
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
-
-	container := deployment.Spec.Template.Spec.Containers[0]
-	Expect(container.Name).To(Equal("controller"))
-
-	replicas := int(*deployment.Spec.Replicas)
-	Expect(replicas).To(Equal(3))
-	Expect(container.Args).To(ContainElement("--leader-elect"))
-}
-
-func TestOperatorHelmPDBEnabled(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"pdb.enabled": `true`,
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
-	pdbData := helm.RenderTemplate(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{"templates/operator/pdb.yaml"})
-	var pdb policyv1.PodDisruptionBudget
-	helm.UnmarshalK8SYaml(t, pdbData, &pdb)
-	maxUnavailable := pdb.Spec.MaxUnavailable.IntValue()
-	Expect(maxUnavailable).To(Equal(1))
-
-	opts = &helm.Options{
-		SetValues: map[string]string{
-			"pdb.enabled":        `true`,
-			"pdb.maxUnavailable": "50%",
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
-	pdbData = helm.RenderTemplate(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{"templates/operator/pdb.yaml"})
-	helm.UnmarshalK8SYaml(t, pdbData, &pdb)
-	maxUnavailablePercent := pdb.Spec.MaxUnavailable.String()
-	Expect(maxUnavailablePercent).To(Equal("50%"))
-
-	expectedTemplates := []string{
-		"templates/operator/pdb.yaml",
-	}
-	unexpectedTemplates := []string{}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
-
-	opts = &helm.Options{
-		SetValues: map[string]string{
-			"pdb.enabled": `false`,
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
-	expectedTemplates = []string{}
-	unexpectedTemplates = []string{
-		"templates/operator/pdb.yaml",
-	}
-	testOperatorHelmTemplates(t, opts, expectedTemplates, unexpectedTemplates)
-}
-
-func testOperatorHelmTemplates(t *testing.T, opts *helm.Options, expectedTemplates, unexpectedTemplates []string) {
+func testOperatorHelmTemplates(opts *helm.Options, expectedTemplates, unexpectedTemplates []string) {
 	for _, tpl := range expectedTemplates {
-		_, err := helm.RenderTemplateE(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{tpl})
+		_, err := helm.RenderTemplateE(GinkgoT(), opts, operatorHelmChartPath, operatorHelmReleaseName, []string{tpl})
 		Expect(err).ToNot(HaveOccurred())
 	}
 
 	for _, tpl := range unexpectedTemplates {
-		_, err := helm.RenderTemplateE(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{tpl})
+		_, err := helm.RenderTemplateE(GinkgoT(), opts, operatorHelmChartPath, operatorHelmReleaseName, []string{tpl})
 		Expect(err).To(HaveOccurred())
 	}
 }
 
-func TestOperatorHelmImageTagAndDigest(t *testing.T) {
-	RegisterTestingT(t)
+var _ = Describe("MariaDB operator Helm chart", func() {
+	It("renders extra envFrom", func() {
+		opts := &helm.Options{
+			// see https://helm.sh/docs/intro/using_helm/#the-format-and-limitations-of---set
+			SetValues: map[string]string{
+				"extraEnvFrom[0].configMapRef.name": `env-extra-configmap`,
+				"extraEnvFrom[1].secretRef.name":    `env-extra-secret`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
 
-	repository := "ghcr.io/mariadb-operator/mariadb-operator"
-	tag := "v1.0.0"
-	digest := "sha256:abc123def456"
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
 
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"image.repository": repository,
-			"image.tag":        tag,
-			"image.digest":     digest,
-		},
-	}
+		container := deployment.Spec.Template.Spec.Containers[0]
+		Expect(container.Name).To(Equal("controller"))
 
-	renderedData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, renderedData, &deployment)
+		configMapEnvFrom := corev1.EnvFromSource{
+			ConfigMapRef: &corev1.ConfigMapEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "env-extra-configmap",
+				},
+			},
+		}
+		Expect(container.EnvFrom).To(ContainElement(configMapEnvFrom))
 
-	container := deployment.Spec.Template.Spec.Containers[0]
-	Expect(container.Name).To(Equal("controller"))
-	Expect(container.Image).To(ContainSubstring(repository + "@" + digest))
+		secretEnvFrom := corev1.EnvFromSource{
+			SecretRef: &corev1.SecretEnvSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: "env-extra-secret",
+				},
+			},
+		}
+		Expect(container.EnvFrom).To(ContainElement(secretEnvFrom))
+	})
 
-	opts = &helm.Options{
-		SetValues: map[string]string{
-			"image.repository": repository,
-			"image.tag":        tag,
-		},
-	}
+	It("renders for current namespace only", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"currentNamespaceOnly": `true`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
 
-	renderedData = helm.RenderTemplate(t, opts, operatorHelmChartPath, operatorHelmReleaseName, []string{"templates/operator/deployment.yaml"})
-	helm.UnmarshalK8SYaml(t, renderedData, &deployment)
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
 
-	container = deployment.Spec.Template.Spec.Containers[0]
-	Expect(container.Name).To(Equal("controller"))
-	Expect(container.Image).To(ContainSubstring(repository + ":" + tag))
-}
+		container := deployment.Spec.Template.Spec.Containers[0]
+		Expect(container.Name).To(Equal("controller"))
 
-func TestOperatorHelmConfigMap(t *testing.T) {
-	RegisterTestingT(t)
-	repository := "ghcr.io/mariadb-operator/mariadb-operator"
-	tag := "v1.0.0"
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"image.repository":                        repository,
-			"image.tag":                               tag,
-			"config.galeraLibPath":                    "/path/to/libgalera.so",
-			"config.mariadbDefaultVersion":            "11.4",
-			"config.mariadbImage.repository":          "mariadb",
-			"config.mariadbImage.tag":                 "10.5",
-			"config.mariadbImageName":                 "mariadb",
-			"config.maxscaleImage.repository":         "maxscale",
-			"config.maxscaleImage.tag":                "2.5",
-			"config.exporterImage.repository":         "exporter",
-			"config.exporterImage.tag":                "1.0",
-			"config.exporterMaxscaleImage.repository": "exporter-maxscale",
-			"config.exporterMaxscaleImage.tag":        "1.0",
-		},
-	}
-	configMapData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/configmap.yaml"})
-	var configMap corev1.ConfigMap
-	helm.UnmarshalK8SYaml(t, configMapData, &configMap)
-	Expect(configMap.Name).To(Equal("mariadb-operator-env"))
-	Expect(configMap.Data["MARIADB_OPERATOR_IMAGE"]).To(Equal(repository + ":" + tag))
-	Expect(configMap.Data["MARIADB_GALERA_LIB_PATH"]).To(Equal("/path/to/libgalera.so"))
-	Expect(configMap.Data["MARIADB_DEFAULT_VERSION"]).To(Equal("11.4"))
-	Expect(configMap.Data["RELATED_IMAGE_MARIADB"]).To(Equal("mariadb:10.5"))
-	Expect(configMap.Data["RELATED_IMAGE_MARIADB_NAME"]).To(Equal("mariadb"))
-	Expect(configMap.Data["RELATED_IMAGE_MAXSCALE"]).To(Equal("maxscale:2.5"))
-	Expect(configMap.Data["RELATED_IMAGE_EXPORTER"]).To(Equal("exporter:1.0"))
-	Expect(configMap.Data["RELATED_IMAGE_EXPORTER_MAXSCALE"]).To(Equal("exporter-maxscale:1.0"))
-}
+		env := corev1.EnvVar{
+			Name:  "WATCH_NAMESPACE",
+			Value: operatorTestNamespace,
+		}
+		Expect(container.Env).To(ContainElement(env))
 
-func TestOperatorHelmPprof(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"pprof.enabled": `true`,
-			"pprof.port":    `6060`,
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+		expectedTemplates := []string{
+			"templates/operator/rbac-namespace.yaml",
+		}
+		unexpectedTemplates := []string{
+			"templates/cert-controller/deployment.yaml",
+			"templates/cert-controller/rbac.yaml",
+			"templates/cert-controller/serviceaccount.yaml",
+			"templates/cert-controller/servicemonitor.yaml",
+			"templates/operator/rbac-user.yaml",
+			"templates/operator/rbac.yaml",
+			"templates/webhook/certificate.yaml",
+			"templates/webhook/config.yaml",
+			"templates/webhook/deployment.yaml",
+			"templates/webhook/service.yaml",
+			"templates/webhook/serviceaccount.yaml",
+			"templates/webhook/servicemonitor.yaml",
+		}
+		testOperatorHelmTemplates(opts, expectedTemplates, unexpectedTemplates)
+	})
 
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+	It("renders cluster wide", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"webhook.cert.certManager.enabled": `true`,
+				"metrics.enabled":                  `true`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
 
-	container := deployment.Spec.Template.Spec.Containers[0]
-	Expect(container.Name).To(Equal("controller"))
-	Expect(container.Args).To(ContainElement("--pprof"))
-	Expect(container.Args).To(ContainElement("--pprof-addr=:6060"))
-	Expect(container.Ports).To(ContainElement(corev1.ContainerPort{
-		Name:          "pprof",
-		Protocol:      "TCP",
-		ContainerPort: 6060,
-	}))
-}
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
 
-func TestOperatorHelmRevisionHistoryLimit(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+		container := deployment.Spec.Template.Spec.Containers[0]
+		Expect(container.Name).To(Equal("controller"))
 
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+		env := corev1.EnvVar{
+			Name:  "WATCH_NAMESPACE",
+			Value: operatorTestNamespace,
+		}
+		Expect(container.Env).ToNot(ContainElement(env))
 
-	// Check default revision history limit
-	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
-	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(10)))
+		expectedTemplates := []string{
+			"templates/operator/rbac-user.yaml",
+			"templates/operator/rbac.yaml",
+			"templates/webhook/certificate.yaml",
+			"templates/webhook/config.yaml",
+			"templates/webhook/deployment.yaml",
+			"templates/webhook/service.yaml",
+			"templates/webhook/serviceaccount.yaml",
+		}
+		unexpectedTemplates := []string{
+			"templates/operator/rbac-namespace.yaml",
+		}
+		testOperatorHelmTemplates(opts, expectedTemplates, unexpectedTemplates)
+	})
 
-	// Test with custom revision history limit
-	opts = &helm.Options{
-		SetValues: map[string]string{
-			"revisionHistoryLimit": "5",
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+	It("renders cert manager", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"webhook.cert.certManager.enabled": `true`,
+			},
+		}
 
-	deploymentData = helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/deployment.yaml"})
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+		expectedTemplates := []string{
+			"templates/webhook/certificate.yaml",
+		}
+		unexpectedTemplates := []string{
+			"templates/cert-controller/deployment.yaml",
+			"templates/cert-controller/rbac.yaml",
+			"templates/cert-controller/serviceaccount.yaml",
+		}
+		testOperatorHelmTemplates(opts, expectedTemplates, unexpectedTemplates)
+	})
 
-	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
-	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(5)))
-}
+	It("renders metrics", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"metrics.enabled": `true`,
+			},
+		}
 
-func TestOperatorHelmStrategy(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"strategy.type":                         "RollingUpdate",
-			"strategy.rollingUpdate.maxSurge":       "1",
-			"strategy.rollingUpdate.maxUnavailable": "0",
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+		expectedTemplates := []string{
+			"templates/cert-controller/servicemonitor.yaml",
+			"templates/webhook/servicemonitor.yaml",
+		}
+		testOperatorHelmTemplates(opts, expectedTemplates, nil)
+	})
 
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/operator/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+	It("renders webhook", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"webhook.enabled": `true`,
+			},
+		}
+		expectedTemplates := []string{
+			"templates/webhook/config.yaml",
+			"templates/webhook/deployment.yaml",
+			"templates/webhook/service.yaml",
+			"templates/webhook/serviceaccount.yaml",
+		}
+		unexpectedTemplates := []string{}
+		testOperatorHelmTemplates(opts, expectedTemplates, unexpectedTemplates)
 
-	Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
-	Expect(deployment.Spec.Strategy.RollingUpdate).ToNot(BeNil())
-	Expect(deployment.Spec.Strategy.RollingUpdate.MaxSurge.String()).To(Equal("1"))
-	Expect(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable.String()).To(Equal("0"))
-}
+		opts = &helm.Options{
+			SetValues: map[string]string{
+				"webhook.enabled": `false`,
+			},
+		}
+		expectedTemplates = []string{}
+		unexpectedTemplates = []string{
+			"templates/webhook/config.yaml",
+			"templates/webhook/deployment.yaml",
+			"templates/webhook/service.yaml",
+			"templates/webhook/serviceaccount.yaml",
+			"templates/webhook/pdb.yaml",
+		}
+		testOperatorHelmTemplates(opts, expectedTemplates, unexpectedTemplates)
+	})
 
-func TestWebhookHelmRevisionHistoryLimit(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"webhook.enabled": `true`,
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+	It("renders cert controller", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"certController.enabled": `true`,
+			},
+		}
+		expectedTemplates := []string{
+			"templates/cert-controller/deployment.yaml",
+			"templates/cert-controller/rbac.yaml",
+			"templates/cert-controller/serviceaccount.yaml",
+		}
+		unexpectedTemplates := []string{}
+		testOperatorHelmTemplates(opts, expectedTemplates, unexpectedTemplates)
 
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/webhook/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+		opts = &helm.Options{
+			SetValues: map[string]string{
+				"certController.enabled": `false`,
+			},
+		}
+		expectedTemplates = []string{}
+		unexpectedTemplates = []string{
+			"templates/cert-controller/deployment.yaml",
+			"templates/cert-controller/rbac.yaml",
+			"templates/cert-controller/serviceaccount.yaml",
+			"templates/cert-controller/pdb.yaml",
+		}
+		testOperatorHelmTemplates(opts, expectedTemplates, unexpectedTemplates)
+	})
 
-	// Check default revision history limit
-	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
-	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(10)))
+	It("renders with HA enabled", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"ha.enabled": `true`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
 
-	// Test with custom revision history limit
-	opts = &helm.Options{
-		SetValues: map[string]string{
-			"webhook.enabled":              `true`,
-			"webhook.revisionHistoryLimit": "3",
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
 
-	deploymentData = helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/webhook/deployment.yaml"})
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+		container := deployment.Spec.Template.Spec.Containers[0]
+		Expect(container.Name).To(Equal("controller"))
 
-	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
-	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(3)))
-}
+		replicas := int(*deployment.Spec.Replicas)
+		Expect(replicas).To(Equal(3))
+		Expect(container.Args).To(ContainElement("--leader-elect"))
+	})
 
-func TestWebhookHelmStrategy(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"webhook.enabled":       `true`,
-			"webhook.strategy.type": "Recreate",
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+	It("renders with PDB enabled", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"pdb.enabled": `true`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+		pdbData := helm.RenderTemplate(GinkgoT(), opts, operatorHelmChartPath, operatorHelmReleaseName, []string{"templates/operator/pdb.yaml"})
+		var pdb policyv1.PodDisruptionBudget
+		helm.UnmarshalK8SYaml(GinkgoT(), pdbData, &pdb)
+		maxUnavailable := pdb.Spec.MaxUnavailable.IntValue()
+		Expect(maxUnavailable).To(Equal(1))
 
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/webhook/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+		opts = &helm.Options{
+			SetValues: map[string]string{
+				"pdb.enabled":        `true`,
+				"pdb.maxUnavailable": "50%",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+		pdbData = helm.RenderTemplate(GinkgoT(), opts, operatorHelmChartPath, operatorHelmReleaseName, []string{"templates/operator/pdb.yaml"})
+		helm.UnmarshalK8SYaml(GinkgoT(), pdbData, &pdb)
+		maxUnavailablePercent := pdb.Spec.MaxUnavailable.String()
+		Expect(maxUnavailablePercent).To(Equal("50%"))
 
-	Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
-}
+		expectedTemplates := []string{
+			"templates/operator/pdb.yaml",
+		}
+		unexpectedTemplates := []string{}
+		testOperatorHelmTemplates(opts, expectedTemplates, unexpectedTemplates)
 
-func TestCertControllerHelmRevisionHistoryLimit(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"certController.enabled": `true`,
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+		opts = &helm.Options{
+			SetValues: map[string]string{
+				"pdb.enabled": `false`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+		expectedTemplates = []string{}
+		unexpectedTemplates = []string{
+			"templates/operator/pdb.yaml",
+		}
+		testOperatorHelmTemplates(opts, expectedTemplates, unexpectedTemplates)
+	})
 
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/cert-controller/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+	It("renders image tag and digest", func() {
+		repository := "docker-registry3.mariadb.com/mariadb-operator/mariadb-operator"
+		tag := "v1.0.0"
+		digest := "sha256:abc123def456"
 
-	// Check default revision history limit
-	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
-	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(10)))
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"image.repository": repository,
+				"image.tag":        tag,
+				"image.digest":     digest,
+			},
+		}
 
-	// Test with custom revision history limit
-	opts = &helm.Options{
-		SetValues: map[string]string{
-			"certController.enabled":              `true`,
-			"certController.revisionHistoryLimit": "7",
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+		renderedData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), renderedData, &deployment)
 
-	deploymentData = helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/cert-controller/deployment.yaml"})
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+		container := deployment.Spec.Template.Spec.Containers[0]
+		Expect(container.Name).To(Equal("controller"))
+		Expect(container.Image).To(ContainSubstring(repository + "@" + digest))
 
-	Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
-	Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(7)))
-}
+		opts = &helm.Options{
+			SetValues: map[string]string{
+				"image.repository": repository,
+				"image.tag":        tag,
+			},
+		}
 
-func TestCertControllerHelmStrategy(t *testing.T) {
-	RegisterTestingT(t)
-	opts := &helm.Options{
-		SetValues: map[string]string{
-			"certController.enabled":                               `true`,
-			"certController.strategy.type":                         "RollingUpdate",
-			"certController.strategy.rollingUpdate.maxSurge":       "25%",
-			"certController.strategy.rollingUpdate.maxUnavailable": "25%",
-		},
-		KubectlOptions: &k8s.KubectlOptions{
-			Namespace: operatorTestNamespace,
-		},
-	}
+		renderedData = helm.RenderTemplate(GinkgoT(), opts, operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		helm.UnmarshalK8SYaml(GinkgoT(), renderedData, &deployment)
 
-	deploymentData := helm.RenderTemplate(t, opts,
-		operatorHelmChartPath, operatorHelmReleaseName,
-		[]string{"templates/cert-controller/deployment.yaml"})
-	var deployment appsv1.Deployment
-	helm.UnmarshalK8SYaml(t, deploymentData, &deployment)
+		container = deployment.Spec.Template.Spec.Containers[0]
+		Expect(container.Name).To(Equal("controller"))
+		Expect(container.Image).To(ContainSubstring(repository + ":" + tag))
+	})
 
-	Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
-	Expect(deployment.Spec.Strategy.RollingUpdate).ToNot(BeNil())
-	Expect(deployment.Spec.Strategy.RollingUpdate.MaxSurge.String()).To(Equal("25%"))
-	Expect(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable.String()).To(Equal("25%"))
-}
+	It("renders the config map", func() {
+		repository := "docker-registry3.mariadb.com/mariadb-operator/mariadb-operator"
+		tag := "v1.0.0"
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"image.repository":                        repository,
+				"image.tag":                               tag,
+				"config.galeraLibPath":                    "/path/to/libgalera.so",
+				"config.mariadbDefaultVersion":            "11.4",
+				"config.mariadbImage.repository":          "mariadb",
+				"config.mariadbImage.tag":                 "10.5",
+				"config.mariadbImageName":                 "mariadb",
+				"config.maxscaleImage.repository":         "maxscale",
+				"config.maxscaleImage.tag":                "2.5",
+				"config.exporterImage.repository":         "exporter",
+				"config.exporterImage.tag":                "1.0",
+				"config.exporterMaxscaleImage.repository": "exporter-maxscale",
+				"config.exporterMaxscaleImage.tag":        "1.0",
+			},
+		}
+		configMapData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/configmap.yaml"})
+		var configMap corev1.ConfigMap
+		helm.UnmarshalK8SYaml(GinkgoT(), configMapData, &configMap)
+		Expect(configMap.Name).To(Equal("mariadb-operator-env"))
+		Expect(configMap.Data["MARIADB_OPERATOR_IMAGE"]).To(Equal(repository + ":" + tag))
+		Expect(configMap.Data["MARIADB_GALERA_LIB_PATH"]).To(Equal("/path/to/libgalera.so"))
+		Expect(configMap.Data["MARIADB_DEFAULT_VERSION"]).To(Equal("11.4"))
+		Expect(configMap.Data["RELATED_IMAGE_MARIADB"]).To(Equal("mariadb:10.5"))
+		Expect(configMap.Data["RELATED_IMAGE_MARIADB_NAME"]).To(Equal("mariadb"))
+		Expect(configMap.Data["RELATED_IMAGE_MAXSCALE"]).To(Equal("maxscale:2.5"))
+		Expect(configMap.Data["RELATED_IMAGE_EXPORTER"]).To(Equal("exporter:1.0"))
+		Expect(configMap.Data["RELATED_IMAGE_EXPORTER_MAXSCALE"]).To(Equal("exporter-maxscale:1.0"))
+	})
+
+	It("renders pprof", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"pprof.enabled": `true`,
+				"pprof.port":    `6060`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		container := deployment.Spec.Template.Spec.Containers[0]
+		Expect(container.Name).To(Equal("controller"))
+		Expect(container.Args).To(ContainElement("--pprof"))
+		Expect(container.Args).To(ContainElement("--pprof-addr=:6060"))
+		Expect(container.Ports).To(ContainElement(corev1.ContainerPort{
+			Name:          "pprof",
+			Protocol:      "TCP",
+			ContainerPort: 6060,
+		}))
+	})
+
+	It("renders operator revision history limit", func() {
+		opts := &helm.Options{
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		// Check default revision history limit
+		Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+		Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(10)))
+
+		// Test with custom revision history limit
+		opts = &helm.Options{
+			SetValues: map[string]string{
+				"revisionHistoryLimit": "5",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData = helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+		Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(5)))
+	})
+
+	It("renders operator strategy", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"strategy.type":                         "RollingUpdate",
+				"strategy.rollingUpdate.maxSurge":       "1",
+				"strategy.rollingUpdate.maxUnavailable": "0",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/operator/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
+		Expect(deployment.Spec.Strategy.RollingUpdate).ToNot(BeNil())
+		Expect(deployment.Spec.Strategy.RollingUpdate.MaxSurge.String()).To(Equal("1"))
+		Expect(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable.String()).To(Equal("0"))
+	})
+
+	It("renders webhook revision history limit", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"webhook.enabled": `true`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/webhook/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		// Check default revision history limit
+		Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+		Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(10)))
+
+		// Test with custom revision history limit
+		opts = &helm.Options{
+			SetValues: map[string]string{
+				"webhook.enabled":              `true`,
+				"webhook.revisionHistoryLimit": "3",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData = helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/webhook/deployment.yaml"})
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+		Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(3)))
+	})
+
+	It("renders webhook strategy", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"webhook.enabled":       `true`,
+				"webhook.strategy.type": "Recreate",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/webhook/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RecreateDeploymentStrategyType))
+	})
+
+	It("renders cert controller revision history limit", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"certController.enabled": `true`,
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/cert-controller/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		// Check default revision history limit
+		Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+		Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(10)))
+
+		// Test with custom revision history limit
+		opts = &helm.Options{
+			SetValues: map[string]string{
+				"certController.enabled":              `true`,
+				"certController.revisionHistoryLimit": "7",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData = helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/cert-controller/deployment.yaml"})
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		Expect(deployment.Spec.RevisionHistoryLimit).ToNot(BeNil())
+		Expect(*deployment.Spec.RevisionHistoryLimit).To(Equal(int32(7)))
+	})
+
+	It("renders cert controller strategy", func() {
+		opts := &helm.Options{
+			SetValues: map[string]string{
+				"certController.enabled":                               `true`,
+				"certController.strategy.type":                         "RollingUpdate",
+				"certController.strategy.rollingUpdate.maxSurge":       "25%",
+				"certController.strategy.rollingUpdate.maxUnavailable": "25%",
+			},
+			KubectlOptions: &k8s.KubectlOptions{
+				Namespace: operatorTestNamespace,
+			},
+		}
+
+		deploymentData := helm.RenderTemplate(GinkgoT(), opts,
+			operatorHelmChartPath, operatorHelmReleaseName,
+			[]string{"templates/cert-controller/deployment.yaml"})
+		var deployment appsv1.Deployment
+		helm.UnmarshalK8SYaml(GinkgoT(), deploymentData, &deployment)
+
+		Expect(deployment.Spec.Strategy.Type).To(Equal(appsv1.RollingUpdateDeploymentStrategyType))
+		Expect(deployment.Spec.Strategy.RollingUpdate).ToNot(BeNil())
+		Expect(deployment.Spec.Strategy.RollingUpdate.MaxSurge.String()).To(Equal("25%"))
+		Expect(deployment.Spec.Strategy.RollingUpdate.MaxUnavailable.String()).To(Equal("25%"))
+	})
+})

--- a/internal/helmtest/suite_test.go
+++ b/internal/helmtest/suite_test.go
@@ -1,0 +1,13 @@
+package test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHelmtest(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Helmtest Suite")
+}


### PR DESCRIPTION
Migrates `internal/helmtest` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified relative to the base branch.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `mariadb_operator_test.go` (18 specs) and `mariadb_cluster_test.go` (7 specs) converted to `Describe` blocks with `It` specs. Entry/spec names match the original test / `t.Run()` names.

Verified with:
```
go test ./internal/helmtest/...
```

Part of #368.
