### PR TITLE
test: migrate pkg/builder tests to Ginkgo

### DIFF
--- a/pkg/builder/batch_builder_test.go
+++ b/pkg/builder/batch_builder_test.go
@@ -1,18 +1,18 @@
 package builder
 
 import (
-	"fmt"
 	"reflect"
 	"strings"
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	labels "github.com/mariadb-operator/mariadb-operator/v26/pkg/builder/labels"
 	builderpki "github.com/mariadb-operator/mariadb-operator/v26/pkg/builder/pki"
 	galeraresources "github.com/mariadb-operator/mariadb-operator/v26/pkg/controller/galera/resources"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/replication"
-	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -22,22 +22,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestBackupJobImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("BackupJobImagePullSecrets", func() {
 	objMeta := metav1.ObjectMeta{
 		Name:      "backup-image-pull-secrets",
 		Namespace: "test",
 	}
-
-	tests := []struct {
-		name            string
-		backup          *mariadbv1alpha1.Backup
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			backup: &mariadbv1alpha1.Backup{
+	DescribeTable("BuildBackupJob ImagePullSecrets",
+		func(backup *mariadbv1alpha1.Backup, mariadb *mariadbv1alpha1.MariaDB, wantPullSecrets []corev1.LocalObjectReference) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildBackupJob(client.ObjectKeyFromObject(backup), backup, mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry("No Secrets",
+			&mariadbv1alpha1.Backup{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.BackupSpec{
 					MariaDBRef: mariadbv1alpha1.MariaDBRef{
@@ -50,15 +48,14 @@ func TestBackupJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec:       mariadbv1alpha1.MariaDBSpec{},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MariaDB",
-			backup: &mariadbv1alpha1.Backup{
+			nil,
+		),
+		Entry("Secrets in MariaDB",
+			&mariadbv1alpha1.Backup{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.BackupSpec{
 					MariaDBRef: mariadbv1alpha1.MariaDBRef{
@@ -71,7 +68,7 @@ func TestBackupJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -83,15 +80,14 @@ func TestBackupJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in Backup",
-			backup: &mariadbv1alpha1.Backup{
+		),
+		Entry("Secrets in Backup",
+			&mariadbv1alpha1.Backup{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.BackupSpec{
 					JobPodTemplate: mariadbv1alpha1.JobPodTemplate{
@@ -111,19 +107,18 @@ func TestBackupJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec:       mariadbv1alpha1.MariaDBSpec{},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "backup-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in MariaDB and Backup",
-			backup: &mariadbv1alpha1.Backup{
+		),
+		Entry("Secrets in MariaDB and Backup",
+			&mariadbv1alpha1.Backup{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.BackupSpec{
 					JobPodTemplate: mariadbv1alpha1.JobPodTemplate{
@@ -143,7 +138,7 @@ func TestBackupJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -155,7 +150,7 @@ func TestBackupJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
@@ -163,43 +158,19 @@ func TestBackupJobImagePullSecrets(t *testing.T) {
 					Name: "backup-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildBackupJob(client.ObjectKeyFromObject(tt.backup), tt.backup, tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building Job: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-// While this test tests mainly the kubernetes_volume_types.go implementation, it still makes a lot of sense to do it
-// here as we get the bonus test coverage if the job building code correctly creates our volume sources. Because of this
-// we only need to do this for backup and not restore.
-// NOTE: We are using a lot of reflection to also capture cases in which a new field is added to the StorageVolumeSource
-// but simply not properly implemented in any of the remaining code. If we would only test for static fields, this test
-// would still pass while this new field would not be properly covered by a test.
-func TestBackupJobVolumeSource(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("BackupJobVolumeSource", func() {
 	objMeta := metav1.ObjectMeta{
 		Name:      "backup-volume-source",
 		Namespace: "test",
 	}
-
 	mariadb := &mariadbv1alpha1.MariaDB{
 		ObjectMeta: objMeta,
 		Spec:       mariadbv1alpha1.MariaDBSpec{},
 	}
-
-	// To make our testing easier (see our reflection code below), we define a single volume source that has ALL volume
-	// source fields set!
-	// NOTE: Our test does NOT check if the actual values are correct in the final job and corev1.VolumeSource.
 	volumeSources := mariadbv1alpha1.StorageVolumeSource{
 		EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
 		NFS: &mariadbv1alpha1.NFSVolumeSource{
@@ -218,20 +189,16 @@ func TestBackupJobVolumeSource(t *testing.T) {
 			ClaimName: "test-pvc",
 		},
 	}
-
 	storageVolumeSourceType := reflect.TypeOf(volumeSources)
 	storageVolumeSourceValue := reflect.ValueOf(volumeSources)
 
 	for i := 0; i < storageVolumeSourceType.NumField(); i++ {
 		field := storageVolumeSourceType.Field(i)
-
-		// To prevent our code from being too fragile (as many of the copy code uses ifs without early aborts), we want
-		// to create a plain StorageVolumeSource with only a single field set. So we need to "dynamically" copy over
-		// from our volumeSources into this new volume source.
 		volumeSource := mariadbv1alpha1.StorageVolumeSource{}
 		reflect.ValueOf(&volumeSource).Elem().FieldByName(field.Name).Set(storageVolumeSourceValue.FieldByName(field.Name))
 
-		t.Run(field.Name, func(t *testing.T) {
+		It(field.Name, func() {
+			builder := newDefaultTestBuilder()
 			backup := &mariadbv1alpha1.Backup{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.BackupSpec{
@@ -247,54 +214,45 @@ func TestBackupJobVolumeSource(t *testing.T) {
 			}
 
 			job, err := builder.BuildBackupJob(client.ObjectKeyFromObject(backup), backup, mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building Job: %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
 
 			coreVolumeSourceValue := reflect.ValueOf(*getVolumeSource(batchStorageVolume, job))
-			if coreVolumeSourceValue.FieldByName(field.Name).IsNil() {
-				// NOTE: Ensure, the field is copied in `func (v StorageVolumeSource) ToKubernetesType()
-				// corev1.VolumeSource`.
-				t.Fatalf("The volume source field '%s' is not properly implemented as it is nil in corev1.VolumeSource.", field.Name)
-			}
-
+			Expect(coreVolumeSourceValue.FieldByName(field.Name).IsNil()).To(BeFalse())
 		})
 	}
+})
 
-}
-
-func TestBackupJobMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("BackupJobMeta", func() {
 	key := types.NamespacedName{
 		Name: "backup-job",
 	}
-	tests := []struct {
-		name        string
-		backup      *mariadbv1alpha1.Backup
-		wantJobMeta *mariadbv1alpha1.Metadata
-		wantPodMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			backup: &mariadbv1alpha1.Backup{
+	DescribeTable("BuildBackupJob Meta",
+		func(backup *mariadbv1alpha1.Backup, wantJobMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildBackupJob(key, backup, &mariadbv1alpha1.MariaDB{})
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&job.ObjectMeta, wantJobMeta.Labels, wantJobMeta.Annotations)
+			assertObjectMeta(&job.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					Storage: mariadbv1alpha1.BackupStorage{
 						PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{},
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit metadata",
-			backup: &mariadbv1alpha1.Backup{
+		),
+		Entry("inherit metadata",
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					Storage: mariadbv1alpha1.BackupStorage{
 						PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{},
@@ -309,7 +267,7 @@ func TestBackupJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -317,7 +275,7 @@ func TestBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -325,10 +283,9 @@ func TestBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod meta",
-			backup: &mariadbv1alpha1.Backup{
+		),
+		Entry("Pod meta",
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					Storage: mariadbv1alpha1.BackupStorage{
 						PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{},
@@ -345,11 +302,11 @@ func TestBackupJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -357,10 +314,9 @@ func TestBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "override inherit metadata",
-			backup: &mariadbv1alpha1.Backup{
+		),
+		Entry("override inherit metadata",
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					Storage: mariadbv1alpha1.BackupStorage{
 						PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{},
@@ -385,7 +341,7 @@ func TestBackupJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "true",
 				},
@@ -393,7 +349,7 @@ func TestBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -401,10 +357,9 @@ func TestBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "all",
-			backup: &mariadbv1alpha1.Backup{
+		),
+		Entry("all",
+			&mariadbv1alpha1.Backup{
 				Spec: mariadbv1alpha1.BackupSpec{
 					Storage: mariadbv1alpha1.BackupStorage{
 						PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{},
@@ -423,13 +378,13 @@ func TestBackupJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{},
 				Annotations: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -437,23 +392,11 @@ func TestBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildBackupJob(key, tt.backup, &mariadbv1alpha1.MariaDB{})
-			if err != nil {
-				t.Fatalf("unexpected error building Backup Job: %v", err)
-			}
-			assertObjectMeta(t, &job.ObjectMeta, tt.wantJobMeta.Labels, tt.wantJobMeta.Annotations)
-			assertObjectMeta(t, &job.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestPhysicalBackupJobPodAffinity(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("PhysicalBackupJobPodAffinity", func() {
 	podObjMeta := metav1.ObjectMeta{
 		Name: "mariadb-0",
 	}
@@ -463,29 +406,48 @@ func TestPhysicalBackupJobPodAffinity(t *testing.T) {
 		},
 		Spec: mariadbv1alpha1.MariaDBSpec{},
 	}
+	DescribeTable("BuildPhysicalBackupJob PodAffinity",
+		func(backup *mariadbv1alpha1.PhysicalBackup, pod *corev1.Pod, wantErr bool, wantPodAffinity bool) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildPhysicalBackupJob(
+				client.ObjectKeyFromObject(backup),
+				backup,
+				mariadb,
+				pod,
+				"backupfile",
+			)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			affinity := job.Spec.Template.Spec.Affinity
+			if wantPodAffinity {
+				Expect(affinity).NotTo(BeNil())
+				Expect(affinity.PodAffinity).NotTo(BeNil())
+				Expect(affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution).NotTo(BeEmpty())
 
-	tests := []struct {
-		name            string
-		backup          *mariadbv1alpha1.PhysicalBackup
-		pod             *corev1.Pod
-		wantErr         bool
-		wantPodAffinity bool
-	}{
-		{
-			name:   "error when pod nodeName is empty",
-			backup: &mariadbv1alpha1.PhysicalBackup{},
-			pod: &corev1.Pod{
+				term := affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
+				Expect(term.TopologyKey).To(Equal("kubernetes.io/hostname"))
+				Expect(term.LabelSelector.MatchLabels["app.kubernetes.io/instance"]).To(Equal(mariadb.Name))
+				Expect(term.LabelSelector.MatchLabels["statefulset.kubernetes.io/pod-name"]).To(Equal(pod.Name))
+			} else {
+				Expect(affinity == nil || affinity.PodAffinity == nil).To(BeTrue())
+			}
+		},
+		Entry("error when pod nodeName is empty",
+			&mariadbv1alpha1.PhysicalBackup{},
+			&corev1.Pod{
 				ObjectMeta: podObjMeta,
 				Spec: corev1.PodSpec{
 					NodeName: "",
 				},
 			},
-			wantErr:         true,
-			wantPodAffinity: false,
-		},
-		{
-			name: "podAffinity set when podAffinity is true (default)",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+			true,
+			false,
+		),
+		Entry("podAffinity set when podAffinity is true (default)",
+			&mariadbv1alpha1.PhysicalBackup{
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					Storage: mariadbv1alpha1.PhysicalBackupStorage{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -494,18 +456,17 @@ func TestPhysicalBackupJobPodAffinity(t *testing.T) {
 					},
 				},
 			},
-			pod: &corev1.Pod{
+			&corev1.Pod{
 				ObjectMeta: podObjMeta,
 				Spec: corev1.PodSpec{
 					NodeName: "node-1",
 				},
 			},
-			wantErr:         false,
-			wantPodAffinity: true,
-		},
-		{
-			name: "podAffinity set when podAffinity is true (explicit)",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+			false,
+			true,
+		),
+		Entry("podAffinity set when podAffinity is true (explicit)",
+			&mariadbv1alpha1.PhysicalBackup{
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					PodAffinity: ptr.To(true),
 					Storage: mariadbv1alpha1.PhysicalBackupStorage{
@@ -515,18 +476,17 @@ func TestPhysicalBackupJobPodAffinity(t *testing.T) {
 					},
 				},
 			},
-			pod: &corev1.Pod{
+			&corev1.Pod{
 				ObjectMeta: podObjMeta,
 				Spec: corev1.PodSpec{
 					NodeName: "node-1",
 				},
 			},
-			wantErr:         false,
-			wantPodAffinity: true,
-		},
-		{
-			name: "podAffinity not set when podAffinity is false",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+			false,
+			true,
+		),
+		Entry("podAffinity not set when podAffinity is false",
+			&mariadbv1alpha1.PhysicalBackup{
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					PodAffinity: ptr.To(false),
 					Storage: mariadbv1alpha1.PhysicalBackupStorage{
@@ -536,58 +496,19 @@ func TestPhysicalBackupJobPodAffinity(t *testing.T) {
 					},
 				},
 			},
-			pod: &corev1.Pod{
+			&corev1.Pod{
 				ObjectMeta: podObjMeta,
 				Spec: corev1.PodSpec{
 					NodeName: "node-1",
 				},
 			},
-			wantErr:         false,
-			wantPodAffinity: false,
-		},
-	}
+			false,
+			false,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildPhysicalBackupJob(
-				client.ObjectKeyFromObject(tt.backup),
-				tt.backup,
-				mariadb,
-				tt.pod,
-				"backupfile",
-			)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error but got none")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			affinity := job.Spec.Template.Spec.Affinity
-			if tt.wantPodAffinity {
-				assert.NotNil(t, affinity, "expected affinity to be set")
-				assert.NotNil(t, affinity.PodAffinity, "expected podAffinity to be set")
-				assert.NotEmpty(t, affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution, "expected required pod affinity terms")
-
-				term := affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution[0]
-				assert.Equal(t, "kubernetes.io/hostname", term.TopologyKey)
-				assert.Equal(t, mariadb.Name, term.LabelSelector.MatchLabels["app.kubernetes.io/instance"])
-				assert.Equal(t, tt.pod.Name, term.LabelSelector.MatchLabels["statefulset.kubernetes.io/pod-name"])
-			} else {
-				assert.True(
-					t,
-					affinity == nil || affinity.PodAffinity == nil,
-					fmt.Errorf("expected affinity to be nil or not have podAffinity, got %v", affinity),
-				)
-			}
-		})
-	}
-}
-
-func TestPhysicalBackupJobMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("PhysicalBackupJobMeta", func() {
 	key := types.NamespacedName{
 		Name: "physical-backup-job",
 	}
@@ -599,15 +520,16 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 			NodeName: "node-1",
 		},
 	}
-	tests := []struct {
-		name        string
-		backup      *mariadbv1alpha1.PhysicalBackup
-		wantJobMeta *mariadbv1alpha1.Metadata
-		wantPodMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+	DescribeTable("BuildPhysicalBackupJob Meta",
+		func(backup *mariadbv1alpha1.PhysicalBackup, wantJobMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildPhysicalBackupJob(key, backup, &mariadbv1alpha1.MariaDB{}, pod, "backupfile")
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&job.ObjectMeta, wantJobMeta.Labels, wantJobMeta.Annotations)
+			assertObjectMeta(&job.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.PhysicalBackup{
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					Storage: mariadbv1alpha1.PhysicalBackupStorage{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -616,18 +538,17 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit metadata",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+		),
+		Entry("inherit metadata",
+			&mariadbv1alpha1.PhysicalBackup{
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					Storage: mariadbv1alpha1.PhysicalBackupStorage{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -644,7 +565,7 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -652,7 +573,7 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -660,10 +581,9 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod meta",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+		),
+		Entry("Pod meta",
+			&mariadbv1alpha1.PhysicalBackup{
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					Storage: mariadbv1alpha1.PhysicalBackupStorage{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -682,11 +602,11 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -694,10 +614,9 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "override inherit metadata",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+		),
+		Entry("override inherit metadata",
+			&mariadbv1alpha1.PhysicalBackup{
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					Storage: mariadbv1alpha1.PhysicalBackupStorage{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -724,7 +643,7 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "true",
 				},
@@ -732,7 +651,7 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -740,10 +659,9 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "all",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+		),
+		Entry("all",
+			&mariadbv1alpha1.PhysicalBackup{
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					Storage: mariadbv1alpha1.PhysicalBackupStorage{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -764,13 +682,13 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{},
 				Annotations: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -778,23 +696,11 @@ func TestPhysicalBackupJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildPhysicalBackupJob(key, tt.backup, &mariadbv1alpha1.MariaDB{}, pod, "backupfile")
-			if err != nil {
-				t.Fatalf("unexpected error building PhysicalBackup Job: %v", err)
-			}
-			assertObjectMeta(t, &job.ObjectMeta, tt.wantJobMeta.Labels, tt.wantJobMeta.Annotations)
-			assertObjectMeta(t, &job.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestPhysicalBackupJobImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("PhysicalBackupJobImagePullSecrets", func() {
 	objMeta := metav1.ObjectMeta{
 		Name:      "physical-backup-image-pull-secrets",
 		Namespace: "test",
@@ -811,184 +717,133 @@ func TestPhysicalBackupJobImagePullSecrets(t *testing.T) {
 			NodeName: "node-1",
 		},
 	}
-
-	tests := []struct {
-		name            string
-		backup          *mariadbv1alpha1.PhysicalBackup
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			backup: &mariadbv1alpha1.PhysicalBackup{
-				ObjectMeta: objMeta,
-				Spec: mariadbv1alpha1.PhysicalBackupSpec{
-					Storage: mariadbv1alpha1.PhysicalBackupStorage{
-						Volume: &mariadbv1alpha1.StorageVolumeSource{
-							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
-						},
-					},
-				},
-			},
-			mariadb:         mariadb,
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MariaDB",
-			backup: &mariadbv1alpha1.PhysicalBackup{
-				ObjectMeta: objMeta,
-				Spec: mariadbv1alpha1.PhysicalBackupSpec{
-					Storage: mariadbv1alpha1.PhysicalBackupStorage{
-						Volume: &mariadbv1alpha1.StorageVolumeSource{
-							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
-						},
-					},
-				},
-			},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: objMeta,
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-						ImagePullSecrets: []mariadbv1alpha1.LocalObjectReference{
-							{
-								Name: "mariadb-registry",
-							},
-						},
-					},
-				},
-			},
-			wantPullSecrets: []corev1.LocalObjectReference{
-				{
-					Name: "mariadb-registry",
-				},
-			},
-		},
-		{
-			name: "Secrets in PhysicalBackup",
-			backup: &mariadbv1alpha1.PhysicalBackup{
-				ObjectMeta: objMeta,
-				Spec: mariadbv1alpha1.PhysicalBackupSpec{
-					PhysicalBackupPodTemplate: mariadbv1alpha1.PhysicalBackupPodTemplate{
-						ImagePullSecrets: []mariadbv1alpha1.LocalObjectReference{
-							{
-								Name: "physicalbackup-registry",
-							},
-						},
-					},
-					Storage: mariadbv1alpha1.PhysicalBackupStorage{
-						Volume: &mariadbv1alpha1.StorageVolumeSource{
-							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
-						},
-					},
-				},
-			},
-			mariadb: mariadb,
-			wantPullSecrets: []corev1.LocalObjectReference{
-				{
-					Name: "physicalbackup-registry",
-				},
-			},
-		},
-		{
-			name: "Secrets in MariaDB and PhysicalBackup",
-			backup: &mariadbv1alpha1.PhysicalBackup{
-				ObjectMeta: objMeta,
-				Spec: mariadbv1alpha1.PhysicalBackupSpec{
-					PhysicalBackupPodTemplate: mariadbv1alpha1.PhysicalBackupPodTemplate{
-						ImagePullSecrets: []mariadbv1alpha1.LocalObjectReference{
-							{
-								Name: "physicalbackup-registry",
-							},
-						},
-					},
-					Storage: mariadbv1alpha1.PhysicalBackupStorage{
-						Volume: &mariadbv1alpha1.StorageVolumeSource{
-							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
-						},
-					},
-				},
-			},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: objMeta,
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-						ImagePullSecrets: []mariadbv1alpha1.LocalObjectReference{
-							{
-								Name: "mariadb-registry",
-							},
-						},
-					},
-				},
-			},
-			wantPullSecrets: []corev1.LocalObjectReference{
-				{
-					Name: "mariadb-registry",
-				},
-				{
-					Name: "physicalbackup-registry",
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	DescribeTable("BuildPhysicalBackupJob ImagePullSecrets",
+		func(backup *mariadbv1alpha1.PhysicalBackup, mariadb *mariadbv1alpha1.MariaDB, wantPullSecrets []corev1.LocalObjectReference) {
+			builder := newDefaultTestBuilder()
 			job, err := builder.BuildPhysicalBackupJob(
-				client.ObjectKeyFromObject(tt.backup),
-				tt.backup,
-				tt.mariadb,
+				client.ObjectKeyFromObject(backup),
+				backup,
+				mariadb,
 				pod,
 				"backupfile",
 			)
-			if err != nil {
-				t.Fatalf("unexpected error building Job: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestPhysicalBackupJobInitContainers(t *testing.T) {
-	tests := []struct {
-		name               string
-		mariadb            *mariadbv1alpha1.MariaDB
-		wantInitContainers []string
-	}{
-		{
-			name: "Point-in-time recovery disabled",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Storage: mariadbv1alpha1.Storage{
-						Size: ptr.To(resource.MustParse("1Gi")),
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry("No Secrets",
+			&mariadbv1alpha1.PhysicalBackup{
+				ObjectMeta: objMeta,
+				Spec: mariadbv1alpha1.PhysicalBackupSpec{
+					Storage: mariadbv1alpha1.PhysicalBackupStorage{
+						Volume: &mariadbv1alpha1.StorageVolumeSource{
+							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+						},
 					},
 				},
 			},
-			wantInitContainers: []string{"mariadb"},
-		},
-		{
-			name: "Replication and point-in-time recovery enabled",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					PointInTimeRecoveryRef: &mariadbv1alpha1.LocalObjectReference{
-						Name: "test",
-					},
-					Replication: &mariadbv1alpha1.Replication{
-						Enabled: true,
-					},
-					Storage: mariadbv1alpha1.Storage{
-						Size: ptr.To(resource.MustParse("1Gi")),
+			mariadb,
+			nil,
+		),
+		Entry("Secrets in MariaDB",
+			&mariadbv1alpha1.PhysicalBackup{
+				ObjectMeta: objMeta,
+				Spec: mariadbv1alpha1.PhysicalBackupSpec{
+					Storage: mariadbv1alpha1.PhysicalBackupStorage{
+						Volume: &mariadbv1alpha1.StorageVolumeSource{
+							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+						},
 					},
 				},
 			},
-			wantInitContainers: []string{"mariadb", "backup-meta"},
-		},
-	}
+			&mariadbv1alpha1.MariaDB{
+				ObjectMeta: objMeta,
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+						ImagePullSecrets: []mariadbv1alpha1.LocalObjectReference{
+							{
+								Name: "mariadb-registry",
+							},
+						},
+					},
+				},
+			},
+			[]corev1.LocalObjectReference{
+				{
+					Name: "mariadb-registry",
+				},
+			},
+		),
+		Entry("Secrets in PhysicalBackup",
+			&mariadbv1alpha1.PhysicalBackup{
+				ObjectMeta: objMeta,
+				Spec: mariadbv1alpha1.PhysicalBackupSpec{
+					PhysicalBackupPodTemplate: mariadbv1alpha1.PhysicalBackupPodTemplate{
+						ImagePullSecrets: []mariadbv1alpha1.LocalObjectReference{
+							{
+								Name: "physicalbackup-registry",
+							},
+						},
+					},
+					Storage: mariadbv1alpha1.PhysicalBackupStorage{
+						Volume: &mariadbv1alpha1.StorageVolumeSource{
+							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+			},
+			mariadb,
+			[]corev1.LocalObjectReference{
+				{
+					Name: "physicalbackup-registry",
+				},
+			},
+		),
+		Entry("Secrets in MariaDB and PhysicalBackup",
+			&mariadbv1alpha1.PhysicalBackup{
+				ObjectMeta: objMeta,
+				Spec: mariadbv1alpha1.PhysicalBackupSpec{
+					PhysicalBackupPodTemplate: mariadbv1alpha1.PhysicalBackupPodTemplate{
+						ImagePullSecrets: []mariadbv1alpha1.LocalObjectReference{
+							{
+								Name: "physicalbackup-registry",
+							},
+						},
+					},
+					Storage: mariadbv1alpha1.PhysicalBackupStorage{
+						Volume: &mariadbv1alpha1.StorageVolumeSource{
+							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+						},
+					},
+				},
+			},
+			&mariadbv1alpha1.MariaDB{
+				ObjectMeta: objMeta,
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+						ImagePullSecrets: []mariadbv1alpha1.LocalObjectReference{
+							{
+								Name: "mariadb-registry",
+							},
+						},
+					},
+				},
+			},
+			[]corev1.LocalObjectReference{
+				{
+					Name: "mariadb-registry",
+				},
+				{
+					Name: "physicalbackup-registry",
+				},
+			},
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			builder := newDefaultTestBuilder(t)
+var _ = Describe("PhysicalBackupJobInitContainers", func() {
+	DescribeTable("BuildPhysicalBackupJob InitContainers",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantInitContainers []string) {
+			builder := newDefaultTestBuilder()
 
 			key := types.NamespacedName{
 				Name:      "test-backup",
@@ -1014,36 +869,60 @@ func TestPhysicalBackupJobInitContainers(t *testing.T) {
 				},
 			}
 
-			job, err := builder.BuildPhysicalBackupJob(key, backup, tt.mariadb, pod, "backup.xb.bz2")
+			job, err := builder.BuildPhysicalBackupJob(key, backup, mariadb, pod, "backup.xb.bz2")
 
-			assert.NoError(t, err)
-			assert.NotNil(t, job)
-			assert.NotNil(t, job.Spec.Template.Spec.InitContainers)
-			assert.Len(t, job.Spec.Template.Spec.InitContainers, len(tt.wantInitContainers))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job).NotTo(BeNil())
+			Expect(job.Spec.Template.Spec.InitContainers).NotTo(BeNil())
+			Expect(job.Spec.Template.Spec.InitContainers).To(HaveLen(len(wantInitContainers)))
 
 			for i, container := range job.Spec.Template.Spec.InitContainers {
-				assert.Equal(t, tt.wantInitContainers[i], container.Name)
+				Expect(container.Name).To(Equal(wantInitContainers[i]))
 			}
-		})
-	}
-}
+		},
+		Entry("Point-in-time recovery disabled",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Storage: mariadbv1alpha1.Storage{
+						Size: ptr.To(resource.MustParse("1Gi")),
+					},
+				},
+			},
+			[]string{"mariadb"},
+		),
+		Entry("Replication and point-in-time recovery enabled",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					PointInTimeRecoveryRef: &mariadbv1alpha1.LocalObjectReference{
+						Name: "test",
+					},
+					Replication: &mariadbv1alpha1.Replication{
+						Enabled: true,
+					},
+					Storage: mariadbv1alpha1.Storage{
+						Size: ptr.To(resource.MustParse("1Gi")),
+					},
+				},
+			},
+			[]string{"mariadb", "backup-meta"},
+		),
+	)
+})
 
-func TestRestoreJobImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("RestoreJobImagePullSecrets", func() {
 	objMeta := metav1.ObjectMeta{
 		Name:      "restore-image-pull-secrets",
 		Namespace: "test",
 	}
-
-	tests := []struct {
-		name            string
-		restore         *mariadbv1alpha1.Restore
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			restore: &mariadbv1alpha1.Restore{
+	DescribeTable("BuildRestoreJob ImagePullSecrets",
+		func(restore *mariadbv1alpha1.Restore, mariadb *mariadbv1alpha1.MariaDB, wantPullSecrets []corev1.LocalObjectReference) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildRestoreJob(client.ObjectKeyFromObject(restore), restore, mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry("No Secrets",
+			&mariadbv1alpha1.Restore{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.RestoreSpec{
 					MariaDBRef: mariadbv1alpha1.MariaDBRef{
@@ -1056,15 +935,14 @@ func TestRestoreJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec:       mariadbv1alpha1.MariaDBSpec{},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MariaDB",
-			restore: &mariadbv1alpha1.Restore{
+			nil,
+		),
+		Entry("Secrets in MariaDB",
+			&mariadbv1alpha1.Restore{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.RestoreSpec{
 					MariaDBRef: mariadbv1alpha1.MariaDBRef{
@@ -1077,7 +955,7 @@ func TestRestoreJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -1089,15 +967,14 @@ func TestRestoreJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in Restore",
-			restore: &mariadbv1alpha1.Restore{
+		),
+		Entry("Secrets in Restore",
+			&mariadbv1alpha1.Restore{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.RestoreSpec{
 					JobPodTemplate: mariadbv1alpha1.JobPodTemplate{
@@ -1117,19 +994,18 @@ func TestRestoreJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec:       mariadbv1alpha1.MariaDBSpec{},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "restore-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in MariaDB and Restore",
-			restore: &mariadbv1alpha1.Restore{
+		),
+		Entry("Secrets in MariaDB and Restore",
+			&mariadbv1alpha1.Restore{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.RestoreSpec{
 					JobPodTemplate: mariadbv1alpha1.JobPodTemplate{
@@ -1149,7 +1025,7 @@ func TestRestoreJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -1161,7 +1037,7 @@ func TestRestoreJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
@@ -1169,36 +1045,24 @@ func TestRestoreJobImagePullSecrets(t *testing.T) {
 					Name: "restore-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildRestoreJob(client.ObjectKeyFromObject(tt.restore), tt.restore, tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building Job: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestRestoreJobMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("RestoreJobMeta", func() {
 	key := types.NamespacedName{
 		Name: "restore-job",
 	}
-	tests := []struct {
-		name        string
-		restore     *mariadbv1alpha1.Restore
-		wantJobMeta *mariadbv1alpha1.Metadata
-		wantPodMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			restore: &mariadbv1alpha1.Restore{
+	DescribeTable("BuildRestoreJob Meta",
+		func(restore *mariadbv1alpha1.Restore, wantJobMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildRestoreJob(key, restore, &mariadbv1alpha1.MariaDB{})
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&job.ObjectMeta, wantJobMeta.Labels, wantJobMeta.Annotations)
+			assertObjectMeta(&job.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.Restore{
 				Spec: mariadbv1alpha1.RestoreSpec{
 					RestoreSource: mariadbv1alpha1.RestoreSource{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -1208,18 +1072,17 @@ func TestRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit metadata",
-			restore: &mariadbv1alpha1.Restore{
+		),
+		Entry("inherit metadata",
+			&mariadbv1alpha1.Restore{
 				Spec: mariadbv1alpha1.RestoreSpec{
 					RestoreSource: mariadbv1alpha1.RestoreSource{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -1237,7 +1100,7 @@ func TestRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1245,7 +1108,7 @@ func TestRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1253,10 +1116,9 @@ func TestRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod meta",
-			restore: &mariadbv1alpha1.Restore{
+		),
+		Entry("Pod meta",
+			&mariadbv1alpha1.Restore{
 				Spec: mariadbv1alpha1.RestoreSpec{
 					RestoreSource: mariadbv1alpha1.RestoreSource{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -1276,11 +1138,11 @@ func TestRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1288,10 +1150,9 @@ func TestRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "override inherit metadata",
-			restore: &mariadbv1alpha1.Restore{
+		),
+		Entry("override inherit metadata",
+			&mariadbv1alpha1.Restore{
 				Spec: mariadbv1alpha1.RestoreSpec{
 					RestoreSource: mariadbv1alpha1.RestoreSource{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -1319,7 +1180,7 @@ func TestRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "true",
 				},
@@ -1327,7 +1188,7 @@ func TestRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1335,10 +1196,9 @@ func TestRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "all",
-			restore: &mariadbv1alpha1.Restore{
+		),
+		Entry("all",
+			&mariadbv1alpha1.Restore{
 				Spec: mariadbv1alpha1.RestoreSpec{
 					RestoreSource: mariadbv1alpha1.RestoreSource{
 						Volume: &mariadbv1alpha1.StorageVolumeSource{
@@ -1360,13 +1220,13 @@ func TestRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{},
 				Annotations: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1374,66 +1234,49 @@ func TestRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildRestoreJob(key, tt.restore, &mariadbv1alpha1.MariaDB{})
-			if err != nil {
-				t.Fatalf("unexpected error building Restore Job: %v", err)
-			}
-			assertObjectMeta(t, &job.ObjectMeta, tt.wantJobMeta.Labels, tt.wantJobMeta.Annotations)
-			assertObjectMeta(t, &job.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestPhysicalBackupRestoreJobSelectorLabels(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	key := types.NamespacedName{
-		Name:      "physical-backup-restore-job",
-		Namespace: "test",
-	}
-
-	// Setup MariaDB with BootstrapFrom and selector labels
-	mariadb := &mariadbv1alpha1.MariaDB{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mariadb-test",
+var _ = Describe("PhysicalBackupRestoreJobSelectorLabels", func() {
+	It("sets selector labels on the pod template", func() {
+		builder := newDefaultTestBuilder()
+		key := types.NamespacedName{
+			Name:      "physical-backup-restore-job",
 			Namespace: "test",
-		},
-		Spec: mariadbv1alpha1.MariaDBSpec{
-			BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
-				Volume: &mariadbv1alpha1.StorageVolumeSource{
-					EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+		}
+
+		mariadb := &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mariadb-test",
+				Namespace: "test",
+			},
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
+					Volume: &mariadbv1alpha1.StorageVolumeSource{
+						EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+					},
 				},
 			},
-		},
-	}
-	podIndex := ptr.To(0)
-
-	job, err := builder.BuildPhysicalBackupRestoreJob(
-		key,
-		mariadb,
-		podIndex,
-		WithBootstrapFrom(mariadb.Spec.BootstrapFrom),
-	)
-	if err != nil {
-		t.Fatalf("unexpected error building PhysicalBackupRestoreJob: %v", err)
-	}
-
-	// The selector labels should be present in the pod template metadata
-	selectorLabels := labels.NewLabelsBuilder().WithMariaDBSelectorLabels(mariadb).Build()
-	for k, v := range selectorLabels {
-		got := job.Spec.Template.Labels[k]
-		if got != v {
-			t.Errorf("expected selector label %q=%q, got %q", k, v, got)
 		}
-	}
-}
+		podIndex := ptr.To(0)
 
-func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+		job, err := builder.BuildPhysicalBackupRestoreJob(
+			key,
+			mariadb,
+			podIndex,
+			WithBootstrapFrom(mariadb.Spec.BootstrapFrom),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		selectorLabels := labels.NewLabelsBuilder().WithMariaDBSelectorLabels(mariadb).Build()
+		for k, v := range selectorLabels {
+			Expect(job.Spec.Template.Labels[k]).To(Equal(v))
+		}
+	})
+})
+
+var _ = Describe("PhysicalBackupRestoreJobMeta", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "mariadb-obj",
 	}
@@ -1441,16 +1284,22 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 		Name:      "physical-backup-restore-job-meta",
 		Namespace: "test",
 	}
-
-	tests := []struct {
-		name        string
-		mariadb     *mariadbv1alpha1.MariaDB
-		wantJobMeta *mariadbv1alpha1.Metadata
-		wantPodMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	podIndex := ptr.To(0)
+	DescribeTable("BuildPhysicalBackupRestoreJob Meta",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantJobMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildPhysicalBackupRestoreJob(
+				key,
+				mariadb,
+				podIndex,
+				WithBootstrapFrom(mariadb.Spec.BootstrapFrom),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&job.ObjectMeta, wantJobMeta.Labels, wantJobMeta.Annotations)
+			assertObjectMeta(&job.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
@@ -1460,21 +1309,20 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit metadata",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("inherit metadata",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
@@ -1492,7 +1340,7 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1500,7 +1348,7 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject":    "false",
 					"app.kubernetes.io/name":     "mariadb",
@@ -1510,10 +1358,9 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("Pod meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
@@ -1533,11 +1380,11 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject":    "false",
 					"app.kubernetes.io/name":     "mariadb",
@@ -1547,10 +1394,9 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "override inherit metadata",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("override inherit metadata",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
@@ -1580,7 +1426,7 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "true",
 				},
@@ -1588,7 +1434,7 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject":    "false",
 					"app.kubernetes.io/name":     "mariadb",
@@ -1598,10 +1444,9 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "all",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("all",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
@@ -1623,13 +1468,13 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{},
 				Annotations: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject":    "false",
 					"app.kubernetes.io/name":     "mariadb",
@@ -1639,29 +1484,11 @@ func TestPhysicalBackupRestoreJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	podIndex := ptr.To(0)
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildPhysicalBackupRestoreJob(
-				key,
-				tt.mariadb,
-				podIndex,
-				WithBootstrapFrom(tt.mariadb.Spec.BootstrapFrom),
-			)
-			if err != nil {
-				t.Fatalf("unexpected error building PhysicalBackupRestoreJob: %v", err)
-			}
-			assertObjectMeta(t, &job.ObjectMeta, tt.wantJobMeta.Labels, tt.wantJobMeta.Annotations)
-			assertObjectMeta(t, &job.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestPhysicalBackupRestoreJobImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("PhysicalBackupRestoreJobImagePullSecrets", func() {
 	objMeta := metav1.ObjectMeta{
 		Name:      "physical-backup-restore-image-pull-secrets",
 		Namespace: "test",
@@ -1670,15 +1497,21 @@ func TestPhysicalBackupRestoreJobImagePullSecrets(t *testing.T) {
 		Name:      "physical-backup-restore-job",
 		Namespace: "test",
 	}
-
-	tests := []struct {
-		name            string
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	podIndex := ptr.To(0)
+	DescribeTable("BuildPhysicalBackupRestoreJob ImagePullSecrets",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantPullSecrets []corev1.LocalObjectReference) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildPhysicalBackupRestoreJob(
+				key,
+				mariadb,
+				podIndex,
+				WithBootstrapFrom(mariadb.Spec.BootstrapFrom),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry("No Secrets",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
@@ -1688,11 +1521,10 @@ func TestPhysicalBackupRestoreJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MariaDB",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+		),
+		Entry("Secrets in MariaDB",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
@@ -1709,47 +1541,28 @@ func TestPhysicalBackupRestoreJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	podIndex := ptr.To(0)
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildPhysicalBackupRestoreJob(
-				key,
-				tt.mariadb,
-				podIndex,
-				WithBootstrapFrom(tt.mariadb.Spec.BootstrapFrom),
-			)
-			if err != nil {
-				t.Fatalf("unexpected error building PhysicalBackupRestoreJob: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestGaleraInitJobImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GaleraInitJobImagePullSecrets", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "init-image-pull-secrets",
 	}
-
-	tests := []struct {
-		name            string
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("BuildGaleraInitJob ImagePullSecrets",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantPullSecrets []corev1.LocalObjectReference) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildGaleraInitJob(mariadb.InitKey(), mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry("No Secrets",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -1757,11 +1570,10 @@ func TestGaleraInitJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MariaDB",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+		),
+		Entry("Secrets in MariaDB",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -1776,44 +1588,32 @@ func TestGaleraInitJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildGaleraInitJob(tt.mariadb.InitKey(), tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building Job: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestGaleraInitJobMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GaleraInitJobMeta", func() {
 	key := types.NamespacedName{
 		Name: "init-obj",
 	}
 	mariadbObjMeta := metav1.ObjectMeta{
 		Name: "mariadb-obj",
 	}
-	tests := []struct {
-		name        string
-		mariadb     *mariadbv1alpha1.MariaDB
-		wantJobMeta *mariadbv1alpha1.Metadata
-		wantPodMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("BuildGaleraInitJob Meta",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantJobMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildGaleraInitJob(key, mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&job.ObjectMeta, wantJobMeta.Labels, wantJobMeta.Annotations)
+			assertObjectMeta(&job.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -1821,18 +1621,17 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("inherit meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -1848,7 +1647,7 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1856,7 +1655,7 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1864,10 +1663,9 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "extra meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("extra meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -1887,7 +1685,7 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1895,7 +1693,7 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1903,10 +1701,9 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("Pod meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -1924,11 +1721,11 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -1936,10 +1733,9 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "override Pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("override Pod meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -1966,13 +1762,13 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "true",
 				},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "true",
 				},
@@ -1980,10 +1776,9 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "all",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("all",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2012,14 +1807,14 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{},
 				Annotations: map[string]string{
 					"database.myorg.io":       "mariadb",
 					"sidecar.istio.io/inject": "false",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -2028,37 +1823,29 @@ func TestGaleraInitJobMeta(t *testing.T) {
 					"sidecar.istio.io/inject": "false",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildGaleraInitJob(key, tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building init Job: %v", err)
-			}
-			assertObjectMeta(t, &job.ObjectMeta, tt.wantJobMeta.Labels, tt.wantJobMeta.Annotations)
-			assertObjectMeta(t, &job.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestGaleraInitJobResources(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GaleraInitJobResources", func() {
 	key := types.NamespacedName{
 		Name: "job-obj",
 	}
 	objMeta := metav1.ObjectMeta{
 		Name: "mariadb-obj",
 	}
-	tests := []struct {
-		name          string
-		mariadb       *mariadbv1alpha1.MariaDB
-		wantResources corev1.ResourceRequirements
-	}{
-		{
-			name: "no resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("BuildGaleraInitJob Resources",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantResources corev1.ResourceRequirements) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildGaleraInitJob(key, mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			podTpl := job.Spec.Template
+			Expect(podTpl.Spec.Containers).To(HaveLen(1))
+			resources := podTpl.Spec.Containers[0].Resources
+			Expect(resources).To(Equal(wantResources))
+		},
+		Entry("no resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2066,11 +1853,10 @@ func TestGaleraInitJobResources(t *testing.T) {
 					},
 				},
 			},
-			wantResources: corev1.ResourceRequirements{},
-		},
-		{
-			name: "mariadb resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			corev1.ResourceRequirements{},
+		),
+		Entry("mariadb resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2085,11 +1871,10 @@ func TestGaleraInitJobResources(t *testing.T) {
 					},
 				},
 			},
-			wantResources: corev1.ResourceRequirements{},
-		},
-		{
-			name: "init Job resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			corev1.ResourceRequirements{},
+		),
+		Entry("init Job resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2106,87 +1891,65 @@ func TestGaleraInitJobResources(t *testing.T) {
 					},
 				},
 			},
-			wantResources: corev1.ResourceRequirements{
+			corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					"cpu": resource.MustParse("100m"),
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildGaleraInitJob(key, tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building Galera init Job: %v", err)
-			}
-			podTpl := job.Spec.Template
-			if len(podTpl.Spec.Containers) != 1 {
-				t.Error("expecting to have one container")
-			}
-			resources := podTpl.Spec.Containers[0].Resources
-			if !reflect.DeepEqual(resources, tt.wantResources) {
-				t.Errorf("unexpected resources, got: %v, expected: %v", resources, tt.wantResources)
-			}
-		})
-	}
-}
-
-func TestGaleraInitContainers(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	key := types.NamespacedName{
-		Name: "job-obj",
-	}
-	mdb := &mariadbv1alpha1.MariaDB{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "mariadb-obj",
-		},
-		Spec: mariadbv1alpha1.MariaDBSpec{
-			MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-				InitContainers: []mariadbv1alpha1.Container{
-					{
-						Name:    "init",
-						Image:   "busybox",
-						Command: []string{"bash", "-c"},
-						Args:    []string{"exit 0;"},
+var _ = Describe("GaleraInitContainers", func() {
+	It("builds the expected init and sidecar containers", func() {
+		builder := newDefaultTestBuilder()
+		key := types.NamespacedName{
+			Name: "job-obj",
+		}
+		mdb := &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mariadb-obj",
+			},
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+					InitContainers: []mariadbv1alpha1.Container{
+						{
+							Name:    "init",
+							Image:   "busybox",
+							Command: []string{"bash", "-c"},
+							Args:    []string{"exit 0;"},
+						},
+					},
+					SidecarContainers: []mariadbv1alpha1.Container{
+						{
+							Name:    "sidecar",
+							Image:   "busybox",
+							Command: []string{"sleep", "infinity"},
+						},
 					},
 				},
-				SidecarContainers: []mariadbv1alpha1.Container{
-					{
-						Name:    "sidecar",
-						Image:   "busybox",
-						Command: []string{"sleep", "infinity"},
+				Galera: &mariadbv1alpha1.Galera{
+					Enabled: true,
+					GaleraSpec: mariadbv1alpha1.GaleraSpec{
+						Recovery: &mariadbv1alpha1.GaleraRecovery{
+							Enabled: true,
+						},
 					},
 				},
 			},
-			Galera: &mariadbv1alpha1.Galera{
-				Enabled: true,
-				GaleraSpec: mariadbv1alpha1.GaleraSpec{
-					Recovery: &mariadbv1alpha1.GaleraRecovery{
-						Enabled: true,
-					},
-				},
-			},
-		},
-	}
+		}
 
-	job, err := builder.BuildGaleraInitJob(key, mdb)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", 0)
-	}
-	initContainers := job.Spec.Template.Spec.InitContainers
-	containers := job.Spec.Template.Spec.Containers
+		job, err := builder.BuildGaleraInitJob(key, mdb)
+		Expect(err).NotTo(HaveOccurred())
+		initContainers := job.Spec.Template.Spec.InitContainers
+		containers := job.Spec.Template.Spec.Containers
 
-	if got := len(initContainers); got != 0 {
-		t.Errorf("expecting 0 init containers, got: %d", got)
-	}
-	if got := len(containers); got != 1 {
-		t.Errorf("expecting 1 container, got: %d", got)
-	}
-}
+		Expect(initContainers).To(BeEmpty())
+		Expect(containers).To(HaveLen(1))
+	})
+})
 
-func TestGaleraRecoveryJobImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GaleraRecoveryJobImagePullSecrets", func() {
 	key := types.NamespacedName{
 		Name: "recovery-obj",
 	}
@@ -2201,14 +1964,15 @@ func TestGaleraRecoveryJobImagePullSecrets(t *testing.T) {
 			NodeName: "compute-0",
 		},
 	}
-	tests := []struct {
-		name            string
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("BuildGaleraRecoveryJob ImagePullSecrets",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantPullSecrets []corev1.LocalObjectReference) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildGaleraRecoveryJob(key, mariadb, &pod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry("No Secrets",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2221,11 +1985,10 @@ func TestGaleraRecoveryJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MariaDB",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+		),
+		Entry("Secrets in MariaDB",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2245,29 +2008,16 @@ func TestGaleraRecoveryJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildGaleraRecoveryJob(key, tt.mariadb, &pod)
-			if err != nil {
-				t.Fatalf("unexpected error building Job: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestGaleraRecoveryJobMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GaleraRecoveryJobMeta", func() {
 	key := types.NamespacedName{
 		Name: "recovery-obj",
 	}
@@ -2282,15 +2032,16 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 			NodeName: "compute-0",
 		},
 	}
-	tests := []struct {
-		name        string
-		mariadb     *mariadbv1alpha1.MariaDB
-		wantJobMeta *mariadbv1alpha1.Metadata
-		wantPodMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("BuildGaleraRecoveryJob Meta",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantJobMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildGaleraRecoveryJob(key, mariadb, &pod)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&job.ObjectMeta, wantJobMeta.Labels, wantJobMeta.Annotations)
+			assertObjectMeta(&job.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2303,18 +2054,17 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("inherit meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2335,7 +2085,7 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -2343,7 +2093,7 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -2351,10 +2101,9 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "extra meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("extra meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2377,7 +2126,7 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -2385,7 +2134,7 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -2393,10 +2142,9 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("Pod meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2419,11 +2167,11 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -2431,10 +2179,9 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "override Pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("override Pod meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2464,13 +2211,13 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "true",
 				},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "true",
 				},
@@ -2478,10 +2225,9 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "all",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("all",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mariadbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2513,14 +2259,14 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{},
 				Annotations: map[string]string{
 					"database.myorg.io":       "mariadb",
 					"sidecar.istio.io/inject": "false",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -2529,23 +2275,11 @@ func TestGaleraRecoveryJobMeta(t *testing.T) {
 					"sidecar.istio.io/inject": "false",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildGaleraRecoveryJob(key, tt.mariadb, &pod)
-			if err != nil {
-				t.Fatalf("unexpected error building Galera recovery Job: %v", err)
-			}
-			assertObjectMeta(t, &job.ObjectMeta, tt.wantJobMeta.Labels, tt.wantJobMeta.Annotations)
-			assertObjectMeta(t, &job.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestGaleraRecoveryJobVolumes(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GaleraRecoveryJobVolumes", func() {
 	key := types.NamespacedName{
 		Name: "job-obj",
 	}
@@ -2560,14 +2294,17 @@ func TestGaleraRecoveryJobVolumes(t *testing.T) {
 			NodeName: "compute-0",
 		},
 	}
-	tests := []struct {
-		name        string
-		mariadb     *mariadbv1alpha1.MariaDB
-		wantVolumes []string
-	}{
-		{
-			name: "dedicated storage",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("BuildGaleraRecoveryJob Volumes",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantVolumes []string) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildGaleraRecoveryJob(key, mariadb, &pod)
+			Expect(err).NotTo(HaveOccurred())
+			for _, wantVolume := range wantVolumes {
+				Expect(hasVolumePVC(job.Spec.Template.Spec.Volumes, wantVolume)).To(BeTrue())
+			}
+		},
+		Entry("dedicated storage",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2609,11 +2346,10 @@ func TestGaleraRecoveryJobVolumes(t *testing.T) {
 					},
 				},
 			},
-			wantVolumes: []string{StorageVolume, galeraresources.GaleraConfigVolume},
-		},
-		{
-			name: "reuse storage",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			[]string{StorageVolume, galeraresources.GaleraConfigVolume},
+		),
+		Entry("reuse storage",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2644,43 +2380,32 @@ func TestGaleraRecoveryJobVolumes(t *testing.T) {
 					},
 				},
 			},
-			wantVolumes: []string{StorageVolume},
-		},
-	}
+			[]string{StorageVolume},
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildGaleraRecoveryJob(key, tt.mariadb, &pod)
-			if err != nil {
-				t.Errorf("unexpected error building Galera recovery Job: %v", err)
-			}
-			for _, wantVolume := range tt.wantVolumes {
-				if !hasVolumePVC(job.Spec.Template.Spec.Volumes, wantVolume) {
-					t.Errorf("expecting Volume PVC \"%s\", but it was not found", wantVolume)
-				}
-			}
-		})
-	}
-}
-
-func TestGaleraRecoveryJobNodeSelector(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GaleraRecoveryJobNodeSelector", func() {
 	key := types.NamespacedName{
 		Name: "job-obj",
 	}
 	objMeta := metav1.ObjectMeta{
 		Name: "mariadb-obj",
 	}
-	tests := []struct {
-		name             string
-		mariadb          *mariadbv1alpha1.MariaDB
-		pod              *corev1.Pod
-		wantNodeSelector map[string]string
-		wantErr          bool
-	}{
-		{
-			name: "no Pod index",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("BuildGaleraRecoveryJob NodeSelector",
+		func(mariadb *mariadbv1alpha1.MariaDB, pod *corev1.Pod, wantNodeSelector map[string]string, wantErr bool) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildGaleraRecoveryJob(key, mariadb, pod)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+				Expect(job).To(BeNil())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(job.Spec.Template.Spec.NodeSelector).To(Equal(wantNodeSelector))
+			}
+		},
+		Entry("no Pod index",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2699,7 +2424,7 @@ func TestGaleraRecoveryJobNodeSelector(t *testing.T) {
 					},
 				},
 			},
-			pod: &corev1.Pod{
+			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
 				},
@@ -2707,12 +2432,11 @@ func TestGaleraRecoveryJobNodeSelector(t *testing.T) {
 					NodeName: "compute-0",
 				},
 			},
-			wantNodeSelector: nil,
-			wantErr:          true,
-		},
-		{
-			name: "no Node",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+			true,
+		),
+		Entry("no Node",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2731,18 +2455,17 @@ func TestGaleraRecoveryJobNodeSelector(t *testing.T) {
 					},
 				},
 			},
-			pod: &corev1.Pod{
+			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mariadb-galera-0",
 				},
 				Spec: corev1.PodSpec{},
 			},
-			wantNodeSelector: nil,
-			wantErr:          true,
-		},
-		{
-			name: "no recovery Job nodeSelector",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+			true,
+		),
+		Entry("no recovery Job nodeSelector",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2761,7 +2484,7 @@ func TestGaleraRecoveryJobNodeSelector(t *testing.T) {
 					},
 				},
 			},
-			pod: &corev1.Pod{
+			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mariadb-galera-0",
 				},
@@ -2769,12 +2492,11 @@ func TestGaleraRecoveryJobNodeSelector(t *testing.T) {
 					NodeName: "compute-0",
 				},
 			},
-			wantNodeSelector: nil,
-			wantErr:          false,
-		},
-		{
-			name: "recovery Job nodeSelector",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+			false,
+		),
+		Entry("recovery Job nodeSelector",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2793,7 +2515,7 @@ func TestGaleraRecoveryJobNodeSelector(t *testing.T) {
 					},
 				},
 			},
-			pod: &corev1.Pod{
+			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mariadb-galera-0",
 				},
@@ -2801,37 +2523,15 @@ func TestGaleraRecoveryJobNodeSelector(t *testing.T) {
 					NodeName: "compute-0",
 				},
 			},
-			wantNodeSelector: map[string]string{
+			map[string]string{
 				"kubernetes.io/hostname": "compute-0",
 			},
-			wantErr: false,
-		},
-	}
+			false,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildGaleraRecoveryJob(key, tt.mariadb, tt.pod)
-			if tt.wantErr {
-				if err == nil {
-					t.Error("expect error to have occurred, got nil")
-				}
-				if job != nil {
-					t.Error("expected Job to be nil")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("expect error to not have occurred, got: %v", err)
-				}
-				if !reflect.DeepEqual(tt.wantNodeSelector, job.Spec.Template.Spec.NodeSelector) {
-					t.Errorf("unexpected nodeSelector, want: %v got: %v", tt.wantNodeSelector, job.Spec.Template.Spec.NodeSelector)
-				}
-			}
-		})
-	}
-}
-
-func TestGaleraRecoveryJobResources(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GaleraRecoveryJobResources", func() {
 	key := types.NamespacedName{
 		Name: "job-obj",
 	}
@@ -2846,14 +2546,18 @@ func TestGaleraRecoveryJobResources(t *testing.T) {
 			NodeName: "compute-0",
 		},
 	}
-	tests := []struct {
-		name          string
-		mariadb       *mariadbv1alpha1.MariaDB
-		wantResources corev1.ResourceRequirements
-	}{
-		{
-			name: "no resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("BuildGaleraRecoveryJob Resources",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantResources corev1.ResourceRequirements) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildGaleraRecoveryJob(key, mariadb, pod)
+			Expect(err).NotTo(HaveOccurred())
+			podTpl := job.Spec.Template
+			Expect(podTpl.Spec.Containers).To(HaveLen(1))
+			resources := podTpl.Spec.Containers[0].Resources
+			Expect(resources).To(Equal(wantResources))
+		},
+		Entry("no resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2866,11 +2570,10 @@ func TestGaleraRecoveryJobResources(t *testing.T) {
 					},
 				},
 			},
-			wantResources: corev1.ResourceRequirements{},
-		},
-		{
-			name: "mariadb resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			corev1.ResourceRequirements{},
+		),
+		Entry("mariadb resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2890,11 +2593,10 @@ func TestGaleraRecoveryJobResources(t *testing.T) {
 					},
 				},
 			},
-			wantResources: corev1.ResourceRequirements{},
-		},
-		{
-			name: "recovery Job resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			corev1.ResourceRequirements{},
+		),
+		Entry("recovery Job resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -2914,152 +2616,127 @@ func TestGaleraRecoveryJobResources(t *testing.T) {
 					},
 				},
 			},
-			wantResources: corev1.ResourceRequirements{
+			corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					"cpu": resource.MustParse("100m"),
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildGaleraRecoveryJob(key, tt.mariadb, pod)
-			if err != nil {
-				t.Fatalf("unexpected error building Galera recovery Job: %v", err)
-			}
-			podTpl := job.Spec.Template
-			if len(podTpl.Spec.Containers) != 1 {
-				t.Error("expecting to have one container")
-			}
-			resources := podTpl.Spec.Containers[0].Resources
-			if !reflect.DeepEqual(resources, tt.wantResources) {
-				t.Errorf("unexpected resources, got: %v, expected: %v", resources, tt.wantResources)
-			}
-		})
-	}
-}
-
-func TestGaleraRecoveryContainers(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	key := types.NamespacedName{
-		Name: "job-obj",
-	}
-	mdb := &mariadbv1alpha1.MariaDB{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "mariadb-obj",
-		},
-		Spec: mariadbv1alpha1.MariaDBSpec{
-			MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-				InitContainers: []mariadbv1alpha1.Container{
-					{
-						Name:    "init",
-						Image:   "busybox",
-						Command: []string{"bash", "-c"},
-						Args:    []string{"exit 0;"},
+var _ = Describe("GaleraRecoveryContainers", func() {
+	It("builds the expected init and sidecar containers", func() {
+		builder := newDefaultTestBuilder()
+		key := types.NamespacedName{
+			Name: "job-obj",
+		}
+		mdb := &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mariadb-obj",
+			},
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+					InitContainers: []mariadbv1alpha1.Container{
+						{
+							Name:    "init",
+							Image:   "busybox",
+							Command: []string{"bash", "-c"},
+							Args:    []string{"exit 0;"},
+						},
+					},
+					SidecarContainers: []mariadbv1alpha1.Container{
+						{
+							Name:    "sidecar",
+							Image:   "busybox",
+							Command: []string{"sleep", "infinity"},
+						},
 					},
 				},
-				SidecarContainers: []mariadbv1alpha1.Container{
-					{
-						Name:    "sidecar",
-						Image:   "busybox",
-						Command: []string{"sleep", "infinity"},
+				Galera: &mariadbv1alpha1.Galera{
+					Enabled: true,
+					GaleraSpec: mariadbv1alpha1.GaleraSpec{
+						Recovery: &mariadbv1alpha1.GaleraRecovery{
+							Enabled: true,
+						},
 					},
 				},
 			},
-			Galera: &mariadbv1alpha1.Galera{
-				Enabled: true,
-				GaleraSpec: mariadbv1alpha1.GaleraSpec{
-					Recovery: &mariadbv1alpha1.GaleraRecovery{
-						Enabled: true,
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mariadb-galera-0",
+			},
+			Spec: corev1.PodSpec{
+				NodeName: "compute-0",
+			},
+		}
+
+		job, err := builder.BuildGaleraRecoveryJob(key, mdb, pod)
+		Expect(err).NotTo(HaveOccurred())
+		initContainers := job.Spec.Template.Spec.InitContainers
+		containers := job.Spec.Template.Spec.Containers
+
+		Expect(initContainers).To(BeEmpty())
+		Expect(containers).To(HaveLen(1))
+	})
+})
+
+var _ = Describe("GaleraRecoveryJobCommand", func() {
+	It("builds the expected galera recovery command", func() {
+		expected := "mariadbd --log-error=/dev/stderr --wsrep-recover"
+		builder := newDefaultTestBuilder()
+		key := types.NamespacedName{
+			Name: "job-obj",
+		}
+		mdb := &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mariadb-obj",
+			},
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				Galera: &mariadbv1alpha1.Galera{
+					Enabled: true,
+					GaleraSpec: mariadbv1alpha1.GaleraSpec{
+						Recovery: &mariadbv1alpha1.GaleraRecovery{
+							Enabled: true,
+						},
 					},
 				},
 			},
-		},
-	}
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "mariadb-galera-0",
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "compute-0",
-		},
-	}
-
-	job, err := builder.BuildGaleraRecoveryJob(key, mdb, pod)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", 0)
-	}
-	initContainers := job.Spec.Template.Spec.InitContainers
-	containers := job.Spec.Template.Spec.Containers
-
-	if got := len(initContainers); got != 0 {
-		t.Errorf("expecting 0 init containers, got: %d", got)
-	}
-	if got := len(containers); got != 1 {
-		t.Errorf("expecting 1 container, got: %d", got)
-	}
-}
-
-func TestGaleraRecoveryJobCommand(t *testing.T) {
-	expected := "mariadbd --log-error=/dev/stderr --wsrep-recover"
-	builder := newDefaultTestBuilder(t)
-	key := types.NamespacedName{
-		Name: "job-obj",
-	}
-	mdb := &mariadbv1alpha1.MariaDB{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "mariadb-obj",
-		},
-		Spec: mariadbv1alpha1.MariaDBSpec{
-			Galera: &mariadbv1alpha1.Galera{
-				Enabled: true,
-				GaleraSpec: mariadbv1alpha1.GaleraSpec{
-					Recovery: &mariadbv1alpha1.GaleraRecovery{
-						Enabled: true,
-					},
-				},
+		}
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "mariadb-galera-0",
 			},
-		},
-	}
-	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "mariadb-galera-0",
-		},
-		Spec: corev1.PodSpec{
-			NodeName: "compute-0",
-		},
-	}
+			Spec: corev1.PodSpec{
+				NodeName: "compute-0",
+			},
+		}
 
-	job, err := builder.BuildGaleraRecoveryJob(key, mdb, pod)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", 0)
-	}
+		job, err := builder.BuildGaleraRecoveryJob(key, mdb, pod)
+		Expect(err).NotTo(HaveOccurred())
 
-	container := job.Spec.Template.Spec.Containers[0]
-	command := strings.Join(append(container.Command, container.Args...), " ")
+		container := job.Spec.Template.Spec.Containers[0]
+		command := strings.Join(append(container.Command, container.Args...), " ")
 
-	if command != expected {
-		t.Errorf("expected galera recovery command to be %s, got: %s", expected, command)
-	}
-}
+		Expect(command).To(Equal(expected))
+	})
+})
 
-func TestSqlJobImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("SqlJobImagePullSecrets", func() {
 	objMeta := metav1.ObjectMeta{
 		Name:      "sqljob-image-pull-secrets",
 		Namespace: "test",
 	}
-
-	tests := []struct {
-		name            string
-		sqlJob          *mariadbv1alpha1.SqlJob
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			sqlJob: &mariadbv1alpha1.SqlJob{
+	DescribeTable("BuildSqlJob ImagePullSecrets",
+		func(sqlJob *mariadbv1alpha1.SqlJob, mariadb *mariadbv1alpha1.MariaDB, wantPullSecrets []corev1.LocalObjectReference) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildSqlJob(client.ObjectKeyFromObject(sqlJob), sqlJob, mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry("No Secrets",
+			&mariadbv1alpha1.SqlJob{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.SqlJobSpec{
 					MariaDBRef: mariadbv1alpha1.MariaDBRef{
@@ -3072,15 +2749,14 @@ func TestSqlJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec:       mariadbv1alpha1.MariaDBSpec{},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MariaDB",
-			sqlJob: &mariadbv1alpha1.SqlJob{
+			nil,
+		),
+		Entry("Secrets in MariaDB",
+			&mariadbv1alpha1.SqlJob{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.SqlJobSpec{
 					MariaDBRef: mariadbv1alpha1.MariaDBRef{
@@ -3093,7 +2769,7 @@ func TestSqlJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -3105,15 +2781,14 @@ func TestSqlJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in SqlJob",
-			sqlJob: &mariadbv1alpha1.SqlJob{
+		),
+		Entry("Secrets in SqlJob",
+			&mariadbv1alpha1.SqlJob{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.SqlJobSpec{
 					JobPodTemplate: mariadbv1alpha1.JobPodTemplate{
@@ -3133,19 +2808,18 @@ func TestSqlJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec:       mariadbv1alpha1.MariaDBSpec{},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "sqljob-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in MariaDB and SqlJob",
-			sqlJob: &mariadbv1alpha1.SqlJob{
+		),
+		Entry("Secrets in MariaDB and SqlJob",
+			&mariadbv1alpha1.SqlJob{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.SqlJobSpec{
 					JobPodTemplate: mariadbv1alpha1.JobPodTemplate{
@@ -3165,7 +2839,7 @@ func TestSqlJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -3177,7 +2851,7 @@ func TestSqlJobImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
@@ -3185,52 +2859,39 @@ func TestSqlJobImagePullSecrets(t *testing.T) {
 					Name: "sqljob-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildSqlJob(client.ObjectKeyFromObject(tt.sqlJob), tt.sqlJob, tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building Job: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestSqlJobMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("SqlJobMeta", func() {
 	key := types.NamespacedName{
 		Name: "sql-job",
 	}
-	tests := []struct {
-		name        string
-		sqlJob      *mariadbv1alpha1.SqlJob
-		wantJobMeta *mariadbv1alpha1.Metadata
-		wantPodMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			sqlJob: &mariadbv1alpha1.SqlJob{
+	DescribeTable("BuildSqlJob Meta",
+		func(sqlJob *mariadbv1alpha1.SqlJob, wantJobMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			job, err := builder.BuildSqlJob(key, sqlJob, &mariadbv1alpha1.MariaDB{})
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&job.ObjectMeta, wantJobMeta.Labels, wantJobMeta.Annotations)
+			assertObjectMeta(&job.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.SqlJob{
 				Spec: mariadbv1alpha1.SqlJobSpec{
 					SqlConfigMapKeyRef: &mariadbv1alpha1.ConfigMapKeySelector{},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit metadata",
-			sqlJob: &mariadbv1alpha1.SqlJob{
+		),
+		Entry("inherit metadata",
+			&mariadbv1alpha1.SqlJob{
 				Spec: mariadbv1alpha1.SqlJobSpec{
 					SqlConfigMapKeyRef: &mariadbv1alpha1.ConfigMapKeySelector{},
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -3243,7 +2904,7 @@ func TestSqlJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -3251,7 +2912,7 @@ func TestSqlJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -3259,10 +2920,9 @@ func TestSqlJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod meta",
-			sqlJob: &mariadbv1alpha1.SqlJob{
+		),
+		Entry("Pod meta",
+			&mariadbv1alpha1.SqlJob{
 				Spec: mariadbv1alpha1.SqlJobSpec{
 					SqlConfigMapKeyRef: &mariadbv1alpha1.ConfigMapKeySelector{},
 					JobPodTemplate: mariadbv1alpha1.JobPodTemplate{
@@ -3277,11 +2937,11 @@ func TestSqlJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -3289,10 +2949,9 @@ func TestSqlJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "override inherit metadata",
-			sqlJob: &mariadbv1alpha1.SqlJob{
+		),
+		Entry("override inherit metadata",
+			&mariadbv1alpha1.SqlJob{
 				Spec: mariadbv1alpha1.SqlJobSpec{
 					SqlConfigMapKeyRef: &mariadbv1alpha1.ConfigMapKeySelector{},
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -3315,7 +2974,7 @@ func TestSqlJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "true",
 				},
@@ -3323,7 +2982,7 @@ func TestSqlJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -3331,10 +2990,9 @@ func TestSqlJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "all",
-			sqlJob: &mariadbv1alpha1.SqlJob{
+		),
+		Entry("all",
+			&mariadbv1alpha1.SqlJob{
 				Spec: mariadbv1alpha1.SqlJobSpec{
 					SqlConfigMapKeyRef: &mariadbv1alpha1.ConfigMapKeySelector{},
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -3351,13 +3009,13 @@ func TestSqlJobMeta(t *testing.T) {
 					},
 				},
 			},
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{},
 				Annotations: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -3365,23 +3023,11 @@ func TestSqlJobMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildSqlJob(key, tt.sqlJob, &mariadbv1alpha1.MariaDB{})
-			if err != nil {
-				t.Fatalf("unexpected error building SqlJob Job: %v", err)
-			}
-			assertObjectMeta(t, &job.ObjectMeta, tt.wantJobMeta.Labels, tt.wantJobMeta.Annotations)
-			assertObjectMeta(t, &job.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestBuildPITRJob(t *testing.T) {
-	t.Parallel()
+var _ = Describe("BuildPITRJob", func() {
 	pitr := &mariadbv1alpha1.PointInTimeRecovery{
 		Spec: mariadbv1alpha1.PointInTimeRecoverySpec{
 			PhysicalBackupRef: mariadbv1alpha1.LocalObjectReference{
@@ -3397,91 +3043,130 @@ func TestBuildPITRJob(t *testing.T) {
 			},
 		},
 	}
-	startGtid := mustParseGtid(t, "0-10-1")
 	targetRecoveryTime := &metav1.Time{Time: time.Now()}
 
-	tests := []struct {
-		name         string
-		pitr         *mariadbv1alpha1.PointInTimeRecovery
-		mariadb      *mariadbv1alpha1.MariaDB
-		restoreOpts  []RestoreOpt
-		wantErr      bool
-		wantJob      bool
-		wantJobMeta  *mariadbv1alpha1.Metadata
-		wantPodMeta  *mariadbv1alpha1.Metadata
-		wantAffinity bool
-	}{
-		{
-			name:    "PITR job missing startGtid",
-			pitr:    pitr,
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			restoreOpts: []RestoreOpt{
-				WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
-					TargetRecoveryTime: targetRecoveryTime,
-					Volume: &mariadbv1alpha1.StorageVolumeSource{
-						EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
-					},
-				}),
-			},
-			wantErr: true,
-			wantJob: false,
+	DescribeTable("BuildPITRJob",
+		func(pitr *mariadbv1alpha1.PointInTimeRecovery, mariadb *mariadbv1alpha1.MariaDB, restoreOptsFn func() []RestoreOpt,
+			wantErr bool, wantJobMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata, wantAffinity bool) {
+			b := newDefaultTestBuilder()
+			key := types.NamespacedName{
+				Name:      "test-pitr-job",
+				Namespace: "test",
+			}
+
+			job, err := b.BuildPITRJob(key, pitr, mariadb, restoreOptsFn()...)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+				Expect(job).To(BeNil())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job).NotTo(BeNil())
+
+			Expect(job.Name).To(Equal(key.Name))
+			Expect(job.Namespace).To(Equal(key.Namespace))
+
+			Expect(job.Spec.Template.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyOnFailure))
+			Expect(job.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+			Expect(job.Spec.Template.Spec.InitContainers).NotTo(BeEmpty())
+
+			if wantJobMeta != nil {
+				assertObjectMeta(&job.ObjectMeta, wantJobMeta.Labels, wantJobMeta.Annotations)
+			}
+			if wantPodMeta != nil {
+				assertObjectMeta(&job.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+			}
+			if wantAffinity {
+				Expect(job.Spec.Template.Spec.Affinity).NotTo(BeNil())
+			} else {
+				Expect(job.Spec.Template.Spec.Affinity).To(BeNil())
+			}
 		},
-		{
-			name:    "PITR job missing targetRecoveryTime",
-			pitr:    pitr,
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			restoreOpts: []RestoreOpt{
-				WithStartGtid(mustParseGtid(t, "0-10-1")),
+		Entry("PITR job missing startGtid",
+			pitr,
+			&mariadbv1alpha1.MariaDB{},
+			func() []RestoreOpt {
+				return []RestoreOpt{
+					WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
+						TargetRecoveryTime: targetRecoveryTime,
+						Volume: &mariadbv1alpha1.StorageVolumeSource{
+							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+						},
+					}),
+				}
 			},
-			wantErr: true,
-			wantJob: false,
-		},
-		{
-			name:    "PITR job missing volume",
-			pitr:    pitr,
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			restoreOpts: []RestoreOpt{
-				WithStartGtid(mustParseGtid(t, "0-10-1")),
-				WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
-					TargetRecoveryTime: &metav1.Time{Time: time.Now()},
-				}),
+			true,
+			nil,
+			nil,
+			false,
+		),
+		Entry("PITR job missing targetRecoveryTime",
+			pitr,
+			&mariadbv1alpha1.MariaDB{},
+			func() []RestoreOpt {
+				return []RestoreOpt{
+					WithStartGtid(mustParseGtid("0-10-1")),
+				}
 			},
-			wantErr: true,
-			wantJob: false,
-		},
-		{
-			name:    "PITR job missing volume",
-			pitr:    pitr,
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			restoreOpts: []RestoreOpt{
-				WithStartGtid(mustParseGtid(t, "0-10-1")),
-				WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
-					TargetRecoveryTime: &metav1.Time{Time: time.Now()},
-				}),
+			true,
+			nil,
+			nil,
+			false,
+		),
+		Entry("PITR job missing volume",
+			pitr,
+			&mariadbv1alpha1.MariaDB{},
+			func() []RestoreOpt {
+				return []RestoreOpt{
+					WithStartGtid(mustParseGtid("0-10-1")),
+					WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
+						TargetRecoveryTime: &metav1.Time{Time: time.Now()},
+					}),
+				}
 			},
-			wantErr: true,
-			wantJob: false,
-		},
-		{
-			name:    "Valid PITR job ",
-			pitr:    pitr,
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			restoreOpts: []RestoreOpt{
-				WithStartGtid(startGtid),
-				WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
-					TargetRecoveryTime: targetRecoveryTime,
-					Volume: &mariadbv1alpha1.StorageVolumeSource{
-						EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
-					},
-				}),
+			true,
+			nil,
+			nil,
+			false,
+		),
+		Entry("PITR job missing volume",
+			pitr,
+			&mariadbv1alpha1.MariaDB{},
+			func() []RestoreOpt {
+				return []RestoreOpt{
+					WithStartGtid(mustParseGtid("0-10-1")),
+					WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
+						TargetRecoveryTime: &metav1.Time{Time: time.Now()},
+					}),
+				}
 			},
-			wantErr: false,
-			wantJob: true,
-		},
-		{
-			name: "Valid PITR job with meta",
-			pitr: pitr,
-			mariadb: &mariadbv1alpha1.MariaDB{
+			true,
+			nil,
+			nil,
+			false,
+		),
+		Entry("Valid PITR job ",
+			pitr,
+			&mariadbv1alpha1.MariaDB{},
+			func() []RestoreOpt {
+				return []RestoreOpt{
+					WithStartGtid(mustParseGtid("0-10-1")),
+					WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
+						TargetRecoveryTime: targetRecoveryTime,
+						Volume: &mariadbv1alpha1.StorageVolumeSource{
+							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+						},
+					}),
+				}
+			},
+			false,
+			nil,
+			nil,
+			false,
+		),
+		Entry("Valid PITR job with meta",
+			pitr,
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
 						Annotations: map[string]string{
@@ -3497,60 +3182,63 @@ func TestBuildPITRJob(t *testing.T) {
 					},
 				},
 			},
-			restoreOpts: []RestoreOpt{
-				WithStartGtid(startGtid),
-				WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
-					TargetRecoveryTime: targetRecoveryTime,
-					Volume: &mariadbv1alpha1.StorageVolumeSource{
-						EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
-					},
-					RestoreJob: &mariadbv1alpha1.Job{
-						Metadata: &mariadbv1alpha1.Metadata{
-							Annotations: map[string]string{
-								"job.myorg.io": "test",
+			func() []RestoreOpt {
+				return []RestoreOpt{
+					WithStartGtid(mustParseGtid("0-10-1")),
+					WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
+						TargetRecoveryTime: targetRecoveryTime,
+						Volume: &mariadbv1alpha1.StorageVolumeSource{
+							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+						},
+						RestoreJob: &mariadbv1alpha1.Job{
+							Metadata: &mariadbv1alpha1.Metadata{
+								Annotations: map[string]string{
+									"job.myorg.io": "test",
+								},
 							},
 						},
-					},
-				}),
+					}),
+				}
 			},
-			wantErr: false,
-			wantJob: true,
-			wantJobMeta: &mariadbv1alpha1.Metadata{
+			false,
+			&mariadbv1alpha1.Metadata{
 				Annotations: map[string]string{
 					"database.myorg.io": "test",
 					"job.myorg.io":      "test",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Annotations: map[string]string{
 					"database.myorg.io": "test",
 					"pod.myorg.io":      "test",
 				},
 			},
-		},
-		{
-			name:    "Valid PITR job with affinity",
-			pitr:    pitr,
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			restoreOpts: []RestoreOpt{
-				WithStartGtid(startGtid),
-				WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
-					TargetRecoveryTime: targetRecoveryTime,
-					Volume: &mariadbv1alpha1.StorageVolumeSource{
-						EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
-					},
-					RestoreJob: &mariadbv1alpha1.Job{
-						Affinity: &mariadbv1alpha1.AffinityConfig{
-							Affinity: mariadbv1alpha1.Affinity{
-								NodeAffinity: &mariadbv1alpha1.NodeAffinity{
-									RequiredDuringSchedulingIgnoredDuringExecution: &mariadbv1alpha1.NodeSelector{
-										NodeSelectorTerms: []mariadbv1alpha1.NodeSelectorTerm{
-											{
-												MatchExpressions: []mariadbv1alpha1.NodeSelectorRequirement{
-													{
-														Key:      "kubernetes.io/hostname",
-														Operator: corev1.NodeSelectorOpIn,
-														Values:   []string{"node1", "node2"},
+			false,
+		),
+		Entry("Valid PITR job with affinity",
+			pitr,
+			&mariadbv1alpha1.MariaDB{},
+			func() []RestoreOpt {
+				return []RestoreOpt{
+					WithStartGtid(mustParseGtid("0-10-1")),
+					WithBootstrapFrom(&mariadbv1alpha1.BootstrapFrom{
+						TargetRecoveryTime: targetRecoveryTime,
+						Volume: &mariadbv1alpha1.StorageVolumeSource{
+							EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+						},
+						RestoreJob: &mariadbv1alpha1.Job{
+							Affinity: &mariadbv1alpha1.AffinityConfig{
+								Affinity: mariadbv1alpha1.Affinity{
+									NodeAffinity: &mariadbv1alpha1.NodeAffinity{
+										RequiredDuringSchedulingIgnoredDuringExecution: &mariadbv1alpha1.NodeSelector{
+											NodeSelectorTerms: []mariadbv1alpha1.NodeSelectorTerm{
+												{
+													MatchExpressions: []mariadbv1alpha1.NodeSelectorRequirement{
+														{
+															Key:      "kubernetes.io/hostname",
+															Operator: corev1.NodeSelectorOpIn,
+															Values:   []string{"node1", "node2"},
+														},
 													},
 												},
 											},
@@ -3559,104 +3247,91 @@ func TestBuildPITRJob(t *testing.T) {
 								},
 							},
 						},
-					},
-				}),
+					}),
+				}
 			},
-			wantErr:      false,
-			wantJob:      true,
-			wantAffinity: true,
-		},
-	}
+			false,
+			nil,
+			nil,
+			true,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			b := newDefaultTestBuilder(t)
-			key := types.NamespacedName{
-				Name:      "test-pitr-job",
-				Namespace: "test",
-			}
-
-			job, err := b.BuildPITRJob(key, tt.pitr, tt.mariadb, tt.restoreOpts...)
-			if tt.wantErr {
-				assert.Error(t, err)
-				assert.Nil(t, job)
-				return
-			}
-			assert.NoError(t, err)
-			assert.NotNil(t, job)
-
-			assert.Equal(t, key.Name, job.Name)
-			assert.Equal(t, key.Namespace, job.Namespace)
-
-			assert.Equal(t, corev1.RestartPolicyOnFailure, job.Spec.Template.Spec.RestartPolicy)
-			assert.NotEmpty(t, job.Spec.Template.Spec.Containers)
-			assert.NotEmpty(t, job.Spec.Template.Spec.InitContainers)
-
-			if tt.wantJobMeta != nil {
-				assertObjectMeta(t, &job.ObjectMeta, tt.wantJobMeta.Labels, tt.wantJobMeta.Annotations)
-			}
-			if tt.wantPodMeta != nil {
-				assertObjectMeta(t, &job.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-			}
-			if tt.wantAffinity {
-				assert.NotNil(t, job.Spec.Template.Spec.Affinity)
-			} else {
-				assert.Nil(t, job.Spec.Template.Spec.Affinity)
-			}
-		})
-	}
-}
-
-func TestJobPhysicalBackupVolumes(t *testing.T) {
+var _ = Describe("JobPhysicalBackupVolumes", func() {
 	podIndex := 0
+	DescribeTable("jobPhysicalBackupVolumes",
+		func(storageVolume mariadbv1alpha1.StorageVolumeSource, s3 *mariadbv1alpha1.S3, abs *mariadbv1alpha1.AzureBlob,
+			mariadb *mariadbv1alpha1.MariaDB, wantVolumeNames []string) {
+			volumes, volumeMounts := jobPhysicalBackupVolumes(storageVolume, s3, abs, mariadb, &podIndex)
 
-	tests := []struct {
-		name            string
-		storageVolume   mariadbv1alpha1.StorageVolumeSource
-		s3              *mariadbv1alpha1.S3
-		abs             *mariadbv1alpha1.AzureBlob
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantVolumeNames []string
-	}{
-		{
-			name: "Basic backup volumes",
-			storageVolume: mariadbv1alpha1.StorageVolumeSource{
+			Expect(volumes).To(HaveLen(len(wantVolumeNames)))
+			Expect(volumeMounts).To(HaveLen(len(wantVolumeNames)))
+
+			for _, wantName := range wantVolumeNames {
+				foundVol := false
+				for _, v := range volumes {
+					if v.Name == wantName {
+						foundVol = true
+						break
+					}
+				}
+				Expect(foundVol).To(BeTrue())
+
+				foundMount := false
+				for _, vm := range volumeMounts {
+					if vm.Name == wantName {
+						foundMount = true
+						break
+					}
+				}
+				Expect(foundMount).To(BeTrue())
+			}
+		},
+		Entry("Basic backup volumes",
+			mariadbv1alpha1.StorageVolumeSource{
 				EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			(*mariadbv1alpha1.S3)(nil),
+			(*mariadbv1alpha1.AzureBlob)(nil),
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-mariadb"},
 			},
-			wantVolumeNames: []string{batchStorageVolume, StorageVolume},
-		},
-		{
-			name: "S3 Volumes",
-			s3: &mariadbv1alpha1.S3{
+			[]string{batchStorageVolume, StorageVolume},
+		),
+		Entry("S3 Volumes",
+			mariadbv1alpha1.StorageVolumeSource{},
+			&mariadbv1alpha1.S3{
 				TLS: &mariadbv1alpha1.TLSConfig{
 					Enabled:        true,
 					CASecretKeyRef: &mariadbv1alpha1.SecretKeySelector{},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			(*mariadbv1alpha1.AzureBlob)(nil),
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-mariadb"},
 			},
-			wantVolumeNames: []string{batchStorageVolume, StorageVolume, S3PKI},
-		},
-		{
-			name: "ABS Volumes",
-			abs: &mariadbv1alpha1.AzureBlob{
+			[]string{batchStorageVolume, StorageVolume, S3PKI},
+		),
+		Entry("ABS Volumes",
+			mariadbv1alpha1.StorageVolumeSource{},
+			(*mariadbv1alpha1.S3)(nil),
+			&mariadbv1alpha1.AzureBlob{
 				TLS: &mariadbv1alpha1.TLSConfig{
 					Enabled:        true,
 					CASecretKeyRef: &mariadbv1alpha1.SecretKeySelector{},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-mariadb"},
 			},
-			wantVolumeNames: []string{batchStorageVolume, StorageVolume, ABSPKI},
-		},
-		{
-			name: "PKI Volumes",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			[]string{batchStorageVolume, StorageVolume, ABSPKI},
+		),
+		Entry("PKI Volumes",
+			mariadbv1alpha1.StorageVolumeSource{},
+			(*mariadbv1alpha1.S3)(nil),
+			(*mariadbv1alpha1.AzureBlob)(nil),
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-mariadb"},
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					TLS: &mariadbv1alpha1.TLS{
@@ -3664,11 +3339,13 @@ func TestJobPhysicalBackupVolumes(t *testing.T) {
 					},
 				},
 			},
-			wantVolumeNames: []string{batchStorageVolume, StorageVolume, builderpki.PKIVolume},
-		},
-		{
-			name: "Additional env",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			[]string{batchStorageVolume, StorageVolume, builderpki.PKIVolume},
+		),
+		Entry("Additional env",
+			mariadbv1alpha1.StorageVolumeSource{},
+			(*mariadbv1alpha1.S3)(nil),
+			(*mariadbv1alpha1.AzureBlob)(nil),
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{Name: "my-mariadb"},
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					TLS: &mariadbv1alpha1.TLS{
@@ -3690,48 +3367,10 @@ func TestJobPhysicalBackupVolumes(t *testing.T) {
 					},
 				},
 			},
-			wantVolumeNames: []string{batchStorageVolume, StorageVolume, builderpki.PKIVolume, "test"},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			volumes, volumeMounts := jobPhysicalBackupVolumes(tt.storageVolume, tt.s3, tt.abs, tt.mariadb, &podIndex)
-
-			if len(volumes) != len(tt.wantVolumeNames) {
-				t.Errorf("got %d volumes, want %d", len(volumes), len(tt.wantVolumeNames))
-			}
-			if len(volumeMounts) != len(tt.wantVolumeNames) {
-				t.Errorf("got %d volumeMounts, want %d", len(volumes), len(tt.wantVolumeNames))
-			}
-
-			for _, wantName := range tt.wantVolumeNames {
-				foundVol := false
-				for _, v := range volumes {
-					if v.Name == wantName {
-						foundVol = true
-						break
-					}
-				}
-				if !foundVol {
-					t.Errorf("volume %s not found in volumes", wantName)
-				}
-
-				// Check if each expected volume mount exists
-				foundMount := false
-				for _, vm := range volumeMounts {
-					if vm.Name == wantName {
-						foundMount = true
-						break
-					}
-				}
-				if !foundMount {
-					t.Errorf("volume mount %s not found in volumeMounts", wantName)
-				}
-			}
-		})
-	}
-}
+			[]string{batchStorageVolume, StorageVolume, builderpki.PKIVolume, "test"},
+		),
+	)
+})
 
 func hasVolumePVC(volumes []corev1.Volume, volumeName string) bool {
 	for _, v := range volumes {
@@ -3751,10 +3390,8 @@ func getVolumeSource(name string, job *v1.Job) *corev1.VolumeSource {
 	return nil
 }
 
-func mustParseGtid(t *testing.T, rawGtid string) *replication.Gtid {
+func mustParseGtid(rawGtid string) *replication.Gtid {
 	gtid, err := replication.ParseGtid(rawGtid)
-	if err != nil {
-		t.Fatalf("unexpected error parsing GTID: %v", err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	return gtid
 }

--- a/pkg/builder/batch_container_builder_test.go
+++ b/pkg/builder/batch_container_builder_test.go
@@ -1,8 +1,8 @@
 package builder
 
 import (
-	"reflect"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/command"
@@ -12,73 +12,61 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func TestJobContainerSecurityContext(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	cmd := command.NewCommand([]string{"mariadbd"}, []string{})
-	image := "mariadb:10.6"
-	volumeMounts := []corev1.VolumeMount{}
-	envVar := []corev1.EnvVar{}
-	resources := &corev1.ResourceRequirements{}
-	mariadb := &mariadbv1alpha1.MariaDB{}
-	var securityContext *mariadbv1alpha1.SecurityContext
+var _ = Describe("JobContainerSecurityContext", func() {
+	It("should build the container security context", func() {
+		builder := newDefaultTestBuilder()
+		cmd := command.NewCommand([]string{"mariadbd"}, []string{})
+		image := "mariadb:10.6"
+		volumeMounts := []corev1.VolumeMount{}
+		envVar := []corev1.EnvVar{}
+		resources := &corev1.ResourceRequirements{}
+		mariadb := &mariadbv1alpha1.MariaDB{}
+		var securityContext *mariadbv1alpha1.SecurityContext
 
-	container, err := builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)
-	if err != nil {
-		t.Fatalf("unexpected error building container: %v", err)
-	}
-	if container.SecurityContext != nil {
-		t.Error("expected SecurityContext to be nil")
-	}
+		container, err := builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(container.SecurityContext).To(BeNil())
 
-	securityContext = &mariadbv1alpha1.SecurityContext{
-		RunAsUser: ptr.To(mysqlUser),
-	}
-	container, err = builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)
-	if err != nil {
-		t.Fatalf("unexpected error building container: %v", err)
-	}
-	if container.SecurityContext == nil {
-		t.Error("expected SecurityContext not to be nil")
-	}
+		securityContext = &mariadbv1alpha1.SecurityContext{
+			RunAsUser: ptr.To(mysqlUser),
+		}
+		container, err = builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(container.SecurityContext).NotTo(BeNil())
 
-	resource := &metav1.APIResourceList{
-		GroupVersion: "security.openshift.io/v1",
-		APIResources: []metav1.APIResource{
-			{
-				Name: "securitycontextconstraints",
+		resource := &metav1.APIResourceList{
+			GroupVersion: "security.openshift.io/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name: "securitycontextconstraints",
+				},
 			},
-		},
-	}
-	discovery, err := discovery.NewFakeDiscovery(resource)
-	if err != nil {
-		t.Fatalf("unexpected error getting discovery: %v", err)
-	}
-	builder = newTestBuilder(discovery)
+		}
+		fakeDiscovery, err := discovery.NewFakeDiscovery(resource)
+		Expect(err).NotTo(HaveOccurred())
+		builder = newTestBuilder(fakeDiscovery)
 
-	container, err = builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)
-	if err != nil {
-		t.Fatalf("unexpected error building container: %v", err)
-	}
-	if container.SecurityContext != nil {
-		t.Error("expected SecurityContext to be nil")
-	}
-}
+		container, err = builder.jobContainer("mariadb", cmd, image, volumeMounts, envVar, resources, mariadb, securityContext)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(container.SecurityContext).To(BeNil())
+	})
+})
 
-func TestPhysicalBackupJobEnv(t *testing.T) {
+var _ = Describe("PhysicalBackupJobEnv", func() {
 	secretKeySelector := mariadbv1alpha1.SecretKeySelector{
 		LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
 			Name: "test",
 		},
 		Key: "test",
 	}
-	tests := []struct {
-		name     string
-		mariadb  *mariadbv1alpha1.MariaDB
-		expected []corev1.EnvVar
-	}{
-		{
-			name: "Environment with credentials",
-			mariadb: &mariadbv1alpha1.MariaDB{
+
+	DescribeTable("building the env",
+		func(mariadb *mariadbv1alpha1.MariaDB, expected []corev1.EnvVar) {
+			got := physicalBackupJobEnv(mariadb)
+			Expect(got).To(Equal(expected))
+		},
+		Entry("Environment with credentials",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					RootPasswordSecretKeyRef: mariadbv1alpha1.GeneratedSecretKeyRef{
 						SecretKeySelector: secretKeySelector,
@@ -86,7 +74,7 @@ func TestPhysicalBackupJobEnv(t *testing.T) {
 					},
 				},
 			},
-			expected: []corev1.EnvVar{
+			[]corev1.EnvVar{
 				{Name: batchUserEnv, Value: "root"},
 				{
 					Name: batchPasswordEnv,
@@ -95,10 +83,9 @@ func TestPhysicalBackupJobEnv(t *testing.T) {
 					},
 				},
 			},
-		},
-		{
-			name: "Environment with credentials and additional env",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("Environment with credentials and additional env",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					RootPasswordSecretKeyRef: mariadbv1alpha1.GeneratedSecretKeyRef{
 						SecretKeySelector: secretKeySelector,
@@ -114,7 +101,7 @@ func TestPhysicalBackupJobEnv(t *testing.T) {
 					},
 				},
 			},
-			expected: []corev1.EnvVar{
+			[]corev1.EnvVar{
 				{Name: batchUserEnv, Value: "root"},
 				{
 					Name: batchPasswordEnv,
@@ -124,21 +111,6 @@ func TestPhysicalBackupJobEnv(t *testing.T) {
 				},
 				{Name: "TEST", Value: "TEST"},
 			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := physicalBackupJobEnv(tt.mariadb)
-
-			if len(got) != len(tt.expected) {
-				t.Errorf("got %d env vars, want %d", len(got), len(tt.expected))
-			}
-
-			// Using reflect.DeepEqual or cmp.Diff to validate the slice content
-			if !reflect.DeepEqual(got, tt.expected) {
-				t.Errorf("unexpected env vars:\ngot: %v\nwant: %v", got, tt.expected)
-			}
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/builder/builder_test.go
+++ b/pkg/builder/builder_test.go
@@ -1,8 +1,7 @@
 package builder
 
 import (
-	"reflect"
-	"testing"
+	. "github.com/onsi/gomega"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -40,34 +39,28 @@ func newTestBuilder(discovery *discovery.Discovery) *Builder {
 	return builder
 }
 
-func newDefaultTestBuilder(t *testing.T) *Builder {
+func newDefaultTestBuilder() *Builder {
 	discovery, err := discovery.NewFakeDiscovery()
-	if err != nil {
-		t.Fatalf("unexpected error creating discovery: %v", err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	return newTestBuilder(discovery)
 }
 
-func assertObjectMeta(t *testing.T, objMeta *metav1.ObjectMeta, wantLabels, wantAnnotations map[string]string) {
-	if objMeta == nil {
-		t.Fatal("expecting object metadata to not be nil")
+func assertObjectMeta(objMeta *metav1.ObjectMeta, wantLabels, wantAnnotations map[string]string) {
+	Expect(objMeta).NotTo(BeNil())
+	if wantLabels != nil {
+		Expect(objMeta.Labels).To(Equal(wantLabels))
 	}
-	if wantLabels != nil && !reflect.DeepEqual(wantLabels, objMeta.Labels) {
-		t.Errorf("unexpected labels, want: %v  got: %v", wantLabels, objMeta.Labels)
-	}
-	if wantAnnotations != nil && !reflect.DeepEqual(wantAnnotations, objMeta.Annotations) {
-		t.Errorf("unexpected annotations, want: %v  got: %v", wantAnnotations, objMeta.Annotations)
+	if wantAnnotations != nil {
+		Expect(objMeta.Annotations).To(Equal(wantAnnotations))
 	}
 }
 
-func assertMeta(t *testing.T, meta *mariadbv1alpha1.Metadata, wantLabels, wantAnnotations map[string]string) {
-	if meta == nil {
-		t.Fatal("expecting metadata to not be nil")
+func assertMeta(meta *mariadbv1alpha1.Metadata, wantLabels, wantAnnotations map[string]string) {
+	Expect(meta).NotTo(BeNil())
+	if wantLabels != nil {
+		Expect(meta.Labels).To(Equal(wantLabels))
 	}
-	if wantLabels != nil && !reflect.DeepEqual(wantLabels, meta.Labels) {
-		t.Errorf("unexpected labels, want: %v  got: %v", wantLabels, meta.Labels)
-	}
-	if wantAnnotations != nil && !reflect.DeepEqual(wantAnnotations, meta.Annotations) {
-		t.Errorf("unexpected annotations, want: %v  got: %v", wantAnnotations, meta.Annotations)
+	if wantAnnotations != nil {
+		Expect(meta.Annotations).To(Equal(wantAnnotations))
 	}
 }

--- a/pkg/builder/certificate_builder_test.go
+++ b/pkg/builder/certificate_builder_test.go
@@ -1,112 +1,102 @@
 package builder
 
 import (
-	"testing"
 	"time"
 
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestBuildCertificate(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("BuildCertificate", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name:      "test-cert",
 		Namespace: "test",
 	}
 	owner := &mariadbv1alpha1.MariaDB{}
-	tests := []struct {
-		name     string
-		certOpts []CertOpt
-		wantErr  bool
-	}{
-		{
-			name: "missing key",
-			certOpts: []CertOpt{
-				WithOwner(owner),
-				WithDNSnames([]string{"example.com"}),
-				WithLifetime(24 * time.Hour),
-				WithRenewBeforePercentage(50),
-				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
-			},
-			wantErr: true,
-		},
-		{
-			name: "missing owner",
-			certOpts: []CertOpt{
-				WithKey(key),
-				WithDNSnames([]string{"example.com"}),
-				WithLifetime(24 * time.Hour),
-				WithRenewBeforePercentage(50),
-				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
-			},
-			wantErr: true,
-		},
-		{
-			name: "missing DNS names",
-			certOpts: []CertOpt{
-				WithKey(key),
-				WithOwner(owner),
-				WithLifetime(24 * time.Hour),
-				WithRenewBeforePercentage(50),
-				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
-			},
-			wantErr: true,
-		},
-		{
-			name: "missing lifetime",
-			certOpts: []CertOpt{
-				WithKey(key),
-				WithOwner(owner),
-				WithDNSnames([]string{"example.com"}),
-				WithRenewBeforePercentage(50),
-				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing renew before percentage",
-			certOpts: []CertOpt{
-				WithKey(key),
-				WithOwner(owner),
-				WithDNSnames([]string{"example.com"}),
-				WithLifetime(24 * time.Hour),
-				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
-			},
-			wantErr: false,
-		},
-		{
-			name: "missing issuer ref",
-			certOpts: []CertOpt{
-				WithKey(key),
-				WithOwner(owner),
-				WithDNSnames([]string{"example.com"}),
-				WithLifetime(24 * time.Hour),
-				WithRenewBeforePercentage(50),
-			},
-			wantErr: true,
-		},
-		{
-			name: "valid options",
-			certOpts: []CertOpt{
-				WithKey(key),
-				WithOwner(owner),
-				WithDNSnames([]string{"example.com"}),
-				WithLifetime(24 * time.Hour),
-				WithRenewBeforePercentage(50),
-				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
-			},
-			wantErr: false,
-		},
-	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := builder.BuildCertificate(tt.certOpts...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("BuildCertificate() error = %v, expectError %v", err, tt.wantErr)
+	DescribeTable("building a certificate",
+		func(certOpts []CertOpt, wantErr bool) {
+			_, err := builder.BuildCertificate(certOpts...)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
 			}
-		})
-	}
-}
+		},
+		Entry("missing key",
+			[]CertOpt{
+				WithOwner(owner),
+				WithDNSnames([]string{"example.com"}),
+				WithLifetime(24 * time.Hour),
+				WithRenewBeforePercentage(50),
+				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
+			},
+			true,
+		),
+		Entry("missing owner",
+			[]CertOpt{
+				WithKey(key),
+				WithDNSnames([]string{"example.com"}),
+				WithLifetime(24 * time.Hour),
+				WithRenewBeforePercentage(50),
+				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
+			},
+			true,
+		),
+		Entry("missing DNS names",
+			[]CertOpt{
+				WithKey(key),
+				WithOwner(owner),
+				WithLifetime(24 * time.Hour),
+				WithRenewBeforePercentage(50),
+				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
+			},
+			true,
+		),
+		Entry("missing lifetime",
+			[]CertOpt{
+				WithKey(key),
+				WithOwner(owner),
+				WithDNSnames([]string{"example.com"}),
+				WithRenewBeforePercentage(50),
+				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
+			},
+			false,
+		),
+		Entry("missing renew before percentage",
+			[]CertOpt{
+				WithKey(key),
+				WithOwner(owner),
+				WithDNSnames([]string{"example.com"}),
+				WithLifetime(24 * time.Hour),
+				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
+			},
+			false,
+		),
+		Entry("missing issuer ref",
+			[]CertOpt{
+				WithKey(key),
+				WithOwner(owner),
+				WithDNSnames([]string{"example.com"}),
+				WithLifetime(24 * time.Hour),
+				WithRenewBeforePercentage(50),
+			},
+			true,
+		),
+		Entry("valid options",
+			[]CertOpt{
+				WithKey(key),
+				WithOwner(owner),
+				WithDNSnames([]string{"example.com"}),
+				WithLifetime(24 * time.Hour),
+				WithRenewBeforePercentage(50),
+				WithIssuerRef(cmmeta.IssuerReference{Name: "test-issuer"}),
+			},
+			false,
+		),
+	)
+})

--- a/pkg/builder/configmap_builder_test.go
+++ b/pkg/builder/configmap_builder_test.go
@@ -1,22 +1,23 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestConfigMapMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	tests := []struct {
-		name     string
-		opts     ConfigMapOpts
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			opts: ConfigMapOpts{
+var _ = Describe("ConfigMapMeta", func() {
+	builder := newDefaultTestBuilder()
+	DescribeTable("ConfigMapMeta",
+		func(opts ConfigMapOpts, wantMeta *mariadbv1alpha1.Metadata) {
+			configMap, err := builder.BuildConfigMap(opts, &mariadbv1alpha1.MariaDB{})
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&configMap.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			ConfigMapOpts{
 				Key: types.NamespacedName{
 					Name: "configmap",
 				},
@@ -24,14 +25,13 @@ func TestConfigMapMeta(t *testing.T) {
 					"my.cnf": "test",
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			opts: ConfigMapOpts{
+		),
+		Entry("meta",
+			ConfigMapOpts{
 				Key: types.NamespacedName{
 					Name: "configmap",
 				},
@@ -47,7 +47,7 @@ func TestConfigMapMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -55,16 +55,6 @@ func TestConfigMapMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configMap, err := builder.BuildConfigMap(tt.opts, &mariadbv1alpha1.MariaDB{})
-			if err != nil {
-				t.Fatalf("unexpected error building ConfigMap: %v", err)
-			}
-			assertObjectMeta(t, &configMap.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/builder/connection_builder_test.go
+++ b/pkg/builder/connection_builder_test.go
@@ -1,35 +1,38 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestConnectionMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	tests := []struct {
-		name     string
-		opts     ConnectionOpts
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			opts: ConnectionOpts{
+var _ = Describe("ConnectionMeta", func() {
+	builder := newDefaultTestBuilder()
+	DescribeTable(
+		"should build Connection metadata",
+		func(opts ConnectionOpts, wantMeta *mariadbv1alpha1.Metadata) {
+			configMap, err := builder.BuildConnection(opts, &mariadbv1alpha1.MariaDB{})
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&configMap.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry(
+			"no meta",
+			ConnectionOpts{
 				Key: types.NamespacedName{
 					Name: "connection",
 				},
 				Metadata: &mariadbv1alpha1.Metadata{},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			opts: ConnectionOpts{
+		),
+		Entry(
+			"meta",
+			ConnectionOpts{
 				Key: types.NamespacedName{
 					Name: "connection",
 				},
@@ -42,7 +45,7 @@ func TestConnectionMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -50,15 +53,6 @@ func TestConnectionMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configMap, err := builder.BuildConnection(tt.opts, &mariadbv1alpha1.MariaDB{})
-			if err != nil {
-				t.Fatalf("unexpected error building Connection: %v", err)
-			}
-			assertObjectMeta(t, &configMap.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/builder/container_builder_test.go
+++ b/pkg/builder/container_builder_test.go
@@ -1,14 +1,15 @@
 package builder
 
 import (
-	"reflect"
+	"os"
 	"slices"
 	"sort"
 	"strconv"
-	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	builderpki "github.com/mariadb-operator/mariadb-operator/v26/pkg/builder/pki"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/datastructures"
@@ -19,16 +20,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func TestMariadbStartupProbe(t *testing.T) {
-	tests := []struct {
-		name      string
-		mariadb   *mariadbv1alpha1.MariaDB
-		wantProbe *corev1.Probe
-	}{
-		{
-			name:    "MariaDB",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantProbe: &corev1.Probe{
+var _ = Describe("MariadbStartupProbe", func() {
+	DescribeTable("should build the expected probe",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantProbe *corev1.Probe) {
+			probe, err := mariadbStartupProbe(mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(probe).To(Equal(wantProbe))
+		},
+		Entry("MariaDB",
+			&mariadbv1alpha1.MariaDB{},
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -42,10 +43,9 @@ func TestMariadbStartupProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB with thresholds",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB with thresholds",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						StartupProbe: &mariadbv1alpha1.Probe{
@@ -56,7 +56,7 @@ func TestMariadbStartupProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -71,10 +71,9 @@ func TestMariadbStartupProbe(t *testing.T) {
 				PeriodSeconds:       10,
 				FailureThreshold:    10,
 			},
-		},
-		{
-			name: "MariaDB custom",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB custom",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						StartupProbe: &mariadbv1alpha1.Probe{
@@ -94,7 +93,7 @@ func TestMariadbStartupProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -108,10 +107,9 @@ func TestMariadbStartupProbe(t *testing.T) {
 				TimeoutSeconds:   10,
 				PeriodSeconds:    10,
 			},
-		},
-		{
-			name: "MariaDB replication",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -123,7 +121,7 @@ func TestMariadbStartupProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -134,10 +132,9 @@ func TestMariadbStartupProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication with thresholds",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication with thresholds",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -156,7 +153,7 @@ func TestMariadbStartupProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -168,10 +165,9 @@ func TestMariadbStartupProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication custom",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication custom",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -196,7 +192,7 @@ func TestMariadbStartupProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -208,10 +204,9 @@ func TestMariadbStartupProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication with standalone probe",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication with standalone probe",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -221,7 +216,7 @@ func TestMariadbStartupProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -235,10 +230,9 @@ func TestMariadbStartupProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB Galera",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB Galera",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -250,7 +244,7 @@ func TestMariadbStartupProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -261,10 +255,9 @@ func TestMariadbStartupProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB Galera with thresholds",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB Galera with thresholds",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -283,7 +276,7 @@ func TestMariadbStartupProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -295,10 +288,9 @@ func TestMariadbStartupProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB Galera custom",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB Galera custom",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -323,7 +315,7 @@ func TestMariadbStartupProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -335,32 +327,20 @@ func TestMariadbStartupProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
+		),
+	)
+})
+
+var _ = Describe("MariadbLivenessProbe", func() {
+	DescribeTable("should build the expected probe",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantProbe *corev1.Probe) {
+			probe, err := mariadbLivenessProbe(mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(probe).To(Equal(wantProbe))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			probe, err := mariadbStartupProbe(tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if diff := cmp.Diff(tt.wantProbe, probe); diff != "" {
-				t.Errorf("unexpected probe (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestMariadbLivenessProbe(t *testing.T) {
-	tests := []struct {
-		name      string
-		mariadb   *mariadbv1alpha1.MariaDB
-		wantProbe *corev1.Probe
-	}{
-		{
-			name:    "MariaDB",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantProbe: &corev1.Probe{
+		Entry("MariaDB",
+			&mariadbv1alpha1.MariaDB{},
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -374,10 +354,9 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB with thresholds",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB with thresholds",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						LivenessProbe: &mariadbv1alpha1.Probe{
@@ -388,7 +367,7 @@ func TestMariadbLivenessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -402,10 +381,9 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB custom",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB custom",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						LivenessProbe: &mariadbv1alpha1.Probe{
@@ -425,7 +403,7 @@ func TestMariadbLivenessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -439,10 +417,9 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -454,7 +431,7 @@ func TestMariadbLivenessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -465,10 +442,9 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication with thresholds",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication with thresholds",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -487,7 +463,7 @@ func TestMariadbLivenessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -498,10 +474,9 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication custom",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication custom",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -526,7 +501,7 @@ func TestMariadbLivenessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -537,10 +512,9 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication with standalone probe",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication with standalone probe",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -550,7 +524,7 @@ func TestMariadbLivenessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -564,10 +538,9 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB Galera",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB Galera",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -579,7 +552,7 @@ func TestMariadbLivenessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -590,10 +563,9 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB Galera with thresholds",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB Galera with thresholds",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -612,7 +584,7 @@ func TestMariadbLivenessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -623,10 +595,9 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB Galera custom",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB Galera custom",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -651,7 +622,7 @@ func TestMariadbLivenessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/liveness",
@@ -662,32 +633,20 @@ func TestMariadbLivenessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
+		),
+	)
+})
+
+var _ = Describe("MariadbReadinessProbe", func() {
+	DescribeTable("should build the expected probe",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantProbe *corev1.Probe) {
+			probe, err := mariadbReadinessProbe(mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(probe).To(Equal(wantProbe))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			probe, err := mariadbLivenessProbe(tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if diff := cmp.Diff(tt.wantProbe, probe); diff != "" {
-				t.Errorf("unexpected probe (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestMariadbReadinessProbe(t *testing.T) {
-	tests := []struct {
-		name      string
-		mariadb   *mariadbv1alpha1.MariaDB
-		wantProbe *corev1.Probe
-	}{
-		{
-			name:    "MariaDB empty",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantProbe: &corev1.Probe{
+		Entry("MariaDB empty",
+			&mariadbv1alpha1.MariaDB{},
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -701,10 +660,9 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB with thresholds",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB with thresholds",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						ReadinessProbe: &mariadbv1alpha1.Probe{
@@ -715,7 +673,7 @@ func TestMariadbReadinessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -729,10 +687,9 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB custom",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB custom",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						ReadinessProbe: &mariadbv1alpha1.Probe{
@@ -752,7 +709,7 @@ func TestMariadbReadinessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{
@@ -766,10 +723,9 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -781,7 +737,7 @@ func TestMariadbReadinessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/readiness",
@@ -792,10 +748,9 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication with thresholds",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication with thresholds",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -814,7 +769,7 @@ func TestMariadbReadinessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/readiness",
@@ -825,10 +780,9 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication custom",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication custom",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -853,7 +807,7 @@ func TestMariadbReadinessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/readiness",
@@ -864,10 +818,9 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB replication with ignored standalone probe",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB replication with ignored standalone probe",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replication: &mariadbv1alpha1.Replication{
 						Enabled: true,
@@ -880,7 +833,7 @@ func TestMariadbReadinessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/readiness",
@@ -891,10 +844,9 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB Galera",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB Galera",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -906,7 +858,7 @@ func TestMariadbReadinessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/readiness",
@@ -917,10 +869,9 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB Galera with thresholds",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB Galera with thresholds",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -939,7 +890,7 @@ func TestMariadbReadinessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/readiness",
@@ -950,10 +901,9 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MariaDB Galera custom",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB Galera custom",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -978,7 +928,7 @@ func TestMariadbReadinessProbe(t *testing.T) {
 					},
 				},
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/readiness",
@@ -989,40 +939,26 @@ func TestMariadbReadinessProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
+		),
+	)
+})
+
+var _ = Describe("MaxScaleProbe", func() {
+	DescribeTable("should build the expected probe",
+		func(maxScale *mariadbv1alpha1.MaxScale, probe *mariadbv1alpha1.Probe, wantProbe *corev1.Probe) {
+			got := maxscaleProbe(maxScale, probe)
+			Expect(got).To(Equal(wantProbe))
 		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			probe, err := mariadbReadinessProbe(tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if diff := cmp.Diff(tt.wantProbe, probe); diff != "" {
-				t.Errorf("unexpected probe (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestMaxScaleProbe(t *testing.T) {
-	tests := []struct {
-		name      string
-		maxScale  *mariadbv1alpha1.MaxScale
-		probe     *mariadbv1alpha1.Probe
-		wantProbe *corev1.Probe
-	}{
-		{
-			name: "MaxScale empty",
-			maxScale: &mariadbv1alpha1.MaxScale{
+		Entry("MaxScale empty",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Admin: mariadbv1alpha1.MaxScaleAdmin{
 						Port: 8989,
 					},
 				},
 			},
-			probe: &mariadbv1alpha1.Probe{},
-			wantProbe: &corev1.Probe{
+			&mariadbv1alpha1.Probe{},
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					TCPSocket: &corev1.TCPSocketAction{
 						Port: intstr.FromInt(8989),
@@ -1032,22 +968,21 @@ func TestMaxScaleProbe(t *testing.T) {
 				TimeoutSeconds:      5,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MaxScale partial",
-			maxScale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("MaxScale partial",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Admin: mariadbv1alpha1.MaxScaleAdmin{
 						Port: 8989,
 					},
 				},
 			},
-			probe: &mariadbv1alpha1.Probe{
+			&mariadbv1alpha1.Probe{
 				InitialDelaySeconds: 10,
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					TCPSocket: &corev1.TCPSocketAction{
 						Port: intstr.FromInt(8989),
@@ -1057,17 +992,16 @@ func TestMaxScaleProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MaxScale full",
-			maxScale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("MaxScale full",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Admin: mariadbv1alpha1.MaxScaleAdmin{
 						Port: 8989,
 					},
 				},
 			},
-			probe: &mariadbv1alpha1.Probe{
+			&mariadbv1alpha1.Probe{
 				ProbeHandler: mariadbv1alpha1.ProbeHandler{
 					TCPSocket: &mariadbv1alpha1.TCPSocketAction{
 						Host: "custom",
@@ -1078,7 +1012,7 @@ func TestMaxScaleProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					TCPSocket: &corev1.TCPSocketAction{
 						Host: "custom",
@@ -1089,17 +1023,16 @@ func TestMaxScaleProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-		{
-			name: "MaxScale Probe with Failure Threshold",
-			maxScale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("MaxScale Probe with Failure Threshold",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Admin: mariadbv1alpha1.MaxScaleAdmin{
 						Port: 8989,
 					},
 				},
 			},
-			probe: &mariadbv1alpha1.Probe{
+			&mariadbv1alpha1.Probe{
 				ProbeHandler: mariadbv1alpha1.ProbeHandler{
 					HTTPGet: &mariadbv1alpha1.HTTPGetAction{
 						Path: "/custom",
@@ -1111,7 +1044,7 @@ func TestMaxScaleProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-			wantProbe: &corev1.Probe{
+			&corev1.Probe{
 				ProbeHandler: corev1.ProbeHandler{
 					HTTPGet: &corev1.HTTPGetAction{
 						Path: "/custom",
@@ -1123,88 +1056,63 @@ func TestMaxScaleProbe(t *testing.T) {
 				TimeoutSeconds:      10,
 				PeriodSeconds:       10,
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			probe := maxscaleProbe(tt.maxScale, tt.probe)
-			if diff := cmp.Diff(tt.wantProbe, probe); diff != "" {
-				t.Errorf("unexpected probe (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
+var _ = Describe("ContainerSecurityContext", func() {
+	It("should build the expected security context", func() {
+		builder := newDefaultTestBuilder()
+		tpl := &mariadbv1alpha1.ContainerTemplate{}
 
-func TestContainerSecurityContext(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	tpl := &mariadbv1alpha1.ContainerTemplate{}
+		container, err := builder.buildContainerWithTemplate("mariadb:10.6", corev1.PullIfNotPresent, tpl)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(container.SecurityContext).To(BeNil())
 
-	container, err := builder.buildContainerWithTemplate("mariadb:10.6", corev1.PullIfNotPresent, tpl)
-	if err != nil {
-		t.Fatalf("unexpected error building container: %v", err)
-	}
-	if container.SecurityContext != nil {
-		t.Error("expected SecurityContext to be nil")
-	}
-
-	tpl = &mariadbv1alpha1.ContainerTemplate{
-		SecurityContext: &mariadbv1alpha1.SecurityContext{
-			RunAsUser: ptr.To(mysqlUser),
-		},
-	}
-	container, err = builder.buildContainerWithTemplate("mariadb:10.6", corev1.PullIfNotPresent, tpl)
-	if err != nil {
-		t.Fatalf("unexpected error building container: %v", err)
-	}
-	if container.SecurityContext == nil {
-		t.Error("expected SecurityContext not to be nil")
-	}
-
-	resource := &metav1.APIResourceList{
-		GroupVersion: "security.openshift.io/v1",
-		APIResources: []metav1.APIResource{
-			{
-				Name: "securitycontextconstraints",
+		tpl = &mariadbv1alpha1.ContainerTemplate{
+			SecurityContext: &mariadbv1alpha1.SecurityContext{
+				RunAsUser: ptr.To(mysqlUser),
 			},
+		}
+		container, err = builder.buildContainerWithTemplate("mariadb:10.6", corev1.PullIfNotPresent, tpl)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(container.SecurityContext).NotTo(BeNil())
+
+		resource := &metav1.APIResourceList{
+			GroupVersion: "security.openshift.io/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name: "securitycontextconstraints",
+				},
+			},
+		}
+		dsc, err := discovery.NewFakeDiscovery(resource)
+		Expect(err).NotTo(HaveOccurred())
+		builder = newTestBuilder(dsc)
+
+		container, err = builder.buildContainerWithTemplate("mariadb:10.6", corev1.PullIfNotPresent, tpl)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(container.SecurityContext).To(BeNil())
+	})
+})
+
+var _ = Describe("BuildContainerLifecycle", func() {
+	DescribeTable("should build the expected lifecycle",
+		func(container *mariadbv1alpha1.ContainerTemplate, opts []mariadbPodOpt, want *corev1.Lifecycle) {
+			builder := newDefaultTestBuilder()
+			got, err := builder.buildContainerWithTemplate("mariadb", corev1.PullIfNotPresent, container, opts...)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.Lifecycle).To(Equal(want))
 		},
-	}
-	discovery, err := discovery.NewFakeDiscovery(resource)
-	if err != nil {
-		t.Fatalf("unexpected error getting discovery: %v", err)
-	}
-	builder = newTestBuilder(discovery)
-
-	container, err = builder.buildContainerWithTemplate("mariadb:10.6", corev1.PullIfNotPresent, tpl)
-	if err != nil {
-		t.Fatalf("unexpected error building container: %v", err)
-	}
-	if container.SecurityContext != nil {
-		t.Error("expected SecurityContext to be nil")
-	}
-}
-
-func TestBuildContainerLifecycle(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-
-	tests := []struct {
-		name      string
-		container *mariadbv1alpha1.ContainerTemplate
-		opts      []mariadbPodOpt
-		want      *corev1.Lifecycle
-	}{
-
-		{
-			name:      "no lifecycle",
-			container: &mariadbv1alpha1.ContainerTemplate{},
-			opts: []mariadbPodOpt{
+		Entry("no lifecycle",
+			&mariadbv1alpha1.ContainerTemplate{},
+			[]mariadbPodOpt{
 				withLifecycle(true),
 			},
-			want: nil,
-		},
-		{
-			name: "with postStart lifecycle",
-			container: &mariadbv1alpha1.ContainerTemplate{
+			nil,
+		),
+		Entry("with postStart lifecycle",
+			&mariadbv1alpha1.ContainerTemplate{
 				Lifecycle: &mariadbv1alpha1.Lifecycle{
 					PostStart: &mariadbv1alpha1.LifecycleHandler{
 						Exec: &mariadbv1alpha1.ExecAction{
@@ -1213,20 +1121,19 @@ func TestBuildContainerLifecycle(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withLifecycle(true),
 			},
-			want: &corev1.Lifecycle{
+			&corev1.Lifecycle{
 				PostStart: &corev1.LifecycleHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{"echo", "hello"},
 					},
 				},
 			},
-		},
-		{
-			name: "with preStop lifecycle",
-			container: &mariadbv1alpha1.ContainerTemplate{
+		),
+		Entry("with preStop lifecycle",
+			&mariadbv1alpha1.ContainerTemplate{
 				Lifecycle: &mariadbv1alpha1.Lifecycle{
 					PreStop: &mariadbv1alpha1.LifecycleHandler{
 						Exec: &mariadbv1alpha1.ExecAction{
@@ -1235,20 +1142,19 @@ func TestBuildContainerLifecycle(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withLifecycle(true),
 			},
-			want: &corev1.Lifecycle{
+			&corev1.Lifecycle{
 				PreStop: &corev1.LifecycleHandler{
 					Exec: &corev1.ExecAction{
 						Command: []string{"echo", "hello"},
 					},
 				},
 			},
-		},
-		{
-			name: "without lifecycle",
-			container: &mariadbv1alpha1.ContainerTemplate{
+		),
+		Entry("without lifecycle",
+			&mariadbv1alpha1.ContainerTemplate{
 				Lifecycle: &mariadbv1alpha1.Lifecycle{
 					PreStop: &mariadbv1alpha1.LifecycleHandler{
 						Exec: &mariadbv1alpha1.ExecAction{
@@ -1257,14 +1163,13 @@ func TestBuildContainerLifecycle(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withLifecycle(false),
 			},
-			want: nil,
-		},
-		{
-			name: "defaults to no lifecycle",
-			container: &mariadbv1alpha1.ContainerTemplate{
+			nil,
+		),
+		Entry("defaults to no lifecycle",
+			&mariadbv1alpha1.ContainerTemplate{
 				Lifecycle: &mariadbv1alpha1.Lifecycle{
 					PreStop: &mariadbv1alpha1.LifecycleHandler{
 						Exec: &mariadbv1alpha1.ExecAction{
@@ -1273,108 +1178,102 @@ func TestBuildContainerLifecycle(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
-		},
-	}
+			nil,
+			nil,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := builder.buildContainerWithTemplate("mariadb", corev1.PullIfNotPresent, tt.container, tt.opts...)
-			if err != nil {
-				t.Fatalf("unexpected error building container: %v", err)
+var _ = Describe("MariadbEnv", func() {
+	DescribeTable("should build the expected env",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantEnv []corev1.EnvVar, setClusterName bool) {
+			if setClusterName {
+				DeferCleanup(os.Setenv, "CLUSTER_NAME", os.Getenv("CLUSTER_NAME"))
+				os.Setenv("CLUSTER_NAME", "example.com")
 			}
+			env, err := mariadbEnv(mariadb)
+			Expect(err).NotTo(HaveOccurred())
 
-			if diff := cmp.Diff(tt.want, got.Lifecycle); diff != "" {
-				t.Errorf("unexpected Lifecycle (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
+			sortedWantEnv := sortEnvVars(wantEnv)
+			sortedEnv := sortEnvVars(env)
 
-func TestMariadbEnv(t *testing.T) {
-	tests := []struct {
-		name           string
-		mariadb        *mariadbv1alpha1.MariaDB
-		wantEnv        []corev1.EnvVar
-		setClusterName bool
-	}{
-		{
-			name:    "MariaDB empty",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantEnv: defaultEnv(nil),
+			Expect(sortedEnv).To(Equal(sortedWantEnv))
 		},
-		{
-			name:    "MariaDB cluster name",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantEnv: defaultEnv([]corev1.EnvVar{
+		Entry("MariaDB empty",
+			&mariadbv1alpha1.MariaDB{},
+			defaultEnv(nil),
+			false,
+		),
+		Entry("MariaDB cluster name",
+			&mariadbv1alpha1.MariaDB{},
+			defaultEnv([]corev1.EnvVar{
 				{
 					Name:  "CLUSTER_NAME",
 					Value: "example.com",
 				},
 			}),
-			setClusterName: true,
-		},
-		{
-			name: "MariaDB tcp port",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			true,
+		),
+		Entry("MariaDB tcp port",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Port: 12345,
 				},
 			},
-			wantEnv: defaultEnv([]corev1.EnvVar{
+			defaultEnv([]corev1.EnvVar{
 				{
 					Name:  "MYSQL_TCP_PORT",
 					Value: strconv.Itoa(12345),
 				},
 			}),
-		},
-		{
-			name: "MariaDB name",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("MariaDB name",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "example",
 				},
 			},
-			wantEnv: defaultEnv([]corev1.EnvVar{
+			defaultEnv([]corev1.EnvVar{
 				{
 					Name:  "MARIADB_NAME",
 					Value: "example",
 				},
 			}),
-		},
-		{
-			name: "MariaDB root empty password",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("MariaDB root empty password",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					RootEmptyPassword: ptr.To(true),
 				},
 			},
-			wantEnv: defaultEnv([]corev1.EnvVar{
+			defaultEnv([]corev1.EnvVar{
 				{
 					Name:  "MARIADB_ALLOW_EMPTY_ROOT_PASSWORD",
 					Value: "yes",
 				},
 			}),
-		},
-		{
-			name: "MariaDB timeZone",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("MariaDB timeZone",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					TimeZone: ptr.To("UTC"),
 				},
 			},
-			wantEnv: removeEnv(defaultEnv(nil), "MYSQL_INITDB_SKIP_TZINFO"),
-		},
-		{
-			name: "MariaDB TLS",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			removeEnv(defaultEnv(nil), "MYSQL_INITDB_SKIP_TZINFO"),
+			false,
+		),
+		Entry("MariaDB TLS",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					TLS: &mariadbv1alpha1.TLS{
 						Enabled: true,
 					},
 				},
 			},
-			wantEnv: append(defaultEnv(nil),
+			append(defaultEnv(nil),
 				[]corev1.EnvVar{
 					{
 						Name:  "TLS_ENABLED",
@@ -1401,10 +1300,10 @@ func TestMariadbEnv(t *testing.T) {
 						Value: builderpki.ClientKeyPath,
 					},
 				}...),
-		},
-		{
-			name: "MariaDB replication",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("MariaDB replication",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mariadb-repl",
 				},
@@ -1422,7 +1321,7 @@ func TestMariadbEnv(t *testing.T) {
 					},
 				},
 			},
-			wantEnv: append(
+			append(
 				defaultEnv([]corev1.EnvVar{
 					{
 						Name:  "MARIADB_NAME",
@@ -1459,10 +1358,10 @@ func TestMariadbEnv(t *testing.T) {
 						Value: "AFTER_COMMIT",
 					},
 				}...),
-		},
-		{
-			name: "MariaDB Galera TLS",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("MariaDB Galera TLS",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mariadb-galera",
 				},
@@ -1475,7 +1374,7 @@ func TestMariadbEnv(t *testing.T) {
 					},
 				},
 			},
-			wantEnv: append(
+			append(
 				defaultEnv([]corev1.EnvVar{
 					{
 						Name:  "MARIADB_NAME",
@@ -1512,10 +1411,10 @@ func TestMariadbEnv(t *testing.T) {
 						Value: "mariadb-galera-client:",
 					},
 				}...),
-		},
-		{
-			name: "MariaDB env append",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("MariaDB env append",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Env: []mariadbv1alpha1.EnvVar{
@@ -1527,14 +1426,14 @@ func TestMariadbEnv(t *testing.T) {
 					},
 				},
 			},
-			wantEnv: append(defaultEnv(nil), corev1.EnvVar{
+			append(defaultEnv(nil), corev1.EnvVar{
 				Name:  "FOO_BAR_BAZ",
 				Value: "LOREM_IPSUM_DOLOR",
 			}),
-		},
-		{
-			name: "MariaDB env override",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("MariaDB env override",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Env: []mariadbv1alpha1.EnvVar{
@@ -1578,7 +1477,7 @@ func TestMariadbEnv(t *testing.T) {
 					},
 				},
 			},
-			wantEnv: []corev1.EnvVar{
+			[]corev1.EnvVar{
 				{
 					Name:  "MYSQL_TCP_PORT",
 					Value: strconv.Itoa(12345),
@@ -1616,205 +1515,165 @@ func TestMariadbEnv(t *testing.T) {
 					Value: "0",
 				},
 			},
-		},
-	}
+			false,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if tt.setClusterName {
-				t.Setenv("CLUSTER_NAME", "example.com")
-			}
-			env, err := mariadbEnv(tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+var _ = Describe("S3Env", func() {
+	DescribeTable("should build the expected env",
+		func(s3 *mariadbv1alpha1.S3, expectedEnv []string) {
+			env := s3Env(s3)
 
-			sortedWantEnv := sortEnvVars(tt.wantEnv)
-			sortedEnv := sortEnvVars(env)
-
-			if diff := cmp.Diff(sortedWantEnv, sortedEnv); diff != "" {
-				t.Errorf("unexpected env (-want +got):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestS3Env(t *testing.T) {
-	tests := []struct {
-		name        string
-		s3          *mariadbv1alpha1.S3
-		expectedEnv []string
-	}{
-		{
-			name:        "nil S3",
-			s3:          nil,
-			expectedEnv: nil,
-		},
-		{
-			name: "S3 with access key only",
-			s3: &mariadbv1alpha1.S3{
-				Bucket:   "test-bucket",
-				Endpoint: "s3.amazonaws.com",
-				AccessKeyIdSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "access-key-id",
-				},
-				SecretAccessKeySecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "secret-access-key",
-				},
-			},
-			expectedEnv: []string{S3AccessKeyId, S3SecretAccessKey},
-		},
-		{
-			name: "S3 with session token",
-			s3: &mariadbv1alpha1.S3{
-				Bucket:   "test-bucket",
-				Endpoint: "s3.amazonaws.com",
-				AccessKeyIdSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "access-key-id",
-				},
-				SecretAccessKeySecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "secret-access-key",
-				},
-				SessionTokenSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "session-token",
-				},
-			},
-			expectedEnv: []string{S3AccessKeyId, S3SecretAccessKey, S3SessionTokenKey},
-		},
-		{
-			name: "S3 with SSE-C",
-			s3: &mariadbv1alpha1.S3{
-				Bucket:   "test-bucket",
-				Endpoint: "s3.amazonaws.com",
-				AccessKeyIdSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "access-key-id",
-				},
-				SecretAccessKeySecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "secret-access-key",
-				},
-				SSEC: &mariadbv1alpha1.SSECConfig{
-					CustomerKeySecretKeyRef: mariadbv1alpha1.SecretKeySelector{
-						LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-							Name: "ssec-key",
-						},
-						Key: "customer-key",
-					},
-				},
-			},
-			expectedEnv: []string{S3AccessKeyId, S3SecretAccessKey, S3SSECCustomerKey},
-		},
-		{
-			name: "S3 with all options",
-			s3: &mariadbv1alpha1.S3{
-				Bucket:   "test-bucket",
-				Endpoint: "s3.amazonaws.com",
-				AccessKeyIdSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "access-key-id",
-				},
-				SecretAccessKeySecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "secret-access-key",
-				},
-				SessionTokenSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
-					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-						Name: "s3-credentials",
-					},
-					Key: "session-token",
-				},
-				SSEC: &mariadbv1alpha1.SSECConfig{
-					CustomerKeySecretKeyRef: mariadbv1alpha1.SecretKeySelector{
-						LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-							Name: "ssec-key",
-						},
-						Key: "customer-key",
-					},
-				},
-			},
-			expectedEnv: []string{S3AccessKeyId, S3SecretAccessKey, S3SessionTokenKey, S3SSECCustomerKey},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			env := s3Env(tt.s3)
-
-			if tt.expectedEnv == nil {
-				if env != nil {
-					t.Errorf("expected nil env, got: %v", env)
-				}
+			if expectedEnv == nil {
+				Expect(env).To(BeNil())
 				return
 			}
 
-			if len(env) != len(tt.expectedEnv) {
-				t.Errorf("expected %d env vars, got: %d", len(tt.expectedEnv), len(env))
-				return
-			}
+			Expect(env).To(HaveLen(len(expectedEnv)))
 
-			for _, expectedName := range tt.expectedEnv {
+			for _, expectedName := range expectedEnv {
 				found := slices.ContainsFunc(env, func(e corev1.EnvVar) bool {
 					return e.Name == expectedName
 				})
-				if !found {
-					t.Errorf("expected env var %s not found in %v", expectedName, env)
-				}
+				Expect(found).To(BeTrue())
 			}
-		})
-	}
-}
-
-func TestContainerArgs(t *testing.T) {
-	tests := []struct {
-		name     string
-		mariadb  *mariadbv1alpha1.MariaDB
-		wantArgs []string
-	}{
-		{
-			name:     "MariaDB args empty",
-			mariadb:  &mariadbv1alpha1.MariaDB{},
-			wantArgs: nil,
 		},
-		{
-			name: "MariaDB args verbose",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		Entry("nil S3",
+			nil,
+			nil,
+		),
+		Entry("S3 with access key only",
+			&mariadbv1alpha1.S3{
+				Bucket:   "test-bucket",
+				Endpoint: "s3.amazonaws.com",
+				AccessKeyIdSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "access-key-id",
+				},
+				SecretAccessKeySecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "secret-access-key",
+				},
+			},
+			[]string{S3AccessKeyId, S3SecretAccessKey},
+		),
+		Entry("S3 with session token",
+			&mariadbv1alpha1.S3{
+				Bucket:   "test-bucket",
+				Endpoint: "s3.amazonaws.com",
+				AccessKeyIdSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "access-key-id",
+				},
+				SecretAccessKeySecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "secret-access-key",
+				},
+				SessionTokenSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "session-token",
+				},
+			},
+			[]string{S3AccessKeyId, S3SecretAccessKey, S3SessionTokenKey},
+		),
+		Entry("S3 with SSE-C",
+			&mariadbv1alpha1.S3{
+				Bucket:   "test-bucket",
+				Endpoint: "s3.amazonaws.com",
+				AccessKeyIdSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "access-key-id",
+				},
+				SecretAccessKeySecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "secret-access-key",
+				},
+				SSEC: &mariadbv1alpha1.SSECConfig{
+					CustomerKeySecretKeyRef: mariadbv1alpha1.SecretKeySelector{
+						LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+							Name: "ssec-key",
+						},
+						Key: "customer-key",
+					},
+				},
+			},
+			[]string{S3AccessKeyId, S3SecretAccessKey, S3SSECCustomerKey},
+		),
+		Entry("S3 with all options",
+			&mariadbv1alpha1.S3{
+				Bucket:   "test-bucket",
+				Endpoint: "s3.amazonaws.com",
+				AccessKeyIdSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "access-key-id",
+				},
+				SecretAccessKeySecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "secret-access-key",
+				},
+				SessionTokenSecretKeyRef: &mariadbv1alpha1.SecretKeySelector{
+					LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+						Name: "s3-credentials",
+					},
+					Key: "session-token",
+				},
+				SSEC: &mariadbv1alpha1.SSECConfig{
+					CustomerKeySecretKeyRef: mariadbv1alpha1.SecretKeySelector{
+						LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+							Name: "ssec-key",
+						},
+						Key: "customer-key",
+					},
+				},
+			},
+			[]string{S3AccessKeyId, S3SecretAccessKey, S3SessionTokenKey, S3SSECCustomerKey},
+		),
+	)
+})
+
+var _ = Describe("ContainerArgs", func() {
+	DescribeTable("should build the expected args",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantArgs []string) {
+			args := mariadbArgs(mariadb)
+			Expect(args).To(Equal(wantArgs))
+		},
+		Entry("MariaDB args empty",
+			&mariadbv1alpha1.MariaDB{},
+			nil,
+		),
+		Entry("MariaDB args verbose",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Args: []string{"--verbose"},
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"--verbose",
 			},
-		},
-		{
-			name: "MariaDB args verbose",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("MariaDB args verbose",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "mariadb-test",
 				},
@@ -1827,198 +1686,181 @@ func TestContainerArgs(t *testing.T) {
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"--verbose",
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			args := mariadbArgs(tt.mariadb)
-			if !reflect.DeepEqual(tt.wantArgs, args) {
-				t.Errorf("unexpected result:\nexpected:\n%s\ngot:\n%s\n", tt.wantArgs, args)
-			}
-		})
-	}
-}
-
-func TestMariadbContainers(t *testing.T) {
-	tests := []struct {
-		name                string
-		mariadb             *mariadbv1alpha1.MariaDB
-		wantName            string
-		wantEnvKeys         []string
-		wantVolumeMountKeys []string
-	}{
-		{
-			name: "Without sidecar container name",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-						SidecarContainers: []mariadbv1alpha1.Container{
-							{
-								Image: "busybox",
-								Command: []string{
-									"sh",
-									"-c",
-									"sleep infinity",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantName:            "sidecar-0",
-			wantEnvKeys:         nil,
-			wantVolumeMountKeys: nil,
-		},
-		{
-			name: "With sidecar container name",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-						SidecarContainers: []mariadbv1alpha1.Container{
-							{
-								Name:  "busybox",
-								Image: "busybox",
-								Command: []string{
-									"sh",
-									"-c",
-									"sleep infinity",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantName:            "busybox",
-			wantEnvKeys:         nil,
-			wantVolumeMountKeys: nil,
-		},
-		{
-			name: "With env",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Port: 3306,
-					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-						SidecarContainers: []mariadbv1alpha1.Container{
-							{
-								Name:  "busybox",
-								Image: "busybox",
-								Command: []string{
-									"sh",
-									"-c",
-									"sleep 1",
-								},
-								Env: []mariadbv1alpha1.EnvVar{
-									{
-										Name:  "TEST",
-										Value: "TEST",
-									},
-									{
-										Name:  "FOO",
-										Value: "FOO",
-									},
-									{
-										Name:  "BAR",
-										Value: "BAR",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantName:            "busybox",
-			wantEnvKeys:         []string{"TEST", "FOO", "BAR"},
-			wantVolumeMountKeys: nil,
-		},
-		{
-			name: "With volumeMount",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Port: 3306,
-					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-						SidecarContainers: []mariadbv1alpha1.Container{
-							{
-								Name:  "busybox",
-								Image: "busybox",
-								Command: []string{
-									"sh",
-									"-c",
-									"sleep 1",
-								},
-								VolumeMounts: []mariadbv1alpha1.VolumeMount{
-									{
-										Name:      "TEST",
-										MountPath: "/test",
-									},
-									{
-										Name:      "FOO",
-										MountPath: "/foo",
-									},
-									{
-										Name:      "BAR",
-										MountPath: "/bar",
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			wantName:            "busybox",
-			wantEnvKeys:         nil,
-			wantVolumeMountKeys: []string{"TEST", "FOO", "BAR"},
-		},
-	}
-
-	builder := newDefaultTestBuilder(t)
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			containers, err := builder.mariadbContainers(tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building containers: %v", err)
-			}
+var _ = Describe("MariadbContainers", func() {
+	DescribeTable("should build the expected container",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantName string, wantEnvKeys []string, wantVolumeMountKeys []string) {
+			builder := newDefaultTestBuilder()
+			containers, err := builder.mariadbContainers(mariadb)
+			Expect(err).NotTo(HaveOccurred())
 
 			container := containers[1]
 
-			if container.Name != tt.wantName {
-				t.Errorf("unexpected result:\nexpected:\n%s\ngot:\n%s\n", tt.wantName, containers[1].Name)
-			}
-			if tt.wantEnvKeys != nil {
+			Expect(container.Name).To(Equal(wantName))
+			if wantEnvKeys != nil {
 				idx := datastructures.NewIndex(container.Env, func(env corev1.EnvVar) string {
 					return env.Name
 				})
-				if !datastructures.AllExists(idx, tt.wantEnvKeys...) {
-					t.Errorf("expected env keys \"%v\" to exist", tt.wantEnvKeys)
-				}
+				Expect(datastructures.AllExists(idx, wantEnvKeys...)).To(BeTrue())
 			}
-			if tt.wantVolumeMountKeys != nil {
+			if wantVolumeMountKeys != nil {
 				idx := datastructures.NewIndex(container.VolumeMounts, func(volumeMount corev1.VolumeMount) string {
 					return volumeMount.Name
 				})
-				if !datastructures.AllExists(idx, tt.wantVolumeMountKeys...) {
-					t.Errorf("expected volumeMount keys \"%s\" to exist", tt.wantVolumeMountKeys)
-				}
+				Expect(datastructures.AllExists(idx, wantVolumeMountKeys...)).To(BeTrue())
 			}
-		})
-	}
-}
+		},
+		Entry("Without sidecar container name",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+						SidecarContainers: []mariadbv1alpha1.Container{
+							{
+								Image: "busybox",
+								Command: []string{
+									"sh",
+									"-c",
+									"sleep infinity",
+								},
+							},
+						},
+					},
+				},
+			},
+			"sidecar-0",
+			nil,
+			nil,
+		),
+		Entry("With sidecar container name",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+						SidecarContainers: []mariadbv1alpha1.Container{
+							{
+								Name:  "busybox",
+								Image: "busybox",
+								Command: []string{
+									"sh",
+									"-c",
+									"sleep infinity",
+								},
+							},
+						},
+					},
+				},
+			},
+			"busybox",
+			nil,
+			nil,
+		),
+		Entry("With env",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+						SidecarContainers: []mariadbv1alpha1.Container{
+							{
+								Name:  "busybox",
+								Image: "busybox",
+								Command: []string{
+									"sh",
+									"-c",
+									"sleep 1",
+								},
+								Env: []mariadbv1alpha1.EnvVar{
+									{
+										Name:  "TEST",
+										Value: "TEST",
+									},
+									{
+										Name:  "FOO",
+										Value: "FOO",
+									},
+									{
+										Name:  "BAR",
+										Value: "BAR",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"busybox",
+			[]string{"TEST", "FOO", "BAR"},
+			nil,
+		),
+		Entry("With volumeMount",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Port: 3306,
+					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+						SidecarContainers: []mariadbv1alpha1.Container{
+							{
+								Name:  "busybox",
+								Image: "busybox",
+								Command: []string{
+									"sh",
+									"-c",
+									"sleep 1",
+								},
+								VolumeMounts: []mariadbv1alpha1.VolumeMount{
+									{
+										Name:      "TEST",
+										MountPath: "/test",
+									},
+									{
+										Name:      "FOO",
+										MountPath: "/foo",
+									},
+									{
+										Name:      "BAR",
+										MountPath: "/bar",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"busybox",
+			nil,
+			[]string{"TEST", "FOO", "BAR"},
+		),
+	)
+})
 
-func TestMariadbInitContainers(t *testing.T) {
-	tests := []struct {
-		name                string
-		mariadb             *mariadbv1alpha1.MariaDB
-		wantName            string
-		wantEnvKeys         []string
-		wantVolumeMountKeys []string
-	}{
-		{
-			name: "Without container name",
-			mariadb: &mariadbv1alpha1.MariaDB{
+var _ = Describe("MariadbInitContainers", func() {
+	DescribeTable("should build the expected init container",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantName string, wantEnvKeys []string, wantVolumeMountKeys []string) {
+			builder := newDefaultTestBuilder()
+			initContainers, err := builder.mariadbInitContainers(mariadb)
+			Expect(err).NotTo(HaveOccurred())
+
+			initContainer := initContainers[0]
+
+			Expect(initContainer.Name).To(Equal(wantName))
+			if wantEnvKeys != nil {
+				idx := datastructures.NewIndex(initContainer.Env, func(env corev1.EnvVar) string {
+					return env.Name
+				})
+				Expect(datastructures.AllExists(idx, wantEnvKeys...)).To(BeTrue())
+			}
+			if wantVolumeMountKeys != nil {
+				idx := datastructures.NewIndex(initContainer.VolumeMounts, func(volumeMount corev1.VolumeMount) string {
+					return volumeMount.Name
+				})
+				Expect(datastructures.AllExists(idx, wantVolumeMountKeys...)).To(BeTrue())
+			}
+		},
+		Entry("Without container name",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
 						InitContainers: []mariadbv1alpha1.Container{
@@ -2034,13 +1876,12 @@ func TestMariadbInitContainers(t *testing.T) {
 					},
 				},
 			},
-			wantName:            "init-0",
-			wantEnvKeys:         nil,
-			wantVolumeMountKeys: nil,
-		},
-		{
-			name: "With container name",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			"init-0",
+			nil,
+			nil,
+		),
+		Entry("With container name",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
 						InitContainers: []mariadbv1alpha1.Container{
@@ -2057,13 +1898,12 @@ func TestMariadbInitContainers(t *testing.T) {
 					},
 				},
 			},
-			wantName:            "busybox",
-			wantEnvKeys:         nil,
-			wantVolumeMountKeys: nil,
-		},
-		{
-			name: "With env",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			"busybox",
+			nil,
+			nil,
+		),
+		Entry("With env",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Port: 3306,
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -2095,13 +1935,12 @@ func TestMariadbInitContainers(t *testing.T) {
 					},
 				},
 			},
-			wantName:            "busybox",
-			wantEnvKeys:         []string{"TEST", "FOO", "BAR"},
-			wantVolumeMountKeys: nil,
-		},
-		{
-			name: "With volumeMount",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			"busybox",
+			[]string{"TEST", "FOO", "BAR"},
+			nil,
+		),
+		Entry("With volumeMount",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Port: 3306,
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -2133,78 +1972,47 @@ func TestMariadbInitContainers(t *testing.T) {
 					},
 				},
 			},
-			wantName:            "busybox",
-			wantEnvKeys:         nil,
-			wantVolumeMountKeys: []string{"TEST", "FOO", "BAR"},
+			"busybox",
+			nil,
+			[]string{"TEST", "FOO", "BAR"},
+		),
+	)
+})
+
+var _ = Describe("MaxscaleContainers", func() {
+	DescribeTable("should build the expected container",
+		func(maxscale *mariadbv1alpha1.MaxScale, wantCommand []string, wantArgs []string) {
+			builder := newDefaultTestBuilder()
+			containers, err := builder.maxscaleContainers(maxscale)
+			Expect(err).NotTo(HaveOccurred())
+
+			container := containers[0]
+
+			Expect(container.Command[0]).To(Equal(wantCommand[0]))
+			Expect(container.Args).To(Equal(wantArgs))
 		},
-	}
-
-	builder := newDefaultTestBuilder(t)
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			initContainers, err := builder.mariadbInitContainers(tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building init containers: %v", err)
-			}
-
-			initContainer := initContainers[0]
-
-			if initContainer.Name != tt.wantName {
-				t.Errorf("unexpected name:\nexpected:\n%s\ngot:\n%s\n", tt.wantName, initContainer.Name)
-			}
-			if tt.wantEnvKeys != nil {
-				idx := datastructures.NewIndex(initContainer.Env, func(env corev1.EnvVar) string {
-					return env.Name
-				})
-				if !datastructures.AllExists(idx, tt.wantEnvKeys...) {
-					t.Errorf("expected env keys \"%v\" to exist", tt.wantEnvKeys)
-				}
-			}
-			if tt.wantVolumeMountKeys != nil {
-				idx := datastructures.NewIndex(initContainer.VolumeMounts, func(volumeMount corev1.VolumeMount) string {
-					return volumeMount.Name
-				})
-				if !datastructures.AllExists(idx, tt.wantVolumeMountKeys...) {
-					t.Errorf("expected volumeMount keys \"%s\" to exist", tt.wantVolumeMountKeys)
-				}
-			}
-		})
-	}
-}
-
-func TestMaxscaleContainers(t *testing.T) {
-	tests := []struct {
-		name        string
-		maxscale    *mariadbv1alpha1.MaxScale
-		wantCommand []string
-		wantArgs    []string
-	}{
-		{
-			name: "Without custom command and args",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		Entry("Without custom command and args",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{},
 				},
 			},
-			wantCommand: []string{"maxscale"},
-			wantArgs:    []string{"--config", "/etc/config/maxscale.cnf", "-dU", "maxscale", "-l", "stdout"},
-		},
-		{
-			name: "With custom command",
-			maxscale: &mariadbv1alpha1.MaxScale{
+			[]string{"maxscale"},
+			[]string{"--config", "/etc/config/maxscale.cnf", "-dU", "maxscale", "-l", "stdout"},
+		),
+		Entry("With custom command",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Command: []string{"maxscale-test"},
 					},
 				},
 			},
-			wantCommand: []string{"maxscale-test"},
-			wantArgs:    []string{"--config", "/etc/config/maxscale.cnf", "-dU", "maxscale", "-l", "stdout"},
-		},
-		{
-			name: "With custom command and args",
-			maxscale: &mariadbv1alpha1.MaxScale{
+			[]string{"maxscale-test"},
+			[]string{"--config", "/etc/config/maxscale.cnf", "-dU", "maxscale", "-l", "stdout"},
+		),
+		Entry("With custom command and args",
+			&mariadbv1alpha1.MaxScale{
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
 						Command: []string{"maxscale-test"},
@@ -2212,47 +2020,24 @@ func TestMaxscaleContainers(t *testing.T) {
 					},
 				},
 			},
-			wantCommand: []string{"maxscale-test"},
-			wantArgs:    []string{"--test", "--unit"},
+			[]string{"maxscale-test"},
+			[]string{"--test", "--unit"},
+		),
+	)
+})
+
+var _ = Describe("MariadbStorageVolumeMount", func() {
+	DescribeTable("should build the expected volume mount",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantSubPath string) {
+			vm := mariadbStorageVolumeMount(mariadb)
+			Expect(vm.SubPath).To(Equal(wantSubPath))
 		},
-	}
-
-	builder := newDefaultTestBuilder(t)
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			containers, err := builder.maxscaleContainers(tt.maxscale)
-			if err != nil {
-				t.Fatalf("unexpected error building containers: %v", err)
-			}
-
-			container := containers[0]
-
-			if !reflect.DeepEqual(container.Command[0], tt.wantCommand[0]) {
-				t.Errorf("unexpected result:\nexpected:\n%s\ngot:\n%s\n", tt.wantCommand[0], container.Command[0])
-			}
-
-			if !reflect.DeepEqual(tt.wantArgs, container.Args) {
-				t.Errorf("expected env keys \"%v\" to exist\n got:\"%v\"", tt.wantArgs, container.Args)
-			}
-		})
-	}
-}
-
-func TestMariadbStorageVolumeMount(t *testing.T) {
-	tests := []struct {
-		name        string
-		mariadb     *mariadbv1alpha1.MariaDB
-		wantSubPath string
-	}{
-		{
-			name:        "no galera configured",
-			mariadb:     &mariadbv1alpha1.MariaDB{Spec: mariadbv1alpha1.MariaDBSpec{}},
-			wantSubPath: "",
-		},
-		{
-			name: "galera enabled reuse disabled",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		Entry("no galera configured",
+			&mariadbv1alpha1.MariaDB{Spec: mariadbv1alpha1.MariaDBSpec{}},
+			"",
+		),
+		Entry("galera enabled reuse disabled",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -2264,11 +2049,10 @@ func TestMariadbStorageVolumeMount(t *testing.T) {
 					},
 				},
 			},
-			wantSubPath: "",
-		},
-		{
-			name: "galera enabled reuse enabled",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			"",
+		),
+		Entry("galera enabled reuse enabled",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
 						Enabled: true,
@@ -2280,19 +2064,10 @@ func TestMariadbStorageVolumeMount(t *testing.T) {
 					},
 				},
 			},
-			wantSubPath: StorageVolume,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			vm := mariadbStorageVolumeMount(tt.mariadb)
-			if vm.SubPath != tt.wantSubPath {
-				t.Fatalf("unexpected SubPath: want=%q got=%q", tt.wantSubPath, vm.SubPath)
-			}
-		})
-	}
-}
+			StorageVolume,
+		),
+	)
+})
 
 func defaultEnv(overrides []corev1.EnvVar) []corev1.EnvVar {
 	mysqlTcpPort := corev1.EnvVar{

--- a/pkg/builder/deployment_builder_test.go
+++ b/pkg/builder/deployment_builder_test.go
@@ -1,8 +1,8 @@
 package builder
 
 import (
-	"reflect"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	builderpki "github.com/mariadb-operator/mariadb-operator/v26/pkg/builder/pki"
@@ -14,21 +14,23 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func TestExporterImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ExporterImagePullSecrets", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name:      "mariadb-metrics-image-pull-secrets",
 		Namespace: "test",
 	}
 
-	tests := []struct {
-		name            string
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable(
+		"should build the expected ImagePullSecrets",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantPullSecrets []corev1.LocalObjectReference) {
+			job, err := builder.BuildExporterDeployment(mariadb, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry(
+			"No Secrets",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -36,11 +38,11 @@ func TestExporterImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MariaDB",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+		),
+		Entry(
+			"Secrets in MariaDB",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -55,15 +57,15 @@ func TestExporterImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in Exporter",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry(
+			"Secrets in Exporter",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -78,15 +80,15 @@ func TestExporterImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "exporter-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in MariaDB and Exporter",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry(
+			"Secrets in MariaDB and Exporter",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -108,7 +110,7 @@ func TestExporterImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
@@ -116,37 +118,27 @@ func TestExporterImagePullSecrets(t *testing.T) {
 					Name: "exporter-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildExporterDeployment(tt.mariadb, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building Deployment: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestExporterMaxScaleImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ExporterMaxScaleImagePullSecrets", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name:      "maxscale-metrics-image-pull-secrets",
 		Namespace: "test",
 	}
 
-	tests := []struct {
-		name            string
-		maxscale        *mariadbv1alpha1.MaxScale
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			maxscale: &mariadbv1alpha1.MaxScale{
+	DescribeTable(
+		"should build the expected ImagePullSecrets",
+		func(maxscale *mariadbv1alpha1.MaxScale, wantPullSecrets []corev1.LocalObjectReference) {
+			job, err := builder.BuildMaxScaleExporterDeployment(maxscale, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry(
+			"No Secrets",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Metrics: &mariadbv1alpha1.MaxScaleMetrics{
@@ -154,11 +146,11 @@ func TestExporterMaxScaleImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MaxScale",
-			maxscale: &mariadbv1alpha1.MaxScale{
+			nil,
+		),
+		Entry(
+			"Secrets in MaxScale",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					MaxScalePodTemplate: mariadbv1alpha1.MaxScalePodTemplate{
@@ -173,15 +165,15 @@ func TestExporterMaxScaleImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "maxscale-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in MaxScale",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry(
+			"Secrets in MaxScale",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Metrics: &mariadbv1alpha1.MaxScaleMetrics{
@@ -196,15 +188,15 @@ func TestExporterMaxScaleImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "exporter-registry",
 				},
 			},
-		},
-		{
-			name: "Secrets in MariaDB and Exporter",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry(
+			"Secrets in MariaDB and Exporter",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					MaxScalePodTemplate: mariadbv1alpha1.MaxScalePodTemplate{
@@ -226,7 +218,7 @@ func TestExporterMaxScaleImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "maxscale-registry",
 				},
@@ -234,37 +226,28 @@ func TestExporterMaxScaleImagePullSecrets(t *testing.T) {
 					Name: "exporter-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildMaxScaleExporterDeployment(tt.maxscale, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building Deployment: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestExporterResources(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ExporterResources", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name:      "mariadb-metrics-resources",
 		Namespace: "test",
 	}
 
-	tests := []struct {
-		name          string
-		mariadb       *mariadbv1alpha1.MariaDB
-		wantResources corev1.ResourceRequirements
-	}{
-		{
-			name: "No Resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable(
+		"should build the expected Resources",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantResources corev1.ResourceRequirements) {
+			job, err := builder.BuildExporterDeployment(mariadb, nil)
+			Expect(err).NotTo(HaveOccurred())
+			resources := job.Spec.Template.Spec.Containers[0].Resources
+			Expect(resources).To(Equal(wantResources))
+		},
+		Entry(
+			"No Resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -272,11 +255,11 @@ func TestExporterResources(t *testing.T) {
 					},
 				},
 			},
-			wantResources: corev1.ResourceRequirements{},
-		},
-		{
-			name: "Resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			corev1.ResourceRequirements{},
+		),
+		Entry(
+			"Resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -295,7 +278,7 @@ func TestExporterResources(t *testing.T) {
 					},
 				},
 			},
-			wantResources: corev1.ResourceRequirements{
+			corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					"cpu":    resource.MustParse("100m"),
 					"memory": resource.MustParse("100Mi"),
@@ -304,38 +287,28 @@ func TestExporterResources(t *testing.T) {
 					"memory": resource.MustParse("100Mi"),
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildExporterDeployment(tt.mariadb, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building Deployment: %v", err)
-			}
-			resources := job.Spec.Template.Spec.Containers[0].Resources
-			if !reflect.DeepEqual(tt.wantResources, resources) {
-				t.Errorf("unexpected Resources, want: %v  got: %v", tt.wantResources, resources)
-			}
-		})
-	}
-}
-
-func TestExporterSecurityContext(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ExporterSecurityContext", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name:      "mariadb-metrics-security-context",
 		Namespace: "test",
 	}
 
-	tests := []struct {
-		name                string
-		mariadb             *mariadbv1alpha1.MariaDB
-		wantSecurityContext *corev1.SecurityContext
-	}{
-		{
-			name: "No SecurityContext",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable(
+		"should build the expected SecurityContext",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantSecurityContext *corev1.SecurityContext) {
+			job, err := builder.BuildExporterDeployment(mariadb, nil)
+			Expect(err).NotTo(HaveOccurred())
+			securityContext := job.Spec.Template.Spec.Containers[0].SecurityContext
+			Expect(securityContext).To(Equal(wantSecurityContext))
+		},
+		Entry(
+			"No SecurityContext",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -343,11 +316,11 @@ func TestExporterSecurityContext(t *testing.T) {
 					},
 				},
 			},
-			wantSecurityContext: nil,
-		},
-		{
-			name: "SecurityContext",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+		),
+		Entry(
+			"SecurityContext",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -360,41 +333,31 @@ func TestExporterSecurityContext(t *testing.T) {
 					},
 				},
 			},
-			wantSecurityContext: &corev1.SecurityContext{
+			&corev1.SecurityContext{
 				RunAsUser: ptr.To(int64(666)),
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildExporterDeployment(tt.mariadb, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building Deployment: %v", err)
-			}
-			securityContext := job.Spec.Template.Spec.Containers[0].SecurityContext
-			if !reflect.DeepEqual(tt.wantSecurityContext, securityContext) {
-				t.Errorf("unexpected SecurityContext, want: %v  got: %v", tt.wantSecurityContext, securityContext)
-			}
-		})
-	}
-}
-
-func TestExporterPodSecurityContext(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ExporterPodSecurityContext", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name:      "mariadb-metrics-pod-security-context",
 		Namespace: "test",
 	}
 
-	tests := []struct {
-		name                string
-		mariadb             *mariadbv1alpha1.MariaDB
-		wantSecurityContext *corev1.PodSecurityContext
-	}{
-		{
-			name: "No PodSecurityContext",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable(
+		"should build the expected PodSecurityContext",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantSecurityContext *corev1.PodSecurityContext) {
+			job, err := builder.BuildExporterDeployment(mariadb, nil)
+			Expect(err).NotTo(HaveOccurred())
+			securityContext := job.Spec.Template.Spec.SecurityContext
+			Expect(securityContext).To(Equal(wantSecurityContext))
+		},
+		Entry(
+			"No PodSecurityContext",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -402,11 +365,11 @@ func TestExporterPodSecurityContext(t *testing.T) {
 					},
 				},
 			},
-			wantSecurityContext: nil,
-		},
-		{
-			name: "PodSecurityContext",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+		),
+		Entry(
+			"PodSecurityContext",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -419,41 +382,31 @@ func TestExporterPodSecurityContext(t *testing.T) {
 					},
 				},
 			},
-			wantSecurityContext: &corev1.PodSecurityContext{
+			&corev1.PodSecurityContext{
 				RunAsUser: ptr.To(int64(666)),
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildExporterDeployment(tt.mariadb, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building Deployment: %v", err)
-			}
-			securityContext := job.Spec.Template.Spec.SecurityContext
-			if !reflect.DeepEqual(tt.wantSecurityContext, securityContext) {
-				t.Errorf("unexpected PodSecurityContext, want: %v  got: %v", tt.wantSecurityContext, securityContext)
-			}
-		})
-	}
-}
-
-func TestExporterDeploymentMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ExporterDeploymentMeta", func() {
+	builder := newDefaultTestBuilder()
 	mdbObjMeta := metav1.ObjectMeta{
 		Name: "test",
 	}
-	tests := []struct {
-		name           string
-		mariadb        *mariadbv1alpha1.MariaDB
-		podAnnotations map[string]string
-		wantDeployMeta *mariadbv1alpha1.Metadata
-		wantPodMeta    *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+
+	DescribeTable(
+		"should build the expected Deployment metadata",
+		func(mariadb *mariadbv1alpha1.MariaDB, podAnnotations map[string]string,
+			wantDeployMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			deploy, err := builder.BuildExporterDeployment(mariadb, podAnnotations)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&deploy.ObjectMeta, wantDeployMeta.Labels, wantDeployMeta.Annotations)
+			assertObjectMeta(&deploy.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry(
+			"no meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mdbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -461,22 +414,22 @@ func TestExporterDeploymentMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: nil,
-			wantDeployMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "test-metrics",
 					"app.kubernetes.io/name":     "exporter",
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry(
+			"inherit meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mdbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -492,8 +445,8 @@ func TestExporterDeploymentMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: nil,
-			wantDeployMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -501,7 +454,7 @@ func TestExporterDeploymentMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "test-metrics",
 					"app.kubernetes.io/name":     "exporter",
@@ -511,10 +464,10 @@ func TestExporterDeploymentMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry(
+			"pod meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mdbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -532,14 +485,14 @@ func TestExporterDeploymentMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: map[string]string{
+			map[string]string{
 				metadata.ConfigAnnotation: "config-hash",
 			},
-			wantDeployMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "test-metrics",
 					"app.kubernetes.io/name":     "exporter",
@@ -550,10 +503,10 @@ func TestExporterDeploymentMeta(t *testing.T) {
 					metadata.ConfigAnnotation: "config-hash",
 				},
 			},
-		},
-		{
-			name: "all",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry(
+			"all",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: mdbObjMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -579,10 +532,10 @@ func TestExporterDeploymentMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: map[string]string{
+			map[string]string{
 				metadata.ConfigAnnotation: "config-hash",
 			},
-			wantDeployMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -590,7 +543,7 @@ func TestExporterDeploymentMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "test-metrics",
 					"app.kubernetes.io/name":     "exporter",
@@ -601,36 +554,28 @@ func TestExporterDeploymentMeta(t *testing.T) {
 					metadata.ConfigAnnotation: "config-hash",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deploy, err := builder.BuildExporterDeployment(tt.mariadb, tt.podAnnotations)
-			if err != nil {
-				t.Fatalf("unexpected error building Deployment: %v", err)
-			}
-			assertObjectMeta(t, &deploy.ObjectMeta, tt.wantDeployMeta.Labels, tt.wantDeployMeta.Annotations)
-			assertObjectMeta(t, &deploy.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ExporterMaxScaleDeploymentMeta", func() {
+	builder := newDefaultTestBuilder()
 	mxsObjMeta := metav1.ObjectMeta{
 		Name: "test",
 	}
-	tests := []struct {
-		name           string
-		maxscale       *mariadbv1alpha1.MaxScale
-		podAnnotations map[string]string
-		wantDeployMeta *mariadbv1alpha1.Metadata
-		wantPodMeta    *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			maxscale: &mariadbv1alpha1.MaxScale{
+
+	DescribeTable(
+		"should build the expected Deployment metadata",
+		func(maxscale *mariadbv1alpha1.MaxScale, podAnnotations map[string]string,
+			wantDeployMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			deploy, err := builder.BuildMaxScaleExporterDeployment(maxscale, podAnnotations)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&deploy.ObjectMeta, wantDeployMeta.Labels, wantDeployMeta.Annotations)
+			assertObjectMeta(&deploy.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry(
+			"no meta",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: mxsObjMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Metrics: &mariadbv1alpha1.MaxScaleMetrics{
@@ -638,22 +583,22 @@ func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: nil,
-			wantDeployMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "test-metrics",
 					"app.kubernetes.io/name":     "exporter",
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit meta",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry(
+			"inherit meta",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: mxsObjMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Metrics: &mariadbv1alpha1.MaxScaleMetrics{
@@ -669,8 +614,8 @@ func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: nil,
-			wantDeployMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -678,7 +623,7 @@ func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "test-metrics",
 					"app.kubernetes.io/name":     "exporter",
@@ -688,10 +633,10 @@ func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "pod meta",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry(
+			"pod meta",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: mxsObjMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					Metrics: &mariadbv1alpha1.MaxScaleMetrics{
@@ -709,14 +654,14 @@ func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: map[string]string{
+			map[string]string{
 				metadata.ConfigAnnotation: "config-hash",
 			},
-			wantDeployMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "test-metrics",
 					"app.kubernetes.io/name":     "exporter",
@@ -727,10 +672,10 @@ func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
 					metadata.ConfigAnnotation: "config-hash",
 				},
 			},
-		},
-		{
-			name: "all",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry(
+			"all",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: mxsObjMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -756,10 +701,10 @@ func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: map[string]string{
+			map[string]string{
 				metadata.ConfigAnnotation: "config-hash",
 			},
-			wantDeployMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -767,7 +712,7 @@ func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "test-metrics",
 					"app.kubernetes.io/name":     "exporter",
@@ -778,66 +723,18 @@ func TestExporterMaxScaleDeploymentMeta(t *testing.T) {
 					metadata.ConfigAnnotation: "config-hash",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deploy, err := builder.BuildMaxScaleExporterDeployment(tt.maxscale, tt.podAnnotations)
-			if err != nil {
-				t.Fatalf("unexpected error building Deployment: %v", err)
-			}
-			assertObjectMeta(t, &deploy.ObjectMeta, tt.wantDeployMeta.Labels, tt.wantDeployMeta.Annotations)
-			assertObjectMeta(t, &deploy.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
+var _ = Describe("ExporterVolumes", func() {
+	builder := newDefaultTestBuilder()
 
-func TestExporterVolumes(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	tests := []struct {
-		name            string
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantVolumeNames []string
-	}{
-		{
-			name: "empty",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Metrics: &mariadbv1alpha1.MariadbMetrics{
-						Enabled: true,
-					},
-				},
-			},
-			wantVolumeNames: []string{
-				deployConfigVolume,
-			},
-		},
-		{
-			name: "TLS",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Metrics: &mariadbv1alpha1.MariadbMetrics{
-						Enabled: true,
-					},
-					TLS: &mariadbv1alpha1.TLS{
-						Enabled: true,
-					},
-				},
-			},
-			wantVolumeNames: []string{
-				deployConfigVolume,
-				builderpki.PKIVolume,
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deploy, err := builder.BuildExporterDeployment(tt.mariadb, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building Deployment: %v", err)
-			}
+	DescribeTable(
+		"should build the expected Volumes",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantVolumeNames []string) {
+			deploy, err := builder.BuildExporterDeployment(mariadb, nil)
+			Expect(err).NotTo(HaveOccurred())
 
 			volumes := deploy.Spec.Template.Spec.Volumes
 			volumeMounts := deploy.Spec.Template.Spec.Containers[0].VolumeMounts
@@ -849,31 +746,61 @@ func TestExporterVolumes(t *testing.T) {
 				return vm.Name
 			})
 
-			if !datastructures.AllExists(volumeIndex, tt.wantVolumeNames...) {
-				t.Errorf("expecting all volumes %v to exist", tt.wantVolumeNames)
-			}
-			if !datastructures.AllExists(volumeMountIndex, tt.wantVolumeNames...) {
-				t.Errorf("expecting all volumeMounts %v to exist", tt.wantVolumeNames)
-			}
-		})
-	}
-}
+			Expect(datastructures.AllExists(volumeIndex, wantVolumeNames...)).To(BeTrue())
+			Expect(datastructures.AllExists(volumeMountIndex, wantVolumeNames...)).To(BeTrue())
+		},
+		Entry(
+			"empty",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Metrics: &mariadbv1alpha1.MariadbMetrics{
+						Enabled: true,
+					},
+				},
+			},
+			[]string{
+				deployConfigVolume,
+			},
+		),
+		Entry(
+			"TLS",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Metrics: &mariadbv1alpha1.MariadbMetrics{
+						Enabled: true,
+					},
+					TLS: &mariadbv1alpha1.TLS{
+						Enabled: true,
+					},
+				},
+			},
+			[]string{
+				deployConfigVolume,
+				builderpki.PKIVolume,
+			},
+		),
+	)
+})
 
-func TestExporterArgs(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ExporterArgs", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name:      "mariadb-metrics-resources",
 		Namespace: "test",
 	}
 
-	tests := []struct {
-		name     string
-		mariadb  *mariadbv1alpha1.MariaDB
-		wantArgs []string
-	}{
-		{
-			name: "Without args",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable(
+		"should build the expected Args",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantArgs []string) {
+			deploy, err := builder.BuildExporterDeployment(mariadb, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			args := deploy.Spec.Template.Spec.Containers[0].Args
+			Expect(args).To(Equal(wantArgs))
+		},
+		Entry(
+			"Without args",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -881,13 +808,13 @@ func TestExporterArgs(t *testing.T) {
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"--config.my-cnf=/etc/config/exporter.cnf",
 			},
-		},
-		{
-			name: "With args",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry(
+			"With args",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
@@ -901,25 +828,11 @@ func TestExporterArgs(t *testing.T) {
 					},
 				},
 			},
-			wantArgs: []string{
+			[]string{
 				"--config.my-cnf=/etc/config/exporter.cnf",
 				"--no-collect.auto_increment.columns",
 				"--collect.sys.user_summary",
 			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			deploy, err := builder.BuildExporterDeployment(tt.mariadb, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building Deployment: %v", err)
-			}
-
-			args := deploy.Spec.Template.Spec.Containers[0].Args
-			if !reflect.DeepEqual(tt.wantArgs, args) {
-				t.Errorf("unexpected Args, want: %v got: %v", tt.wantArgs, args)
-			}
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/builder/endpoints_builder_test.go
+++ b/pkg/builder/endpoints_builder_test.go
@@ -1,7 +1,8 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/metadata"
@@ -10,8 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestEndpointsMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("EndpointsMeta", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "endpoints",
 	}
@@ -19,25 +20,28 @@ func TestEndpointsMeta(t *testing.T) {
 	endpoints := []discoveryv1.Endpoint{}
 	ports := []discoveryv1.EndpointPort{}
 	serviceName := "test"
-	tests := []struct {
-		name     string
-		mariadb  *mariadbv1alpha1.MariaDB
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name:    "no meta",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantMeta: &mariadbv1alpha1.Metadata{
+
+	DescribeTable(
+		"should build the expected Endpoints meta",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantMeta *mariadbv1alpha1.Metadata) {
+			endpoints, err := builder.BuildEndpointSlice(key, mariadb, addressType, endpoints, ports, serviceName)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&endpoints.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry(
+			"no meta",
+			&mariadbv1alpha1.MariaDB{},
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					metadata.KubernetesEndpointSliceManagedByLabel: metadata.KubernetesEndpointSliceManagedByValue,
 					metadata.KubernetesServiceLabel:                serviceName,
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry(
+			"meta",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
 						Labels: map[string]string{
@@ -49,7 +53,7 @@ func TestEndpointsMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					metadata.KubernetesEndpointSliceManagedByLabel: metadata.KubernetesEndpointSliceManagedByValue,
 					metadata.KubernetesServiceLabel:                serviceName,
@@ -59,16 +63,6 @@ func TestEndpointsMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			endpoints, err := builder.BuildEndpointSlice(key, tt.mariadb, addressType, endpoints, ports, serviceName)
-			if err != nil {
-				t.Fatalf("unexpected error building Endpoints: %v", err)
-			}
-			assertObjectMeta(t, &endpoints.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/builder/persistentvolumeclaim_builder_test.go
+++ b/pkg/builder/persistentvolumeclaim_builder_test.go
@@ -1,157 +1,123 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestInvalidBackupStoragePVC(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("InvalidBackupStoragePVC", func() {
 	key := types.NamespacedName{
 		Name: "invalid-backup-pvc",
 	}
-	tests := []struct {
-		name    string
-		backup  *mariadbv1alpha1.Backup
-		wantErr bool
-	}{
-		{
-			name:    "empty",
-			backup:  &mariadbv1alpha1.Backup{},
-			wantErr: true,
+	DescribeTable("building Backup storage PVC",
+		func(backup *mariadbv1alpha1.Backup, wantErr bool) {
+			builder := newDefaultTestBuilder()
+			_, err := builder.BuildBackupStoragePVC(
+				key,
+				backup.Spec.Storage.PersistentVolumeClaim,
+				backup.Spec.InheritMetadata,
+			)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
 		},
-		{
-			name: "PVC",
-			backup: &mariadbv1alpha1.Backup{
-				Spec: mariadbv1alpha1.BackupSpec{
-					Storage: mariadbv1alpha1.BackupStorage{
-						PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("100Mi"),
-								},
+		Entry("empty", &mariadbv1alpha1.Backup{}, true),
+		Entry("PVC", &mariadbv1alpha1.Backup{
+			Spec: mariadbv1alpha1.BackupSpec{
+				Storage: mariadbv1alpha1.BackupStorage{
+					PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("100Mi"),
 							},
-							AccessModes: []corev1.PersistentVolumeAccessMode{
-								corev1.ReadWriteOnce,
-							},
+						},
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
 						},
 					},
 				},
 			},
-			wantErr: false,
-		},
-	}
+		}, false),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := builder.BuildBackupStoragePVC(
-				key,
-				tt.backup.Spec.Storage.PersistentVolumeClaim,
-				tt.backup.Spec.InheritMetadata,
-			)
-			if tt.wantErr && err == nil {
-				t.Error("expect error to have occurred, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("expect error to not have occurred, got: %v", err)
-			}
-		})
-	}
-}
-
-func TestBackupStoragePVCMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("BackupStoragePVCMeta", func() {
 	key := types.NamespacedName{
 		Name: "backup-pvc",
 	}
-	tests := []struct {
-		name     string
-		backup   *mariadbv1alpha1.Backup
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "PVC",
-			backup: &mariadbv1alpha1.Backup{
-				Spec: mariadbv1alpha1.BackupSpec{
-					Storage: mariadbv1alpha1.BackupStorage{
-						PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("100Mi"),
-								},
-							},
-							AccessModes: []corev1.PersistentVolumeAccessMode{
-								corev1.ReadWriteOnce,
-							},
-						},
-					},
-				},
-			},
-			wantMeta: &mariadbv1alpha1.Metadata{
-				Labels:      map[string]string{},
-				Annotations: map[string]string{},
-			},
-		},
-		{
-			name: "PVC and inherit meta",
-			backup: &mariadbv1alpha1.Backup{
-				Spec: mariadbv1alpha1.BackupSpec{
-					Storage: mariadbv1alpha1.BackupStorage{
-						PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{
-							Resources: corev1.VolumeResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceStorage: resource.MustParse("100Mi"),
-								},
-							},
-							AccessModes: []corev1.PersistentVolumeAccessMode{
-								corev1.ReadWriteOnce,
-							},
-						},
-					},
-					InheritMetadata: &mariadbv1alpha1.Metadata{
-						Labels: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-						Annotations: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-					},
-				},
-			},
-			wantMeta: &mariadbv1alpha1.Metadata{
-				Labels: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
-				Annotations: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	DescribeTable("building Backup storage PVC metadata",
+		func(backup *mariadbv1alpha1.Backup, wantMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
 			pvc, err := builder.BuildBackupStoragePVC(
 				key,
-				tt.backup.Spec.Storage.PersistentVolumeClaim,
-				tt.backup.Spec.InheritMetadata,
+				backup.Spec.Storage.PersistentVolumeClaim,
+				backup.Spec.InheritMetadata,
 			)
-			if err != nil {
-				t.Fatalf("unexpected error building Backup PVC: %v", err)
-			}
-			assertObjectMeta(t, &pvc.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&pvc.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("PVC", &mariadbv1alpha1.Backup{
+			Spec: mariadbv1alpha1.BackupSpec{
+				Storage: mariadbv1alpha1.BackupStorage{
+					PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("100Mi"),
+							},
+						},
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+					},
+				},
+			},
+		}, &mariadbv1alpha1.Metadata{
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		}),
+		Entry("PVC and inherit meta", &mariadbv1alpha1.Backup{
+			Spec: mariadbv1alpha1.BackupSpec{
+				Storage: mariadbv1alpha1.BackupStorage{
+					PersistentVolumeClaim: &mariadbv1alpha1.PersistentVolumeClaimSpec{
+						Resources: corev1.VolumeResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceStorage: resource.MustParse("100Mi"),
+							},
+						},
+						AccessModes: []corev1.PersistentVolumeAccessMode{
+							corev1.ReadWriteOnce,
+						},
+					},
+				},
+				InheritMetadata: &mariadbv1alpha1.Metadata{
+					Labels: map[string]string{
+						"database.myorg.io": "mariadb",
+					},
+					Annotations: map[string]string{
+						"database.myorg.io": "mariadb",
+					},
+				},
+			},
+		}, &mariadbv1alpha1.Metadata{
+			Labels: map[string]string{
+				"database.myorg.io": "mariadb",
+			},
+			Annotations: map[string]string{
+				"database.myorg.io": "mariadb",
+			},
+		}),
+	)
+})
 
-func TestBackupStagingPVCOwnerReference(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("BackupStagingPVCOwnerReference", func() {
 	key := types.NamespacedName{
 		Name:      "staging-pvc",
 		Namespace: "test",
@@ -179,89 +145,90 @@ func TestBackupStagingPVCOwnerReference(t *testing.T) {
 		},
 	}
 
-	tests := []struct {
-		name         string
-		owner        *mariadbv1alpha1.MariaDB
-		wantOwnerRef bool
-	}{
-		{
-			name:         "with owner",
-			owner:        owner,
-			wantOwnerRef: true,
-		},
-		{
-			name:         "without owner",
-			owner:        nil,
-			wantOwnerRef: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pvc, err := builder.BuildStagingPVC(key, pvcSpec, meta, tt.owner)
-			assert.NoError(t, err, "unexpected error building Backup Staging PVC")
-			assert.NotNil(t, pvc, "expected PVC to be created")
+	DescribeTable("building Backup staging PVC owner reference",
+		func(owner *mariadbv1alpha1.MariaDB, wantOwnerRef bool) {
+			builder := newDefaultTestBuilder()
+			pvc, err := builder.BuildStagingPVC(key, pvcSpec, meta, owner)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc).NotTo(BeNil())
 
 			found := false
 			for _, ref := range pvc.OwnerReferences {
-				if tt.owner != nil && ref.UID == tt.owner.UID && ref.Name == tt.owner.Name && ref.Kind == "MariaDB" {
+				if owner != nil && ref.UID == owner.UID && ref.Name == owner.Name && ref.Kind == "MariaDB" {
 					found = true
-					assert.True(t, *ref.Controller, "expected Controller to be true")
+					Expect(*ref.Controller).To(BeTrue())
 					break
 				}
 			}
-			assert.Equal(t, tt.wantOwnerRef, found, "unexpected owner reference presence")
-		})
-	}
-}
+			Expect(found).To(Equal(wantOwnerRef))
+		},
+		Entry("with owner", owner, true),
+		Entry("without owner", (*mariadbv1alpha1.MariaDB)(nil), false),
+	)
+})
 
-func TestStoragePVCMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("StoragePVCMeta", func() {
 	key := types.NamespacedName{
 		Name: "backup-pvc",
 	}
 	mariadbObjMeta := metav1.ObjectMeta{
 		Name: "mariadb-obj",
 	}
-	tests := []struct {
-		name     string
-		tpl      *mariadbv1alpha1.VolumeClaimTemplate
-		mariadb  *mariadbv1alpha1.MariaDB
-		wantMeta *mariadbv1alpha1.Metadata
-		wantErr  bool
-	}{
-		{
-			name: "no tpl",
-			tpl:  nil,
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: mariadbObjMeta,
-			},
-			wantMeta: &mariadbv1alpha1.Metadata{
-				Labels:      map[string]string{},
-				Annotations: map[string]string{},
-			},
-			wantErr: true,
+	DescribeTable("building storage PVC metadata",
+		func(tpl *mariadbv1alpha1.VolumeClaimTemplate, mariadb *mariadbv1alpha1.MariaDB, wantMeta *mariadbv1alpha1.Metadata, wantErr bool) {
+			builder := newDefaultTestBuilder()
+			pvc, err := builder.BuildStoragePVC(key, tpl, mariadb)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			if pvc != nil {
+				assertObjectMeta(&pvc.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+			}
 		},
-		{
-			name: "empty",
-			tpl:  &mariadbv1alpha1.VolumeClaimTemplate{},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: mariadbObjMeta,
+		Entry("no tpl", nil, &mariadbv1alpha1.MariaDB{
+			ObjectMeta: mariadbObjMeta,
+		}, &mariadbv1alpha1.Metadata{
+			Labels:      map[string]string{},
+			Annotations: map[string]string{},
+		}, true),
+		Entry("empty", &mariadbv1alpha1.VolumeClaimTemplate{}, &mariadbv1alpha1.MariaDB{
+			ObjectMeta: mariadbObjMeta,
+		}, &mariadbv1alpha1.Metadata{
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "mariadb",
+				"app.kubernetes.io/instance": "mariadb-obj",
+				"pvc.k8s.mariadb.com/role":   "storage",
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			Annotations: map[string]string{},
+		}, false),
+		Entry("tpl", &mariadbv1alpha1.VolumeClaimTemplate{
+			Metadata: &mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
-					"app.kubernetes.io/name":     "mariadb",
-					"app.kubernetes.io/instance": "mariadb-obj",
-					"pvc.k8s.mariadb.com/role":   "storage",
+					"database.myorg.io": "mariadb",
 				},
-				Annotations: map[string]string{},
+				Annotations: map[string]string{
+					"database.myorg.io": "mariadb",
+				},
 			},
-			wantErr: false,
-		},
-		{
-			name: "tpl",
-			tpl: &mariadbv1alpha1.VolumeClaimTemplate{
-				Metadata: &mariadbv1alpha1.Metadata{
+		}, &mariadbv1alpha1.MariaDB{
+			ObjectMeta: mariadbObjMeta,
+		}, &mariadbv1alpha1.Metadata{
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "mariadb",
+				"app.kubernetes.io/instance": "mariadb-obj",
+				"pvc.k8s.mariadb.com/role":   "storage",
+				"database.myorg.io":          "mariadb",
+			},
+			Annotations: map[string]string{
+				"database.myorg.io": "mariadb",
+			},
+		}, false),
+		Entry("inherit meta", &mariadbv1alpha1.VolumeClaimTemplate{}, &mariadbv1alpha1.MariaDB{
+			ObjectMeta: mariadbObjMeta,
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				InheritMetadata: &mariadbv1alpha1.Metadata{
 					Labels: map[string]string{
 						"database.myorg.io": "mariadb",
 					},
@@ -270,137 +237,75 @@ func TestStoragePVCMeta(t *testing.T) {
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: mariadbObjMeta,
+		}, &mariadbv1alpha1.Metadata{
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "mariadb",
+				"app.kubernetes.io/instance": "mariadb-obj",
+				"pvc.k8s.mariadb.com/role":   "storage",
+				"database.myorg.io":          "mariadb",
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			Annotations: map[string]string{
+				"database.myorg.io": "mariadb",
+			},
+		}, false),
+		Entry("all", &mariadbv1alpha1.VolumeClaimTemplate{
+			Metadata: &mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
-					"app.kubernetes.io/name":     "mariadb",
-					"app.kubernetes.io/instance": "mariadb-obj",
-					"pvc.k8s.mariadb.com/role":   "storage",
-					"database.myorg.io":          "mariadb",
-				},
-				Annotations: map[string]string{
-					"database.myorg.io": "mariadb",
+					"sidecar.istio.io/inject": "false",
 				},
 			},
-			wantErr: false,
-		},
-		{
-			name: "inherit meta",
-			tpl:  &mariadbv1alpha1.VolumeClaimTemplate{},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: mariadbObjMeta,
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					InheritMetadata: &mariadbv1alpha1.Metadata{
-						Labels: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-						Annotations: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-					},
-				},
-			},
-			wantMeta: &mariadbv1alpha1.Metadata{
-				Labels: map[string]string{
-					"app.kubernetes.io/name":     "mariadb",
-					"app.kubernetes.io/instance": "mariadb-obj",
-					"pvc.k8s.mariadb.com/role":   "storage",
-					"database.myorg.io":          "mariadb",
-				},
-				Annotations: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "all",
-			tpl: &mariadbv1alpha1.VolumeClaimTemplate{
-				Metadata: &mariadbv1alpha1.Metadata{
+		}, &mariadbv1alpha1.MariaDB{
+			ObjectMeta: mariadbObjMeta,
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				InheritMetadata: &mariadbv1alpha1.Metadata{
 					Labels: map[string]string{
-						"sidecar.istio.io/inject": "false",
+						"sidecar.istio.io/inject": "true",
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: mariadbObjMeta,
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					InheritMetadata: &mariadbv1alpha1.Metadata{
-						Labels: map[string]string{
-							"sidecar.istio.io/inject": "true",
-						},
-					},
-				},
+		}, &mariadbv1alpha1.Metadata{
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "mariadb",
+				"app.kubernetes.io/instance": "mariadb-obj",
+				"pvc.k8s.mariadb.com/role":   "storage",
+				"sidecar.istio.io/inject":    "false",
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			Annotations: map[string]string{},
+		}, false),
+		Entry("tpl override inherit meta", &mariadbv1alpha1.VolumeClaimTemplate{
+			Metadata: &mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
-					"app.kubernetes.io/name":     "mariadb",
-					"app.kubernetes.io/instance": "mariadb-obj",
-					"pvc.k8s.mariadb.com/role":   "storage",
-					"sidecar.istio.io/inject":    "false",
+					"sidecar.istio.io/inject": "false",
 				},
-				Annotations: map[string]string{},
 			},
-			wantErr: false,
-		},
-		{
-			name: "tpl override inherit meta",
-			tpl: &mariadbv1alpha1.VolumeClaimTemplate{
-				Metadata: &mariadbv1alpha1.Metadata{
+		}, &mariadbv1alpha1.MariaDB{
+			ObjectMeta: mariadbObjMeta,
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				InheritMetadata: &mariadbv1alpha1.Metadata{
 					Labels: map[string]string{
-						"sidecar.istio.io/inject": "false",
+						"database.myorg.io": "mariadb",
+					},
+					Annotations: map[string]string{
+						"database.myorg.io": "mariadb",
 					},
 				},
 			},
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: mariadbObjMeta,
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					InheritMetadata: &mariadbv1alpha1.Metadata{
-						Labels: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-						Annotations: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-					},
-				},
+		}, &mariadbv1alpha1.Metadata{
+			Labels: map[string]string{
+				"app.kubernetes.io/name":     "mariadb",
+				"app.kubernetes.io/instance": "mariadb-obj",
+				"database.myorg.io":          "mariadb",
+				"pvc.k8s.mariadb.com/role":   "storage",
+				"sidecar.istio.io/inject":    "false",
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
-				Labels: map[string]string{
-					"app.kubernetes.io/name":     "mariadb",
-					"app.kubernetes.io/instance": "mariadb-obj",
-					"database.myorg.io":          "mariadb",
-					"pvc.k8s.mariadb.com/role":   "storage",
-					"sidecar.istio.io/inject":    "false",
-				},
-				Annotations: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
+			Annotations: map[string]string{
+				"database.myorg.io": "mariadb",
 			},
-			wantErr: false,
-		},
-	}
+		}, false),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pvc, err := builder.BuildStoragePVC(key, tt.tpl, tt.mariadb)
-			if tt.wantErr && err == nil {
-				t.Error("expect error to have occurred, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("expect error to not have occurred, got: %v", err)
-			}
-			if pvc != nil {
-				assertObjectMeta(t, &pvc.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-			}
-		})
-	}
-}
-
-func TestStoragePVCDataSource(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("StoragePVCDataSource", func() {
 	key := types.NamespacedName{Name: "snapshot-pvc"}
 	tpl := &mariadbv1alpha1.VolumeClaimTemplate{
 		PersistentVolumeClaimSpec: mariadbv1alpha1.PersistentVolumeClaimSpec{
@@ -416,45 +321,24 @@ func TestStoragePVCDataSource(t *testing.T) {
 	}
 	mariadb := &mariadbv1alpha1.MariaDB{}
 
-	tests := []struct {
-		name             string
-		opts             []PVCOption
-		wantDataSource   bool
-		wantSnapshotName string
-	}{
-		{
-			name:           "without WithVolumeSnapshotDataSource",
-			opts:           []PVCOption{},
-			wantDataSource: false,
-		},
-		{
-			name:             "with WithVolumeSnapshotDataSource",
-			opts:             []PVCOption{WithVolumeSnapshotDataSource("my-snapshot")},
-			wantDataSource:   true,
-			wantSnapshotName: "my-snapshot",
-		},
-	}
+	DescribeTable("building storage PVC data source",
+		func(opts []PVCOption, wantDataSource bool, wantSnapshotName string) {
+			builder := newDefaultTestBuilder()
+			pvc, err := builder.BuildStoragePVC(key, tpl, mariadb, opts...)
+			Expect(err).NotTo(HaveOccurred())
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pvc, err := builder.BuildStoragePVC(key, tpl, mariadb, tt.opts...)
-			assert.NoError(t, err, "unexpected error building Storage PVC")
+			if wantDataSource {
+				Expect(pvc.Spec.DataSource).NotTo(BeNil())
+				Expect(pvc.Spec.DataSource.Kind).To(Equal("VolumeSnapshot"))
 
-			if tt.wantDataSource {
-				assert.NotNil(t, pvc.Spec.DataSource, "expected DataSource to be set")
-				assert.Equal(t, "VolumeSnapshot", pvc.Spec.DataSource.Kind, "expected DataSource.Kind to be 'VolumeSnapshot'")
-
-				assert.Equal(t, tt.wantSnapshotName, pvc.Spec.DataSource.Name, "expected DataSource.Name to match")
-				assert.NotNil(t, pvc.Spec.DataSource.APIGroup, "expected DataSource.APIGroup to be set")
-				assert.Equal(
-					t,
-					"snapshot.storage.k8s.io",
-					*pvc.Spec.DataSource.APIGroup,
-					"expected DataSource.APIGroup to be 'snapshot.storage.k8s.io'",
-				)
+				Expect(pvc.Spec.DataSource.Name).To(Equal(wantSnapshotName))
+				Expect(pvc.Spec.DataSource.APIGroup).NotTo(BeNil())
+				Expect(*pvc.Spec.DataSource.APIGroup).To(Equal("snapshot.storage.k8s.io"))
 			} else {
-				assert.Nil(t, pvc.Spec.DataSource, "expected DataSource to be nil")
+				Expect(pvc.Spec.DataSource).To(BeNil())
 			}
-		})
-	}
-}
+		},
+		Entry("without WithVolumeSnapshotDataSource", []PVCOption{}, false, ""),
+		Entry("with WithVolumeSnapshotDataSource", []PVCOption{WithVolumeSnapshotDataSource("my-snapshot")}, true, "my-snapshot"),
+	)
+})

--- a/pkg/builder/pod_builder_test.go
+++ b/pkg/builder/pod_builder_test.go
@@ -2,9 +2,10 @@ package builder
 
 import (
 	"reflect"
-	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/datastructures"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/discovery"
@@ -15,34 +16,32 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func TestMariadbPodMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MariadbPodMeta", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "mariadb-obj",
 	}
-	tests := []struct {
-		name     string
-		mariadb  *mariadbv1alpha1.MariaDB
-		opts     []mariadbPodOpt
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("mariadbPodTemplate meta",
+		func(mariadb *mariadbv1alpha1.MariaDB, opts []mariadbPodOpt, wantMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			podTpl, err := builder.mariadbPodTemplate(mariadb, opts...)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&podTpl.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 			},
-			opts: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("inherit meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -55,8 +54,8 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				},
 			},
-			opts: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -66,10 +65,9 @@ func TestMariadbPodMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "HA",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("HA",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -77,8 +75,8 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				},
 			},
-			opts: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -88,10 +86,9 @@ func TestMariadbPodMeta(t *testing.T) {
 					"k8s.mariadb.com/galera":  "",
 				},
 			},
-		},
-		{
-			name: "Pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("Pod meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -106,8 +103,8 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				},
 			},
-			opts: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -117,13 +114,12 @@ func TestMariadbPodMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "extra meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("extra meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withMeta(&mariadbv1alpha1.Metadata{
 					Labels: map[string]string{
 						"sidecar.istio.io/inject": "false",
@@ -133,7 +129,7 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				}),
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -143,10 +139,9 @@ func TestMariadbPodMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "inherit and Pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("inherit and Pod meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -163,8 +158,8 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				},
 			},
-			opts: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -174,10 +169,9 @@ func TestMariadbPodMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "extra override Pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("extra override Pod meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -189,14 +183,14 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withMeta(&mariadbv1alpha1.Metadata{
 					Labels: map[string]string{
 						"sidecar.istio.io/inject": "true",
 					},
 				}),
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -204,10 +198,9 @@ func TestMariadbPodMeta(t *testing.T) {
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "Pod override inherit meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("Pod override inherit meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -227,8 +220,8 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				},
 			},
-			opts: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -238,10 +231,9 @@ func TestMariadbPodMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "without selector labels",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("without selector labels",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -253,19 +245,18 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withMariadbSelectorLabels(false),
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "without HA annotations",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("without HA annotations",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -283,10 +274,10 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withHAAnnotations(false),
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -296,10 +287,9 @@ func TestMariadbPodMeta(t *testing.T) {
 					"sidecar.istio.io/inject": "false",
 				},
 			},
-		},
-		{
-			name: "all",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("all",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -319,14 +309,14 @@ func TestMariadbPodMeta(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withMeta(&mariadbv1alpha1.Metadata{
 					Annotations: map[string]string{
 						"sidecar.istio.io/inject": "false",
 					},
 				}),
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -339,48 +329,36 @@ func TestMariadbPodMeta(t *testing.T) {
 					"sidecar.istio.io/inject": "false",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			podTpl, err := builder.mariadbPodTemplate(tt.mariadb, tt.opts...)
-			if err != nil {
-				t.Fatalf("unexpected error building MariaDB Pod template: %v", err)
-			}
-			assertObjectMeta(t, &podTpl.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
-
-func TestMaxScalePodMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MaxScalePodMeta", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "maxscale-obj",
 	}
-	tests := []struct {
-		name        string
-		maxscale    *mariadbv1alpha1.MaxScale
-		annotations map[string]string
-		wantMeta    *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			maxscale: &mariadbv1alpha1.MaxScale{
+	DescribeTable("maxscalePodTemplate meta",
+		func(maxscale *mariadbv1alpha1.MaxScale, annotations map[string]string, wantMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			podTpl, err := builder.maxscalePodTemplate(maxscale, annotations)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&podTpl.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 			},
-			annotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "maxscale",
 					"app.kubernetes.io/instance": "maxscale-obj",
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit meta",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("inherit meta",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -393,8 +371,8 @@ func TestMaxScalePodMeta(t *testing.T) {
 					},
 				},
 			},
-			annotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "maxscale",
 					"app.kubernetes.io/instance": "maxscale-obj",
@@ -404,10 +382,9 @@ func TestMaxScalePodMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod meta",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("Pod meta",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					MaxScalePodTemplate: mariadbv1alpha1.MaxScalePodTemplate{
@@ -422,8 +399,8 @@ func TestMaxScalePodMeta(t *testing.T) {
 					},
 				},
 			},
-			annotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "maxscale",
 					"app.kubernetes.io/instance": "maxscale-obj",
@@ -433,16 +410,15 @@ func TestMaxScalePodMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "annotations",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("annotations",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 			},
-			annotations: map[string]string{
+			map[string]string{
 				metadata.TLSServerCertAnnotation: "cert",
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "maxscale",
 					"app.kubernetes.io/instance": "maxscale-obj",
@@ -451,10 +427,9 @@ func TestMaxScalePodMeta(t *testing.T) {
 					metadata.TLSServerCertAnnotation: "cert",
 				},
 			},
-		},
-		{
-			name: "inherit and Pod meta",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("inherit and Pod meta",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -471,8 +446,8 @@ func TestMaxScalePodMeta(t *testing.T) {
 					},
 				},
 			},
-			annotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "maxscale",
 					"app.kubernetes.io/instance": "maxscale-obj",
@@ -482,10 +457,9 @@ func TestMaxScalePodMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod override inherit meta",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("Pod override inherit meta",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -505,8 +479,8 @@ func TestMaxScalePodMeta(t *testing.T) {
 					},
 				},
 			},
-			annotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "maxscale",
 					"app.kubernetes.io/instance": "maxscale-obj",
@@ -516,10 +490,9 @@ func TestMaxScalePodMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "all",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("all",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -542,10 +515,10 @@ func TestMaxScalePodMeta(t *testing.T) {
 					},
 				},
 			},
-			annotations: map[string]string{
+			map[string]string{
 				metadata.TLSServerCertAnnotation: "cert",
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/name":     "maxscale",
 					"app.kubernetes.io/instance": "maxscale-obj",
@@ -558,90 +531,69 @@ func TestMaxScalePodMeta(t *testing.T) {
 					metadata.TLSServerCertAnnotation: "cert",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			podTpl, err := builder.maxscalePodTemplate(tt.maxscale, tt.annotations)
-			if err != nil {
-				t.Fatalf("unexpected error building MaxScale Pod template: %v", err)
-			}
-
-			assertObjectMeta(t, &podTpl.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
-
-func TestMariadbPodBuilder(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	mariadb := &mariadbv1alpha1.MariaDB{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-mariadb-builder",
-		},
-		Spec: mariadbv1alpha1.MariaDBSpec{
-			Storage: mariadbv1alpha1.Storage{
-				Size: ptr.To(resource.MustParse("300Mi")),
+var _ = Describe("MariadbPodBuilder", func() {
+	It("should build the MariaDB Pod template", func() {
+		builder := newDefaultTestBuilder()
+		mariadb := &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mariadb-builder",
 			},
-		},
-	}
-	opts := []mariadbPodOpt{
-		withResources(&corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{
-				"cpu": resource.MustParse("100m"),
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				Storage: mariadbv1alpha1.Storage{
+					Size: ptr.To(resource.MustParse("300Mi")),
+				},
 			},
-		}),
-	}
+		}
+		opts := []mariadbPodOpt{
+			withResources(&corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					"cpu": resource.MustParse("100m"),
+				},
+			}),
+		}
 
-	podTpl, err := builder.mariadbPodTemplate(mariadb, opts...)
-	if err != nil {
-		t.Fatalf("unexpected error building MariaDB Pod template: %v", err)
-	}
+		podTpl, err := builder.mariadbPodTemplate(mariadb, opts...)
+		Expect(err).NotTo(HaveOccurred())
 
-	if reflect.ValueOf(podTpl.Spec.Containers[0].Resources).IsZero() {
-		t.Error("expected resources to have been set")
-	}
+		Expect(reflect.ValueOf(podTpl.Spec.Containers[0].Resources).IsZero()).To(BeFalse())
 
-	if podTpl.Spec.SecurityContext == nil {
-		t.Error("expected podSecurityContext to have been set")
-	}
-	sc := ptr.Deref(podTpl.Spec.SecurityContext, corev1.PodSecurityContext{})
-	runAsUser := ptr.Deref(sc.RunAsUser, 0)
-	if runAsUser != mysqlUser {
-		t.Errorf("expected to run as mysql user, got user: %d", runAsUser)
-	}
-	runAsGroup := ptr.Deref(sc.RunAsGroup, 0)
-	if runAsGroup != mysqlGroup {
-		t.Errorf("expected to run as mysql group, got group: %d", runAsGroup)
-	}
-	fsGroup := ptr.Deref(sc.FSGroup, 0)
-	if fsGroup != mysqlGroup {
-		t.Errorf("expected to run as mysql fsGroup, got fsGroup: %d", fsGroup)
-	}
-}
+		Expect(podTpl.Spec.SecurityContext).NotTo(BeNil())
+		sc := ptr.Deref(podTpl.Spec.SecurityContext, corev1.PodSecurityContext{})
+		runAsUser := ptr.Deref(sc.RunAsUser, 0)
+		Expect(runAsUser).To(Equal(mysqlUser))
+		runAsGroup := ptr.Deref(sc.RunAsGroup, 0)
+		Expect(runAsGroup).To(Equal(mysqlGroup))
+		fsGroup := ptr.Deref(sc.FSGroup, 0)
+		Expect(fsGroup).To(Equal(mysqlGroup))
+	})
+})
 
-func TestMariadbPodBuilderResources(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MariadbPodBuilderResources", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "test-mariadb-builder-resources",
 	}
-	tests := []struct {
-		name          string
-		mariadb       *mariadbv1alpha1.MariaDB
-		opts          []mariadbPodOpt
-		wantResources corev1.ResourceRequirements
-	}{
-		{
-			name: "no resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("mariadbPodTemplate resources",
+		func(mariadb *mariadbv1alpha1.MariaDB, opts []mariadbPodOpt, wantResources corev1.ResourceRequirements) {
+			builder := newDefaultTestBuilder()
+			podTpl, err := builder.mariadbPodTemplate(mariadb, opts...)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podTpl.Spec.Containers).To(HaveLen(1))
+			resources := podTpl.Spec.Containers[0].Resources
+			Expect(resources).To(Equal(wantResources))
+		},
+		Entry("no resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 			},
-			opts:          nil,
-			wantResources: corev1.ResourceRequirements{},
-		},
-		{
-			name: "mariadb resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+			corev1.ResourceRequirements{},
+		),
+		Entry("mariadb resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
@@ -653,19 +605,18 @@ func TestMariadbPodBuilderResources(t *testing.T) {
 					},
 				},
 			},
-			opts: nil,
-			wantResources: corev1.ResourceRequirements{
+			nil,
+			corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					"cpu": resource.MustParse("300m"),
 				},
 			},
-		},
-		{
-			name: "opt resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("opt resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withResources(&corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						"cpu": resource.MustParse("100m"),
@@ -673,15 +624,14 @@ func TestMariadbPodBuilderResources(t *testing.T) {
 				}),
 				withMariadbResources(false),
 			},
-			wantResources: corev1.ResourceRequirements{
+			corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					"cpu": resource.MustParse("100m"),
 				},
 			},
-		},
-		{
-			name: "mariadb and opt resources",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("mariadb and opt resources",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
@@ -693,7 +643,7 @@ func TestMariadbPodBuilderResources(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withResources(&corev1.ResourceRequirements{
 					Requests: corev1.ResourceList{
 						"cpu": resource.MustParse("100m"),
@@ -701,81 +651,25 @@ func TestMariadbPodBuilderResources(t *testing.T) {
 				}),
 				withMariadbResources(true),
 			},
-			wantResources: corev1.ResourceRequirements{
+			corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					"cpu": resource.MustParse("100m"),
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			podTpl, err := builder.mariadbPodTemplate(tt.mariadb, tt.opts...)
-			if err != nil {
-				t.Fatalf("unexpected error building MariaDB Pod template: %v", err)
-			}
-			if len(podTpl.Spec.Containers) != 1 {
-				t.Error("expecting to have one container")
-			}
-			resources := podTpl.Spec.Containers[0].Resources
-			if !reflect.DeepEqual(resources, tt.wantResources) {
-				t.Errorf("unexpected resources, got: %v, expected: %v", resources, tt.wantResources)
-			}
-		})
-	}
-}
-
-func TestMariadbPodBuilderServiceAccount(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MariadbPodBuilderServiceAccount", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "test-mariadb-builder-serviceaccount",
 	}
-	tests := []struct {
-		name               string
-		mariadb            *mariadbv1alpha1.MariaDB
-		opts               []mariadbPodOpt
-		wantServiceAccount bool
-	}{
-		{
-			name: "serviceaccount",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: objMeta,
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Galera: &mariadbv1alpha1.Galera{
-						Enabled: true,
-					},
-				},
-			},
-			opts:               nil,
-			wantServiceAccount: true,
-		},
-		{
-			name: "no serviceaccount",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				ObjectMeta: objMeta,
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					Galera: &mariadbv1alpha1.Galera{
-						Enabled: true,
-					},
-				},
-			},
-			opts: []mariadbPodOpt{
-				withServiceAccount(false),
-			},
-			wantServiceAccount: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			podTpl, err := builder.mariadbPodTemplate(tt.mariadb, tt.opts...)
-			if err != nil {
-				t.Fatalf("unexpected error building MariaDB Pod template: %v", err)
-			}
-			if len(podTpl.Spec.Containers) == 0 {
-				t.Error("expecting to have containers")
-			}
+	DescribeTable("mariadbPodTemplate serviceAccount",
+		func(mariadb *mariadbv1alpha1.MariaDB, opts []mariadbPodOpt, wantServiceAccount bool) {
+			builder := newDefaultTestBuilder()
+			podTpl, err := builder.mariadbPodTemplate(mariadb, opts...)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podTpl.Spec.Containers).NotTo(BeEmpty())
 
 			container := podTpl.Spec.Containers[0]
 			scName := podTpl.Spec.ServiceAccountName
@@ -786,47 +680,77 @@ func TestMariadbPodBuilderServiceAccount(t *testing.T) {
 				return volMount.Name == ServiceAccountVolume
 			})
 
-			if tt.wantServiceAccount {
-				if scName != objMeta.Name {
-					t.Error("expecting to have ServiceAccount")
-				}
-				if scVol == nil {
-					t.Error("expecting to have ServiceAccount Volume")
-				}
-				if scVolMount == nil {
-					t.Error("expecting to have ServiceAccount VolumeMount")
-				}
+			if wantServiceAccount {
+				Expect(scName).To(Equal(objMeta.Name))
+				Expect(scVol).NotTo(BeNil())
+				Expect(scVolMount).NotTo(BeNil())
 			} else {
-				if scName != "" {
-					t.Error("expecting to NOT have ServiceAccount")
-				}
-				if scVol != nil {
-					t.Error("expecting to NOT have ServiceAccount Volume")
-				}
-				if scVolMount != nil {
-					t.Error("expecting to NOT have ServiceAccount VolumeMount")
-				}
+				Expect(scName).To(Equal(""))
+				Expect(scVol).To(BeNil())
+				Expect(scVolMount).To(BeNil())
 			}
-		})
-	}
-}
+		},
+		Entry("serviceaccount",
+			&mariadbv1alpha1.MariaDB{
+				ObjectMeta: objMeta,
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Galera: &mariadbv1alpha1.Galera{
+						Enabled: true,
+					},
+				},
+			},
+			nil,
+			true,
+		),
+		Entry("no serviceaccount",
+			&mariadbv1alpha1.MariaDB{
+				ObjectMeta: objMeta,
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Galera: &mariadbv1alpha1.Galera{
+						Enabled: true,
+					},
+				},
+			},
+			[]mariadbPodOpt{
+				withServiceAccount(false),
+			},
+			false,
+		),
+	)
+})
 
-func TestMariadbPodBuilderAffinity(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MariadbPodBuilderAffinity", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "test-mariadb-builder-affinity",
 	}
-	tests := []struct {
-		name                          string
-		mariadb                       *mariadbv1alpha1.MariaDB
-		opts                          []mariadbPodOpt
-		wantAffinity                  bool
-		wantTopologySpreadConstraints bool
-		wantNodeAffinity              bool
-	}{
-		{
-			name: "no affinity",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("mariadbPodTemplate affinity",
+		func(mariadb *mariadbv1alpha1.MariaDB, opts []mariadbPodOpt,
+			wantAffinity, wantTopologySpreadConstraints, wantNodeAffinity bool) {
+			builder := newDefaultTestBuilder()
+			podTpl, err := builder.mariadbPodTemplate(mariadb, opts...)
+			Expect(err).NotTo(HaveOccurred())
+
+			if wantAffinity {
+				Expect(podTpl.Spec.Affinity).NotTo(BeNil())
+			} else {
+				Expect(podTpl.Spec.Affinity).To(BeNil())
+			}
+
+			if wantTopologySpreadConstraints {
+				Expect(podTpl.Spec.TopologySpreadConstraints).NotTo(BeNil())
+			} else {
+				Expect(podTpl.Spec.TopologySpreadConstraints).To(BeNil())
+			}
+
+			if wantNodeAffinity {
+				Expect(podTpl.Spec.Affinity.NodeAffinity).NotTo(BeNil())
+			}
+			if !wantNodeAffinity && podTpl.Spec.Affinity != nil {
+				Expect(podTpl.Spec.Affinity.NodeAffinity).To(BeNil())
+			}
+		},
+		Entry("no affinity",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Storage: mariadbv1alpha1.Storage{
@@ -834,14 +758,13 @@ func TestMariadbPodBuilderAffinity(t *testing.T) {
 					},
 				},
 			},
-			opts:                          nil,
-			wantAffinity:                  false,
-			wantTopologySpreadConstraints: false,
-			wantNodeAffinity:              false,
-		},
-		{
-			name: "mariadb affinity",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+			false,
+			false,
+			false,
+		),
+		Entry("mariadb affinity",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -854,14 +777,13 @@ func TestMariadbPodBuilderAffinity(t *testing.T) {
 					},
 				},
 			},
-			opts:                          nil,
-			wantAffinity:                  true,
-			wantTopologySpreadConstraints: false,
-			wantNodeAffinity:              false,
-		},
-		{
-			name: "mariadb topologyspreadconstraints",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+			true,
+			false,
+			false,
+		),
+		Entry("mariadb topologyspreadconstraints",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -877,14 +799,13 @@ func TestMariadbPodBuilderAffinity(t *testing.T) {
 					},
 				},
 			},
-			opts:                          nil,
-			wantAffinity:                  false,
-			wantTopologySpreadConstraints: true,
-			wantNodeAffinity:              false,
-		},
-		{
-			name: "opt affinity",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+			false,
+			true,
+			false,
+		),
+		Entry("opt affinity",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Storage: mariadbv1alpha1.Storage{
@@ -892,17 +813,16 @@ func TestMariadbPodBuilderAffinity(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withAffinity(&corev1.Affinity{}),
 				withAffinityEnabled(true),
 			},
-			wantAffinity:                  true,
-			wantTopologySpreadConstraints: false,
-			wantNodeAffinity:              false,
-		},
-		{
-			name: "mariadb and opt affinity",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			true,
+			false,
+			false,
+		),
+		Entry("mariadb and opt affinity",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -921,17 +841,16 @@ func TestMariadbPodBuilderAffinity(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withAffinity(&corev1.Affinity{}),
 				withAffinityEnabled(true),
 			},
-			wantAffinity:                  true,
-			wantTopologySpreadConstraints: true,
-			wantNodeAffinity:              false,
-		},
-		{
-			name: "disable affinity",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			true,
+			true,
+			false,
+		),
+		Entry("disable affinity",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -950,17 +869,16 @@ func TestMariadbPodBuilderAffinity(t *testing.T) {
 					},
 				},
 			},
-			opts: []mariadbPodOpt{
+			[]mariadbPodOpt{
 				withAffinity(&corev1.Affinity{}),
 				withAffinityEnabled(false),
 			},
-			wantAffinity:                  false,
-			wantTopologySpreadConstraints: false,
-			wantNodeAffinity:              false,
-		},
-		{
-			name: "mariadb with node affinity",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+			false,
+			false,
+		),
+		Entry("mariadb with node affinity",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -990,139 +908,107 @@ func TestMariadbPodBuilderAffinity(t *testing.T) {
 					},
 				},
 			},
-			opts:                          nil,
-			wantAffinity:                  true,
-			wantTopologySpreadConstraints: false,
-			wantNodeAffinity:              true,
-		},
-	}
+			nil,
+			true,
+			false,
+			true,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			podTpl, err := builder.mariadbPodTemplate(tt.mariadb, tt.opts...)
-			if err != nil {
-				t.Fatalf("unexpected error building MariaDB Pod template: %v", err)
-			}
-			if tt.wantAffinity && podTpl.Spec.Affinity == nil {
-				t.Error("expected affinity to have been set")
-			}
-			if !tt.wantAffinity && podTpl.Spec.Affinity != nil {
-				t.Error("expected affinity to not have been set")
-			}
+var _ = Describe("MariadbPodLifecycleOnlyFirst", func() {
+	It("should only set lifecycle on the first container", func() {
+		builder := newDefaultTestBuilder()
 
-			if tt.wantTopologySpreadConstraints && podTpl.Spec.TopologySpreadConstraints == nil {
-				t.Error("expected topologySpreadConstraints to have been set")
-			}
-			if !tt.wantTopologySpreadConstraints && podTpl.Spec.TopologySpreadConstraints != nil {
-				t.Error("expected topologySpreadConstraints to not have been set")
-			}
-
-			if tt.wantNodeAffinity && podTpl.Spec.Affinity.NodeAffinity == nil {
-				t.Error("expected node affinity to have been set")
-			}
-			if !tt.wantNodeAffinity && podTpl.Spec.Affinity != nil && podTpl.Spec.Affinity.NodeAffinity != nil {
-				t.Error("expected node affinity to not have been set")
-			}
-		})
-	}
-}
-
-func TestMariadbPodLifecycleOnlyFirst(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-
-	mariadb := &mariadbv1alpha1.MariaDB{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-mariadb-lifecycle",
-		},
-		Spec: mariadbv1alpha1.MariaDBSpec{
-			ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
-				Lifecycle: &mariadbv1alpha1.Lifecycle{
-					PostStart: &mariadbv1alpha1.LifecycleHandler{
-						Exec: &mariadbv1alpha1.ExecAction{
-							Command: []string{"echo", "hello"},
+		mariadb := &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mariadb-lifecycle",
+			},
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
+					Lifecycle: &mariadbv1alpha1.Lifecycle{
+						PostStart: &mariadbv1alpha1.LifecycleHandler{
+							Exec: &mariadbv1alpha1.ExecAction{
+								Command: []string{"echo", "hello"},
+							},
+						},
+					},
+				},
+				MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+					SidecarContainers: []mariadbv1alpha1.Container{
+						{
+							Image: "busybox",
+							Command: []string{
+								"sh",
+								"-c",
+								"sleep 1",
+							},
 						},
 					},
 				},
 			},
-			MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-				SidecarContainers: []mariadbv1alpha1.Container{
-					{
-						Image: "busybox",
-						Command: []string{
-							"sh",
-							"-c",
-							"sleep 1",
+		}
+
+		podTpl, err := builder.mariadbPodTemplate(mariadb)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(len(podTpl.Spec.Containers)).To(BeNumerically(">=", 2))
+
+		Expect(podTpl.Spec.Containers[0].Lifecycle).NotTo(BeNil())
+		Expect(podTpl.Spec.Containers[1].Lifecycle).To(BeNil())
+	})
+})
+
+var _ = Describe("MaxScalePodLifecycleSingle", func() {
+	It("should set lifecycle on the maxscale container", func() {
+		builder := newDefaultTestBuilder()
+
+		mxs := &mariadbv1alpha1.MaxScale{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-maxscale-lifecycle",
+			},
+			Spec: mariadbv1alpha1.MaxScaleSpec{
+				ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
+					Lifecycle: &mariadbv1alpha1.Lifecycle{
+						PostStart: &mariadbv1alpha1.LifecycleHandler{
+							Exec: &mariadbv1alpha1.ExecAction{
+								Command: []string{"echo", "hello"},
+							},
 						},
 					},
 				},
 			},
-		},
-	}
+		}
 
-	podTpl, err := builder.mariadbPodTemplate(mariadb)
-	if err != nil {
-		t.Fatalf("unexpected error building MariaDB Pod template: %v", err)
-	}
+		podTpl, err := builder.maxscalePodTemplate(mxs, nil)
+		Expect(err).NotTo(HaveOccurred())
 
-	if len(podTpl.Spec.Containers) < 2 {
-		t.Fatalf("expected at least two containers, got %d", len(podTpl.Spec.Containers))
-	}
+		Expect(podTpl.Spec.Containers).To(HaveLen(1))
 
-	if podTpl.Spec.Containers[0].Lifecycle == nil {
-		t.Error("expected lifecycle on first container")
-	}
-	if podTpl.Spec.Containers[1].Lifecycle != nil {
-		t.Error("did not expect lifecycle on second (sidecar) container")
-	}
-}
+		Expect(podTpl.Spec.Containers[0].Lifecycle).NotTo(BeNil())
+	})
+})
 
-func TestMaxScalePodLifecycleSingle(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-
-	mxs := &mariadbv1alpha1.MaxScale{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-maxscale-lifecycle",
-		},
-		Spec: mariadbv1alpha1.MaxScaleSpec{
-			ContainerTemplate: mariadbv1alpha1.ContainerTemplate{
-				Lifecycle: &mariadbv1alpha1.Lifecycle{
-					PostStart: &mariadbv1alpha1.LifecycleHandler{
-						Exec: &mariadbv1alpha1.ExecAction{
-							Command: []string{"echo", "hello"},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	podTpl, err := builder.maxscalePodTemplate(mxs, nil)
-	if err != nil {
-		t.Fatalf("unexpected error building MaxScale Pod template: %v", err)
-	}
-
-	if len(podTpl.Spec.Containers) != 1 {
-		t.Fatalf("expected one container, got %d", len(podTpl.Spec.Containers))
-	}
-
-	if podTpl.Spec.Containers[0].Lifecycle == nil {
-		t.Error("expected lifecycle on maxscale container")
-	}
-}
-
-func TestMariadbPodBuilderInitContainers(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MariadbPodBuilderInitContainers", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "test-mariadb-builder-initcontainers",
 	}
-	tests := []struct {
-		name               string
-		mariadb            *mariadbv1alpha1.MariaDB
-		wantInitContainers int
-	}{
-		{
-			name: "no init containers",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("mariadbPodTemplate initContainers",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantInitContainers int) {
+			builder := newDefaultTestBuilder()
+			podTpl, err := builder.mariadbPodTemplate(mariadb)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(podTpl.Spec.InitContainers).To(HaveLen(wantInitContainers))
+
+			for _, container := range podTpl.Spec.InitContainers {
+				Expect(container.Image).NotTo(Equal(""))
+				Expect(container.Env).NotTo(BeNil())
+				Expect(container.VolumeMounts).NotTo(BeNil())
+			}
+		},
+		Entry("no init containers",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Image: "mariadb:11.4.3",
@@ -1131,11 +1017,10 @@ func TestMariadbPodBuilderInitContainers(t *testing.T) {
 					},
 				},
 			},
-			wantInitContainers: 0,
-		},
-		{
-			name: "init containers",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			0,
+		),
+		Entry("init containers",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Image: "mariadb:11.4.3",
@@ -1151,49 +1036,31 @@ func TestMariadbPodBuilderInitContainers(t *testing.T) {
 					},
 				},
 			},
-			wantInitContainers: 2,
-		},
-	}
+			2,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			podTpl, err := builder.mariadbPodTemplate(tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building MariaDB Pod template: %v", err)
-			}
-
-			if len(podTpl.Spec.InitContainers) != tt.wantInitContainers {
-				t.Errorf("unexpected number of init containers, got: %v, want: %v", len(podTpl.Spec.InitContainers), tt.wantInitContainers)
-			}
-
-			for _, container := range podTpl.Spec.InitContainers {
-				if container.Image == "" {
-					t.Error("expected container image to be set")
-				}
-				if container.Env == nil {
-					t.Error("expected container env to be set")
-				}
-				if container.VolumeMounts == nil {
-					t.Error("expected container VolumeMounts to be set")
-				}
-			}
-		})
-	}
-}
-
-func TestMariadbPodBuilderSidecarContainers(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MariadbPodBuilderSidecarContainers", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "test-mariadb-builder-sidecarcontainers",
 	}
-	tests := []struct {
-		name           string
-		mariadb        *mariadbv1alpha1.MariaDB
-		wantContainers int
-	}{
-		{
-			name: "no sidecar containers",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("mariadbPodTemplate sidecarContainers",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantContainers int) {
+			builder := newDefaultTestBuilder()
+			podTpl, err := builder.mariadbPodTemplate(mariadb)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(podTpl.Spec.Containers).To(HaveLen(wantContainers))
+
+			for _, container := range podTpl.Spec.Containers {
+				Expect(container.Image).NotTo(Equal(""))
+				Expect(container.Env).NotTo(BeNil())
+				Expect(container.VolumeMounts).NotTo(BeNil())
+			}
+		},
+		Entry("no sidecar containers",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Image: "mariadb:11.4.3",
@@ -1202,11 +1069,10 @@ func TestMariadbPodBuilderSidecarContainers(t *testing.T) {
 					},
 				},
 			},
-			wantContainers: 1,
-		},
-		{
-			name: "sidecar containers",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			1,
+		),
+		Entry("sidecar containers",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Image: "mariadb:11.4.3",
@@ -1222,149 +1088,87 @@ func TestMariadbPodBuilderSidecarContainers(t *testing.T) {
 					},
 				},
 			},
-			wantContainers: 3,
-		},
-	}
+			3,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			podTpl, err := builder.mariadbPodTemplate(tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building MariaDB Pod template: %v", err)
-			}
-
-			if len(podTpl.Spec.Containers) != tt.wantContainers {
-				t.Errorf("unexpected number of containers, got: %v, want: %v", len(podTpl.Spec.Containers), tt.wantContainers)
-			}
-
-			for _, container := range podTpl.Spec.Containers {
-				if container.Image == "" {
-					t.Error("expected container image to be set")
-				}
-				if container.Env == nil {
-					t.Error("expected container env to be set")
-				}
-				if container.VolumeMounts == nil {
-					t.Error("expected container VolumeMounts to be set")
-				}
-			}
-		})
-	}
-}
-
-func TestMaxscalePodBuilder(t *testing.T) {
-	d, err := discovery.NewFakeDiscovery()
-	if err != nil {
-		t.Fatalf("unexpected error getting discovery: %v", err)
-	}
-	builder := newTestBuilder(d)
-	mxs := &mariadbv1alpha1.MaxScale{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-maxscale-builder",
-		},
-	}
-
-	podTpl, err := builder.maxscalePodTemplate(mxs, nil)
-	if err != nil {
-		t.Fatalf("unexpected error building MaxScale Pod template: %v", err)
-	}
-
-	if podTpl.Spec.SecurityContext == nil {
-		t.Error("expected podSecurityContext to have been set")
-	}
-	sc := ptr.Deref(podTpl.Spec.SecurityContext, corev1.PodSecurityContext{})
-	runAsUser := ptr.Deref(sc.RunAsUser, 0)
-	runAsGroup := ptr.Deref(sc.RunAsGroup, 0)
-	fsGroup := ptr.Deref(sc.FSGroup, 0)
-
-	if runAsUser != maxscaleUser {
-		t.Errorf("expected to run as maxscale user, got user: %d", runAsUser)
-	}
-	if runAsGroup != maxscaleGroup {
-		t.Errorf("expected to run as maxscale group, got group: %d", runAsGroup)
-	}
-	if fsGroup != maxscaleGroup {
-		t.Errorf("expected to run as maxscale fsGroup, got fsGroup: %d", fsGroup)
-	}
-}
-
-func TestMariadbConfigVolume(t *testing.T) {
-	mariadb := &mariadbv1alpha1.MariaDB{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-mariadb-builder",
-		},
-		Spec: mariadbv1alpha1.MariaDBSpec{
-			Storage: mariadbv1alpha1.Storage{
-				Size: ptr.To(resource.MustParse("300Mi")),
+var _ = Describe("MaxscalePodBuilder", func() {
+	It("should build the MaxScale Pod template", func() {
+		d, err := discovery.NewFakeDiscovery()
+		Expect(err).NotTo(HaveOccurred())
+		builder := newTestBuilder(d)
+		mxs := &mariadbv1alpha1.MaxScale{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-maxscale-builder",
 			},
-		},
-	}
+		}
 
-	volume := mariadbConfigVolume(mariadb)
-	if volume.Projected == nil {
-		t.Fatal("expected volume to be projected")
-	}
-	expectedSources := 1
-	if len(volume.Projected.Sources) != expectedSources {
-		t.Fatalf("expecting to have %d sources, got: %d", expectedSources, len(volume.Projected.Sources))
-	}
-	expectedKey := "0-default.cnf"
-	if volume.Projected.Sources[0].ConfigMap.Items[0].Key != expectedKey {
-		t.Fatalf("expecting to have '%s' key, got: '%s'", expectedKey, volume.Projected.Sources[0].ConfigMap.Items[0].Key)
-	}
+		podTpl, err := builder.maxscalePodTemplate(mxs, nil)
+		Expect(err).NotTo(HaveOccurred())
 
-	mariadb.Spec.MyCnfConfigMapKeyRef = &mariadbv1alpha1.ConfigMapKeySelector{
-		LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
-			Name: "test",
-		},
-		Key: "my.cnf",
-	}
+		Expect(podTpl.Spec.SecurityContext).NotTo(BeNil())
+		sc := ptr.Deref(podTpl.Spec.SecurityContext, corev1.PodSecurityContext{})
+		runAsUser := ptr.Deref(sc.RunAsUser, 0)
+		runAsGroup := ptr.Deref(sc.RunAsGroup, 0)
+		fsGroup := ptr.Deref(sc.FSGroup, 0)
 
-	volume = mariadbConfigVolume(mariadb)
-	if volume.Projected == nil {
-		t.Fatal("expected volume to be projected")
-	}
-	expectedSources = 2
-	if len(volume.Projected.Sources) != expectedSources {
-		t.Fatalf("expecting to have %d sources, got: %d", expectedSources, len(volume.Projected.Sources))
-	}
-	expectedKey = "0-default.cnf"
-	if volume.Projected.Sources[0].ConfigMap.Items[0].Key != expectedKey {
-		t.Fatalf("expecting to have '%s' key, got: '%s'", expectedKey, volume.Projected.Sources[0].ConfigMap.Items[0].Key)
-	}
-	expectedKey = "my.cnf"
-	if volume.Projected.Sources[1].ConfigMap.Items[0].Key != expectedKey {
-		t.Fatalf("expecting to have '%s' key, got: '%s'", expectedKey, volume.Projected.Sources[0].ConfigMap.Items[0].Key)
-	}
-}
+		Expect(runAsUser).To(Equal(maxscaleUser))
+		Expect(runAsGroup).To(Equal(maxscaleGroup))
+		Expect(fsGroup).To(Equal(maxscaleGroup))
+	})
+})
 
-func TestMariadbTerminationGracePeriodSeconds(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MariadbConfigVolume", func() {
+	It("should build the MariaDB config volume", func() {
+		mariadb := &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-mariadb-builder",
+			},
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				Storage: mariadbv1alpha1.Storage{
+					Size: ptr.To(resource.MustParse("300Mi")),
+				},
+			},
+		}
+
+		volume := mariadbConfigVolume(mariadb)
+		Expect(volume.Projected).NotTo(BeNil())
+		expectedSources := 1
+		Expect(volume.Projected.Sources).To(HaveLen(expectedSources))
+		expectedKey := "0-default.cnf"
+		Expect(volume.Projected.Sources[0].ConfigMap.Items[0].Key).To(Equal(expectedKey))
+
+		mariadb.Spec.MyCnfConfigMapKeyRef = &mariadbv1alpha1.ConfigMapKeySelector{
+			LocalObjectReference: mariadbv1alpha1.LocalObjectReference{
+				Name: "test",
+			},
+			Key: "my.cnf",
+		}
+
+		volume = mariadbConfigVolume(mariadb)
+		Expect(volume.Projected).NotTo(BeNil())
+		expectedSources = 2
+		Expect(volume.Projected.Sources).To(HaveLen(expectedSources))
+		expectedKey = "0-default.cnf"
+		Expect(volume.Projected.Sources[0].ConfigMap.Items[0].Key).To(Equal(expectedKey))
+		expectedKey = "my.cnf"
+		Expect(volume.Projected.Sources[1].ConfigMap.Items[0].Key).To(Equal(expectedKey))
+	})
+})
+
+var _ = Describe("MariadbTerminationGracePeriodSeconds", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "test-mariadb-termination-grace",
 	}
-
-	tests := []struct {
-		name string
-		tgs  *int64
-	}{
-		{
-			name: "unset",
-			tgs:  nil,
-		},
-		{
-			name: "set",
-			tgs:  ptr.To(int64(5)),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	DescribeTable("mariadbPodTemplate terminationGracePeriodSeconds",
+		func(tgs *int64) {
+			builder := newDefaultTestBuilder()
 			mariadb := &mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
-						TerminationGracePeriodSeconds: tt.tgs,
+						TerminationGracePeriodSeconds: tgs,
 					},
 					Storage: mariadbv1alpha1.Storage{
 						Size: ptr.To(resource.MustParse("300Mi")),
@@ -1373,12 +1177,10 @@ func TestMariadbTerminationGracePeriodSeconds(t *testing.T) {
 			}
 
 			podTpl, err := builder.mariadbPodTemplate(mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building MariaDB Pod template: %v", err)
-			}
-			if diff := cmp.Diff(podTpl.Spec.TerminationGracePeriodSeconds, tt.tgs); diff != "" {
-				t.Errorf("unexpected TerminationGracePeriodSeconds(-want +got):\n%s", diff)
-			}
-		})
-	}
-}
+			Expect(err).NotTo(HaveOccurred())
+			Expect(podTpl.Spec.TerminationGracePeriodSeconds).To(Equal(tgs))
+		},
+		Entry("unset", nil),
+		Entry("set", ptr.To(int64(5))),
+	)
+})

--- a/pkg/builder/poddisruptionbudget_builder_test.go
+++ b/pkg/builder/poddisruptionbudget_builder_test.go
@@ -1,29 +1,34 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 )
 
-func TestPodDisruptionBudgetMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	tests := []struct {
-		name     string
-		opts     PodDisruptionBudgetOpts
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			opts: PodDisruptionBudgetOpts{},
-			wantMeta: &mariadbv1alpha1.Metadata{
+var _ = Describe("PodDisruptionBudgetMeta", func() {
+	var builder *Builder
+
+	BeforeEach(func() {
+		builder = newDefaultTestBuilder()
+	})
+
+	DescribeTable("BuildPodDisruptionBudget",
+		func(opts PodDisruptionBudgetOpts, wantMeta *mariadbv1alpha1.Metadata) {
+			configMap, err := builder.BuildPodDisruptionBudget(opts, &mariadbv1alpha1.MariaDB{})
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&configMap.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			PodDisruptionBudgetOpts{},
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			opts: PodDisruptionBudgetOpts{
+		),
+		Entry("meta",
+			PodDisruptionBudgetOpts{
 				Metadata: &mariadbv1alpha1.Metadata{
 					Labels: map[string]string{
 						"database.myorg.io": "mariadb",
@@ -33,7 +38,7 @@ func TestPodDisruptionBudgetMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -41,16 +46,6 @@ func TestPodDisruptionBudgetMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configMap, err := builder.BuildPodDisruptionBudget(tt.opts, &mariadbv1alpha1.MariaDB{})
-			if err != nil {
-				t.Fatalf("unexpected error building PDB: %v", err)
-			}
-			assertObjectMeta(t, &configMap.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/builder/rbac_builder_test.go
+++ b/pkg/builder/rbac_builder_test.go
@@ -1,7 +1,8 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -9,27 +10,27 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestServiceAccountMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ServiceAccountMeta", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "sa",
 	}
-	tests := []struct {
-		name     string
-		meta     *mariadbv1alpha1.Metadata
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			meta: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+
+	DescribeTable("should build the ServiceAccount with the expected metadata",
+		func(meta *mariadbv1alpha1.Metadata, wantMeta *mariadbv1alpha1.Metadata) {
+			sa, err := builder.BuildServiceAccount(key, &mariadbv1alpha1.MariaDB{}, meta)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&sa.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			meta: &mariadbv1alpha1.Metadata{
+		),
+		Entry("meta",
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -37,7 +38,7 @@ func TestServiceAccountMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -45,43 +46,32 @@ func TestServiceAccountMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sa, err := builder.BuildServiceAccount(key, &mariadbv1alpha1.MariaDB{}, tt.meta)
-			if err != nil {
-				t.Fatalf("unexpected error building ServiceAccount: %v", err)
-			}
-			assertObjectMeta(t, &sa.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
-
-func TestRoleMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("RoleMeta", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "role",
 	}
 	rules := []rbacv1.PolicyRule{}
 
-	tests := []struct {
-		name     string
-		mariadb  *mariadbv1alpha1.MariaDB
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name:    "no meta",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantMeta: &mariadbv1alpha1.Metadata{
+	DescribeTable("should build the Role with the expected metadata",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantMeta *mariadbv1alpha1.Metadata) {
+			role, err := builder.BuildRole(key, mariadb, mariadb.Spec.InheritMetadata, rules)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&role.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			&mariadbv1alpha1.MariaDB{},
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("meta",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
 						Labels: map[string]string{
@@ -93,7 +83,7 @@ func TestRoleMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -101,44 +91,33 @@ func TestRoleMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			role, err := builder.BuildRole(key, tt.mariadb, tt.mariadb.Spec.InheritMetadata, rules)
-			if err != nil {
-				t.Fatalf("unexpected error building Role: %v", err)
-			}
-			assertObjectMeta(t, &role.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
-
-func TestRoleBindingMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("RoleBindingMeta", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "rolebinding",
 	}
 	sa := corev1.ServiceAccount{}
 	roleRef := rbacv1.RoleRef{}
 
-	tests := []struct {
-		name     string
-		mariadb  *mariadbv1alpha1.MariaDB
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name:    "no meta",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantMeta: &mariadbv1alpha1.Metadata{
+	DescribeTable("should build the RoleBinding with the expected metadata",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantMeta *mariadbv1alpha1.Metadata) {
+			role, err := builder.BuildRoleBinding(key, mariadb, mariadb.Spec.InheritMetadata, &sa, roleRef)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&role.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			&mariadbv1alpha1.MariaDB{},
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("meta",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
 						Labels: map[string]string{
@@ -150,7 +129,7 @@ func TestRoleBindingMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -158,44 +137,33 @@ func TestRoleBindingMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			role, err := builder.BuildRoleBinding(key, tt.mariadb, tt.mariadb.Spec.InheritMetadata, &sa, roleRef)
-			if err != nil {
-				t.Fatalf("unexpected error building RoleBinding: %v", err)
-			}
-			assertObjectMeta(t, &role.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
-
-func TestClusterRoleBindingMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ClusterRoleBindingMeta", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "clusterrolebinding",
 	}
 	sa := corev1.ServiceAccount{}
 	roleRef := rbacv1.RoleRef{}
 
-	tests := []struct {
-		name     string
-		mariadb  *mariadbv1alpha1.MariaDB
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name:    "no meta",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantMeta: &mariadbv1alpha1.Metadata{
+	DescribeTable("should build the ClusterRoleBinding with the expected metadata",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantMeta *mariadbv1alpha1.Metadata) {
+			role, err := builder.BuildClusterRoleBinding(key, mariadb, mariadb.Spec.InheritMetadata, &sa, roleRef)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&role.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			&mariadbv1alpha1.MariaDB{},
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("meta",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
 						Labels: map[string]string{
@@ -207,7 +175,7 @@ func TestClusterRoleBindingMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -215,16 +183,6 @@ func TestClusterRoleBindingMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			role, err := builder.BuildClusterRoleBinding(key, tt.mariadb, tt.mariadb.Spec.InheritMetadata, &sa, roleRef)
-			if err != nil {
-				t.Fatalf("unexpected error building ClusterRoleBinding: %v", err)
-			}
-			assertObjectMeta(t, &role.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/builder/restore_builder_test.go
+++ b/pkg/builder/restore_builder_test.go
@@ -1,7 +1,8 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -11,201 +12,187 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func TestRestoreMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("RestoreMeta", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "restore",
 	}
-	tests := []struct {
-		name            string
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantRestoreMeta *mariadbv1alpha1.Metadata
-		wantPodMeta     *mariadbv1alpha1.Metadata
-	}{
-		{
-			name:    "no meta",
-			mariadb: &mariadbv1alpha1.MariaDB{},
-			wantRestoreMeta: &mariadbv1alpha1.Metadata{
-				Labels:      map[string]string{},
-				Annotations: map[string]string{},
-			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
-				Labels:      map[string]string{},
-				Annotations: map[string]string{},
-			},
-		},
-		{
-			name: "inherit meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					InheritMetadata: &mariadbv1alpha1.Metadata{
-						Labels: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-						Annotations: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-					},
-				},
-			},
-			wantRestoreMeta: &mariadbv1alpha1.Metadata{
-				Labels: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
-				Annotations: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
-			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
-				Labels: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
-				Annotations: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
-			},
-		},
-		{
-			name: "pod meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
-						RestoreJob: &mariadbv1alpha1.Job{
-							Metadata: &mariadbv1alpha1.Metadata{
-								Labels: map[string]string{
-									"database.myorg.io": "job",
-								},
-								Annotations: map[string]string{
-									"database.myorg.io": "job",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantRestoreMeta: &mariadbv1alpha1.Metadata{
-				Labels:      map[string]string{},
-				Annotations: map[string]string{},
-			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
-				Labels: map[string]string{
-					"database.myorg.io": "job",
-				},
-				Annotations: map[string]string{
-					"database.myorg.io": "job",
-				},
-			},
-		},
-		{
-			name: "all",
-			mariadb: &mariadbv1alpha1.MariaDB{
-				Spec: mariadbv1alpha1.MariaDBSpec{
-					InheritMetadata: &mariadbv1alpha1.Metadata{
-						Labels: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-						Annotations: map[string]string{
-							"database.myorg.io": "mariadb",
-						},
-					},
-					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
-						RestoreJob: &mariadbv1alpha1.Job{
-							Metadata: &mariadbv1alpha1.Metadata{
-								Labels: map[string]string{
-									"database.myorg.io": "job",
-								},
-								Annotations: map[string]string{
-									"database.myorg.io": "job",
-								},
-							},
-						},
-					},
-				},
-			},
-			wantRestoreMeta: &mariadbv1alpha1.Metadata{
-				Labels: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
-				Annotations: map[string]string{
-					"database.myorg.io": "mariadb",
-				},
-			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
-				Labels: map[string]string{
-					"database.myorg.io": "job",
-				},
-				Annotations: map[string]string{
-					"database.myorg.io": "job",
-				},
-			},
-		},
-	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			restore, err := builder.BuildRestore(tt.mariadb, key)
-			if err != nil {
-				t.Fatalf("unexpected error building Restore: %v", err)
-			}
-			assertObjectMeta(t, &restore.ObjectMeta, tt.wantRestoreMeta.Labels, tt.wantRestoreMeta.Annotations)
+	DescribeTable(
+		"should build Restore meta",
+		func(
+			mariadb *mariadbv1alpha1.MariaDB,
+			wantRestoreMeta *mariadbv1alpha1.Metadata,
+			wantPodMeta *mariadbv1alpha1.Metadata,
+		) {
+			restore, err := builder.BuildRestore(mariadb, key)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&restore.ObjectMeta, wantRestoreMeta.Labels, wantRestoreMeta.Annotations)
 			meta := ptr.Deref(restore.Spec.PodMetadata, mariadbv1alpha1.Metadata{})
-			assertMeta(t, &meta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestBuildRestore(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	mariadb := &mariadbv1alpha1.MariaDB{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-restore-builder",
+			assertMeta(&meta, wantPodMeta.Labels, wantPodMeta.Annotations)
 		},
-		Spec: mariadbv1alpha1.MariaDBSpec{
-			Storage: mariadbv1alpha1.Storage{
-				Size: ptr.To(resource.MustParse("300Mi")),
+		Entry(
+			"no meta",
+			&mariadbv1alpha1.MariaDB{},
+			&mariadbv1alpha1.Metadata{
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
 			},
-			BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
-				RestoreJob: &mariadbv1alpha1.Job{
-					Affinity: &mariadbv1alpha1.AffinityConfig{
-						AntiAffinityEnabled: ptr.To(true),
-						Affinity:            mariadbv1alpha1.Affinity{},
-					},
-					NodeSelector: map[string]string{
-						"kubernetes.io/hostname": "compute-0",
-					},
-					Tolerations: []corev1.Toleration{},
-					Resources: &mariadbv1alpha1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							"cpu": resource.MustParse("100m"),
+			&mariadbv1alpha1.Metadata{
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+		),
+		Entry(
+			"inherit meta",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					InheritMetadata: &mariadbv1alpha1.Metadata{
+						Labels: map[string]string{
+							"database.myorg.io": "mariadb",
+						},
+						Annotations: map[string]string{
+							"database.myorg.io": "mariadb",
 						},
 					},
-					Args: []string{"--verbose"},
 				},
 			},
-		},
-	}
-	key := types.NamespacedName{
-		Name: "test-restore",
-	}
+			&mariadbv1alpha1.Metadata{
+				Labels: map[string]string{
+					"database.myorg.io": "mariadb",
+				},
+				Annotations: map[string]string{
+					"database.myorg.io": "mariadb",
+				},
+			},
+			&mariadbv1alpha1.Metadata{
+				Labels: map[string]string{
+					"database.myorg.io": "mariadb",
+				},
+				Annotations: map[string]string{
+					"database.myorg.io": "mariadb",
+				},
+			},
+		),
+		Entry(
+			"pod meta",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
+						RestoreJob: &mariadbv1alpha1.Job{
+							Metadata: &mariadbv1alpha1.Metadata{
+								Labels: map[string]string{
+									"database.myorg.io": "job",
+								},
+								Annotations: map[string]string{
+									"database.myorg.io": "job",
+								},
+							},
+						},
+					},
+				},
+			},
+			&mariadbv1alpha1.Metadata{
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			&mariadbv1alpha1.Metadata{
+				Labels: map[string]string{
+					"database.myorg.io": "job",
+				},
+				Annotations: map[string]string{
+					"database.myorg.io": "job",
+				},
+			},
+		),
+		Entry(
+			"all",
+			&mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					InheritMetadata: &mariadbv1alpha1.Metadata{
+						Labels: map[string]string{
+							"database.myorg.io": "mariadb",
+						},
+						Annotations: map[string]string{
+							"database.myorg.io": "mariadb",
+						},
+					},
+					BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
+						RestoreJob: &mariadbv1alpha1.Job{
+							Metadata: &mariadbv1alpha1.Metadata{
+								Labels: map[string]string{
+									"database.myorg.io": "job",
+								},
+								Annotations: map[string]string{
+									"database.myorg.io": "job",
+								},
+							},
+						},
+					},
+				},
+			},
+			&mariadbv1alpha1.Metadata{
+				Labels: map[string]string{
+					"database.myorg.io": "mariadb",
+				},
+				Annotations: map[string]string{
+					"database.myorg.io": "mariadb",
+				},
+			},
+			&mariadbv1alpha1.Metadata{
+				Labels: map[string]string{
+					"database.myorg.io": "job",
+				},
+				Annotations: map[string]string{
+					"database.myorg.io": "job",
+				},
+			},
+		),
+	)
+})
 
-	restore, err := builder.BuildRestore(mariadb, key)
-	if err != nil {
-		t.Errorf("unexpected error building Restore: %v", err)
-	}
+var _ = Describe("BuildRestore", func() {
+	It("should build Restore", func() {
+		builder := newDefaultTestBuilder()
+		mariadb := &mariadbv1alpha1.MariaDB{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-restore-builder",
+			},
+			Spec: mariadbv1alpha1.MariaDBSpec{
+				Storage: mariadbv1alpha1.Storage{
+					Size: ptr.To(resource.MustParse("300Mi")),
+				},
+				BootstrapFrom: &mariadbv1alpha1.BootstrapFrom{
+					RestoreJob: &mariadbv1alpha1.Job{
+						Affinity: &mariadbv1alpha1.AffinityConfig{
+							AntiAffinityEnabled: ptr.To(true),
+							Affinity:            mariadbv1alpha1.Affinity{},
+						},
+						NodeSelector: map[string]string{
+							"kubernetes.io/hostname": "compute-0",
+						},
+						Tolerations: []corev1.Toleration{},
+						Resources: &mariadbv1alpha1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								"cpu": resource.MustParse("100m"),
+							},
+						},
+						Args: []string{"--verbose"},
+					},
+				},
+			},
+		}
+		key := types.NamespacedName{
+			Name: "test-restore",
+		}
 
-	if restore.Spec.Affinity == nil {
-		t.Error("expected affinity to have been set")
-	}
-	if len(restore.Spec.NodeSelector) <= 0 {
-		t.Error("expected nodeSelector to have been set")
-	}
-	if restore.Spec.Tolerations == nil {
-		t.Error("expected Tolerations to have been set")
-	}
-	if restore.Spec.Resources == nil {
-		t.Error("expected resources to have been set")
-	}
-	if restore.Spec.Args == nil {
-		t.Error("expected args to have been set")
-	}
-}
+		restore, err := builder.BuildRestore(mariadb, key)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(restore.Spec.Affinity).NotTo(BeNil())
+		Expect(restore.Spec.NodeSelector).ToNot(BeEmpty())
+		Expect(restore.Spec.Tolerations).NotTo(BeNil())
+		Expect(restore.Spec.Resources).NotTo(BeNil())
+		Expect(restore.Spec.Args).NotTo(BeNil())
+	})
+})

--- a/pkg/builder/secret_builder_test.go
+++ b/pkg/builder/secret_builder_test.go
@@ -1,25 +1,25 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func TestSecretBuilder(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	tests := []struct {
-		name     string
-		opts     SecretOpts
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			opts: SecretOpts{
+var _ = Describe("SecretBuilder", func() {
+	DescribeTable("Building a Secret with metadata",
+		func(opts SecretOpts, wantMeta *mariadbv1alpha1.Metadata) {
+			builder := newDefaultTestBuilder()
+			configMap, err := builder.BuildSecret(opts, &mariadbv1alpha1.MariaDB{})
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&configMap.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			SecretOpts{
 				Metadata: []*mariadbv1alpha1.Metadata{},
 				Key: types.NamespacedName{
 					Name: "configmap",
@@ -28,14 +28,13 @@ func TestSecretBuilder(t *testing.T) {
 					"password": []byte("test"),
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "single meta",
-			opts: SecretOpts{
+		),
+		Entry("single meta",
+			SecretOpts{
 				Metadata: []*mariadbv1alpha1.Metadata{
 					{
 						Labels: map[string]string{
@@ -53,7 +52,7 @@ func TestSecretBuilder(t *testing.T) {
 					"password": []byte("test"),
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -61,10 +60,9 @@ func TestSecretBuilder(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "multiple meta",
-			opts: SecretOpts{
+		),
+		Entry("multiple meta",
+			SecretOpts{
 				Metadata: []*mariadbv1alpha1.Metadata{
 					{
 						Labels: map[string]string{
@@ -87,7 +85,7 @@ func TestSecretBuilder(t *testing.T) {
 					"password": []byte("test"),
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io":       "mariadb",
 					"sidecar.istio.io/inject": "false",
@@ -96,46 +94,29 @@ func TestSecretBuilder(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configMap, err := builder.BuildSecret(tt.opts, &mariadbv1alpha1.MariaDB{})
-			if err != nil {
-				t.Fatalf("unexpected error building Secret: %v", err)
+var _ = Describe("BuildSecret", func() {
+	DescribeTable("Building a Secret",
+		func(opts SecretOpts, owner metav1.Object, wantErr bool) {
+			builder := newDefaultTestBuilder()
+			secret, err := builder.BuildSecret(opts, owner)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
 			}
-			assertObjectMeta(t, &configMap.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
-
-func TestBuildSecret(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	tests := []struct {
-		name    string
-		opts    SecretOpts
-		owner   metav1.Object
-		wantErr bool
-	}{
-		{
-			name: "no owner",
-			opts: SecretOpts{
-				Metadata: []*mariadbv1alpha1.Metadata{},
-				Key: types.NamespacedName{
-					Name:      "test-secret",
-					Namespace: "default",
-				},
-				Data: map[string][]byte{
-					"key": []byte("value"),
-				},
-			},
-			owner:   nil,
-			wantErr: false,
+			Expect(secret.Data).To(Equal(opts.Data))
+			Expect(secret.Name).To(Equal(opts.Key.Name))
+			Expect(secret.Namespace).To(Equal(opts.Key.Namespace))
+			if owner != nil {
+				Expect(controllerutil.HasControllerReference(secret)).To(BeTrue())
+			}
 		},
-		{
-			name: "with owner",
-			opts: SecretOpts{
+		Entry("no owner",
+			SecretOpts{
 				Metadata: []*mariadbv1alpha1.Metadata{},
 				Key: types.NamespacedName{
 					Name:      "test-secret",
@@ -145,29 +126,27 @@ func TestBuildSecret(t *testing.T) {
 					"key": []byte("value"),
 				},
 			},
-			owner: &mariadbv1alpha1.MariaDB{
+			nil,
+			false,
+		),
+		Entry("with owner",
+			SecretOpts{
+				Metadata: []*mariadbv1alpha1.Metadata{},
+				Key: types.NamespacedName{
+					Name:      "test-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"key": []byte("value"),
+				},
+			},
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-mariadb",
 					Namespace: "default",
 				},
 			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			secret, err := builder.BuildSecret(tt.opts, tt.owner)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("BuildSecret() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			assert.Equal(t, tt.opts.Data, secret.Data)
-			assert.Equal(t, tt.opts.Key.Name, secret.Name)
-			assert.Equal(t, tt.opts.Key.Namespace, secret.Namespace)
-			if tt.owner != nil {
-				assert.True(t, controllerutil.HasControllerReference(secret))
-			}
-		})
-	}
-}
+			false,
+		),
+	)
+})

--- a/pkg/builder/securitycontext_builder_test.go
+++ b/pkg/builder/securitycontext_builder_test.go
@@ -1,145 +1,107 @@
 package builder
 
 import (
-	"testing"
-
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/discovery"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
-func TestBuildContainerSecurityContext(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("BuildContainerSecurityContext", func() {
+	It("should build the container SecurityContext", func() {
+		builder := newDefaultTestBuilder()
 
-	sc, err := builder.buildContainerSecurityContext(&mariadbv1alpha1.SecurityContext{
-		RunAsUser: ptr.To(mysqlUser),
-	})
-	if err != nil {
-		t.Fatalf("unexpected error building SecurityContext: %v", err)
-	}
-	if sc == nil {
-		t.Error("SecurityContext must be non nil")
-	}
+		sc, err := builder.buildContainerSecurityContext(&mariadbv1alpha1.SecurityContext{
+			RunAsUser: ptr.To(mysqlUser),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc).NotTo(BeNil())
 
-	resource := &metav1.APIResourceList{
-		GroupVersion: "security.openshift.io/v1",
-		APIResources: []metav1.APIResource{
-			{
-				Name: "securitycontextconstraints",
+		resource := &metav1.APIResourceList{
+			GroupVersion: "security.openshift.io/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name: "securitycontextconstraints",
+				},
 			},
-		},
-	}
-	discovery, err := discovery.NewFakeDiscovery(resource)
-	if err != nil {
-		t.Fatalf("unexpected error getting discovery: %v", err)
-	}
-	builder = newTestBuilder(discovery)
-
-	sc, err = builder.buildContainerSecurityContext(&mariadbv1alpha1.SecurityContext{
-		RunAsUser: ptr.To(mysqlUser),
-	})
-	if err != nil {
-		t.Fatalf("unexpected error building SecurityContext: %v", err)
-	}
-	if sc != nil {
-		t.Error("SecurityContext must be nil")
-	}
-}
-
-func TestBuildPodSecurityContext(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-
-	sc, err := builder.buildPodSecurityContext(&mariadbv1alpha1.PodSecurityContext{
-		RunAsUser: ptr.To(mysqlUser),
-	})
-	if err != nil {
-		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
-	}
-	if sc == nil {
-		t.Error("PodSecurityContext must be non nil")
-	}
-
-	resource := &metav1.APIResourceList{
-		GroupVersion: "security.openshift.io/v1",
-		APIResources: []metav1.APIResource{
-			{
-				Name: "securitycontextconstraints",
-			},
-		},
-	}
-	discovery, err := discovery.NewFakeDiscovery(resource)
-	if err != nil {
-		t.Fatalf("unexpected error getting discovery: %v", err)
-	}
-	builder = newTestBuilder(discovery)
-
-	sc, err = builder.buildPodSecurityContext(&mariadbv1alpha1.PodSecurityContext{
-		RunAsUser: ptr.To(mysqlUser),
-	})
-	if err != nil {
-		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
-	}
-	if sc != nil {
-		t.Error("PodSecurityContext must be nil")
-	}
-}
-
-func TestBuildPodSecurityContextWithUserGroup(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-
-	sc, err := builder.buildPodSecurityContextWithUserGroup(&mariadbv1alpha1.PodSecurityContext{
-		RunAsUser: ptr.To(mysqlUser),
-	}, mysqlUser, mysqlGroup)
-	if err != nil {
-		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
-	}
-	if sc == nil {
-		t.Error("PodSecurityContext must be non nil")
-	}
-
-	sc, err = builder.buildPodSecurityContextWithUserGroup(nil, mysqlUser, mysqlGroup)
-	if err != nil {
-		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
-	}
-	if sc == nil {
-		t.Fatal("PodSecurityContext must be non nil")
-	} else {
-		runAsUser := ptr.Deref(sc.RunAsUser, 0)
-		if runAsUser != mysqlUser {
-			t.Errorf("expected to run as mysql user, got user: %d", runAsUser)
 		}
-	}
-	runAsGroup := ptr.Deref(sc.RunAsGroup, 0)
-	if runAsGroup != mysqlGroup {
-		t.Errorf("expected to run as mysql group, got group: %d", runAsGroup)
-	}
-	fsGroup := ptr.Deref(sc.FSGroup, 0)
-	if fsGroup != mysqlGroup {
-		t.Errorf("expected to run as mysql fsGroup, got fsGroup: %d", fsGroup)
-	}
+		fakeDiscovery, err := discovery.NewFakeDiscovery(resource)
+		Expect(err).NotTo(HaveOccurred())
+		builder = newTestBuilder(fakeDiscovery)
 
-	resource := &metav1.APIResourceList{
-		GroupVersion: "security.openshift.io/v1",
-		APIResources: []metav1.APIResource{
-			{
-				Name: "securitycontextconstraints",
+		sc, err = builder.buildContainerSecurityContext(&mariadbv1alpha1.SecurityContext{
+			RunAsUser: ptr.To(mysqlUser),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc).To(BeNil())
+	})
+})
+
+var _ = Describe("BuildPodSecurityContext", func() {
+	It("should build the pod SecurityContext", func() {
+		builder := newDefaultTestBuilder()
+
+		sc, err := builder.buildPodSecurityContext(&mariadbv1alpha1.PodSecurityContext{
+			RunAsUser: ptr.To(mysqlUser),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc).NotTo(BeNil())
+
+		resource := &metav1.APIResourceList{
+			GroupVersion: "security.openshift.io/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name: "securitycontextconstraints",
+				},
 			},
-		},
-	}
-	discovery, err := discovery.NewFakeDiscovery(resource)
-	if err != nil {
-		t.Fatalf("unexpected error getting discovery: %v", err)
-	}
-	builder = newTestBuilder(discovery)
+		}
+		fakeDiscovery, err := discovery.NewFakeDiscovery(resource)
+		Expect(err).NotTo(HaveOccurred())
+		builder = newTestBuilder(fakeDiscovery)
 
-	sc, err = builder.buildPodSecurityContextWithUserGroup(&mariadbv1alpha1.PodSecurityContext{
-		RunAsUser: ptr.To(mysqlUser),
-	}, mysqlUser, mysqlGroup)
-	if err != nil {
-		t.Fatalf("unexpected error building PodSecurityContext: %v", err)
-	}
-	if sc != nil {
-		t.Error("PodSecurityContext must be nil")
-	}
-}
+		sc, err = builder.buildPodSecurityContext(&mariadbv1alpha1.PodSecurityContext{
+			RunAsUser: ptr.To(mysqlUser),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc).To(BeNil())
+	})
+})
+
+var _ = Describe("BuildPodSecurityContextWithUserGroup", func() {
+	It("should build the pod SecurityContext with user and group", func() {
+		builder := newDefaultTestBuilder()
+
+		sc, err := builder.buildPodSecurityContextWithUserGroup(&mariadbv1alpha1.PodSecurityContext{
+			RunAsUser: ptr.To(mysqlUser),
+		}, mysqlUser, mysqlGroup)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc).NotTo(BeNil())
+
+		sc, err = builder.buildPodSecurityContextWithUserGroup(nil, mysqlUser, mysqlGroup)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc).NotTo(BeNil())
+		Expect(ptr.Deref(sc.RunAsUser, 0)).To(Equal(mysqlUser))
+		Expect(ptr.Deref(sc.RunAsGroup, 0)).To(Equal(mysqlGroup))
+		Expect(ptr.Deref(sc.FSGroup, 0)).To(Equal(mysqlGroup))
+
+		resource := &metav1.APIResourceList{
+			GroupVersion: "security.openshift.io/v1",
+			APIResources: []metav1.APIResource{
+				{
+					Name: "securitycontextconstraints",
+				},
+			},
+		}
+		fakeDiscovery, err := discovery.NewFakeDiscovery(resource)
+		Expect(err).NotTo(HaveOccurred())
+		builder = newTestBuilder(fakeDiscovery)
+
+		sc, err = builder.buildPodSecurityContextWithUserGroup(&mariadbv1alpha1.PodSecurityContext{
+			RunAsUser: ptr.To(mysqlUser),
+		}, mysqlUser, mysqlGroup)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc).To(BeNil())
+	})
+})

--- a/pkg/builder/service_builder_test.go
+++ b/pkg/builder/service_builder_test.go
@@ -1,37 +1,38 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestServiceMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ServiceMeta", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "service",
 	}
-	tests := []struct {
-		name     string
-		opts     ServiceOpts
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			opts: ServiceOpts{
+
+	DescribeTable("should build the Service metadata",
+		func(opts ServiceOpts, wantMeta *mariadbv1alpha1.Metadata) {
+			svc, err := builder.BuildService(key, &mariadbv1alpha1.MariaDB{}, opts)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&svc.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			ServiceOpts{
 				ExtraMeta:             &mariadbv1alpha1.Metadata{},
 				ExcludeSelectorLabels: true,
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			opts: ServiceOpts{
+		),
+		Entry("meta",
+			ServiceOpts{
 				ServiceTemplate: mariadbv1alpha1.ServiceTemplate{
 					Metadata: &mariadbv1alpha1.Metadata{
 						Labels: map[string]string{
@@ -44,7 +45,7 @@ func TestServiceMeta(t *testing.T) {
 				},
 				ExcludeSelectorLabels: true,
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -52,10 +53,9 @@ func TestServiceMeta(t *testing.T) {
 					"metallb.io/loadBalancerIPs": "172.18.0.20",
 				},
 			},
-		},
-		{
-			name: "extra meta",
-			opts: ServiceOpts{
+		),
+		Entry("extra meta",
+			ServiceOpts{
 				ExtraMeta: &mariadbv1alpha1.Metadata{
 					Labels: map[string]string{
 						"database.myorg.io": "mariadb",
@@ -66,7 +66,7 @@ func TestServiceMeta(t *testing.T) {
 				},
 				ExcludeSelectorLabels: true,
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -74,10 +74,9 @@ func TestServiceMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "meta and extra meta",
-			opts: ServiceOpts{
+		),
+		Entry("meta and extra meta",
+			ServiceOpts{
 				ServiceTemplate: mariadbv1alpha1.ServiceTemplate{
 					Metadata: &mariadbv1alpha1.Metadata{
 						Labels: map[string]string{
@@ -98,7 +97,7 @@ func TestServiceMeta(t *testing.T) {
 				},
 				ExcludeSelectorLabels: true,
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -107,31 +106,23 @@ func TestServiceMeta(t *testing.T) {
 					"metallb.io/loadBalancerIPs": "172.18.0.20",
 				},
 			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			configMap, err := builder.BuildService(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
-			if err != nil {
-				t.Fatalf("unexpected error building Service: %v", err)
-			}
-			assertObjectMeta(t, &configMap.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+		),
+	)
+})
 
-func TestServicePorts(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ServicePorts", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "service",
 	}
-	tests := []struct {
-		name string
-		opts ServiceOpts
-	}{
-		{
-			name: "duplicated port names",
-			opts: ServiceOpts{
+
+	DescribeTable("should return an error building the Service",
+		func(opts ServiceOpts) {
+			_, err := builder.BuildService(key, &mariadbv1alpha1.MariaDB{}, opts)
+			Expect(err).To(HaveOccurred())
+		},
+		Entry("duplicated port names",
+			ServiceOpts{
 				Ports: []corev1.ServicePort{
 					{
 						Name: "mariadb",
@@ -144,10 +135,9 @@ func TestServicePorts(t *testing.T) {
 				},
 				ExcludeSelectorLabels: true,
 			},
-		},
-		{
-			name: "duplicated port numbers",
-			opts: ServiceOpts{
+		),
+		Entry("duplicated port numbers",
+			ServiceOpts{
 				Ports: []corev1.ServicePort{
 					{
 						Name: "mariadb",
@@ -160,64 +150,42 @@ func TestServicePorts(t *testing.T) {
 				},
 				ExcludeSelectorLabels: true,
 			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := builder.BuildService(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
-			if err == nil {
-				t.Errorf("expected error building Service but got success\n")
-			}
-		})
-	}
-}
+		),
+	)
+})
 
-func TestServiceLoadBalancerClass(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("ServiceLoadBalancerClass", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "service",
 	}
 	loadBalancerClass := "tailscale"
-	tests := []struct {
-		name                  string
-		opts                  ServiceOpts
-		wantLoadBalancerClass *string
-	}{
-		{
-			name: "no loadBalancerClass",
-			opts: ServiceOpts{
+
+	DescribeTable("should build the Service LoadBalancerClass",
+		func(opts ServiceOpts, wantLoadBalancerClass *string) {
+			svc, err := builder.BuildService(key, &mariadbv1alpha1.MariaDB{}, opts)
+			Expect(err).NotTo(HaveOccurred())
+			if wantLoadBalancerClass == nil {
+				Expect(svc.Spec.LoadBalancerClass).To(BeNil())
+			} else {
+				Expect(svc.Spec.LoadBalancerClass).NotTo(BeNil())
+				Expect(*svc.Spec.LoadBalancerClass).To(Equal(*wantLoadBalancerClass))
+			}
+		},
+		Entry("no loadBalancerClass",
+			ServiceOpts{
 				ExcludeSelectorLabels: true,
 			},
-			wantLoadBalancerClass: nil,
-		},
-		{
-			name: "with loadBalancerClass",
-			opts: ServiceOpts{
+			nil,
+		),
+		Entry("with loadBalancerClass",
+			ServiceOpts{
 				ServiceTemplate: mariadbv1alpha1.ServiceTemplate{
 					LoadBalancerClass: &loadBalancerClass,
 				},
 				ExcludeSelectorLabels: true,
 			},
-			wantLoadBalancerClass: &loadBalancerClass,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			svc, err := builder.BuildService(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
-			if err != nil {
-				t.Fatalf("unexpected error building Service: %v", err)
-			}
-			if tt.wantLoadBalancerClass == nil {
-				if svc.Spec.LoadBalancerClass != nil {
-					t.Errorf("expected nil LoadBalancerClass, got %v", *svc.Spec.LoadBalancerClass)
-				}
-			} else {
-				if svc.Spec.LoadBalancerClass == nil {
-					t.Errorf("expected LoadBalancerClass %v, got nil", *tt.wantLoadBalancerClass)
-				} else if *svc.Spec.LoadBalancerClass != *tt.wantLoadBalancerClass {
-					t.Errorf("expected LoadBalancerClass %v, got %v", *tt.wantLoadBalancerClass, *svc.Spec.LoadBalancerClass)
-				}
-			}
-		})
-	}
-}
+			&loadBalancerClass,
+		),
+	)
+})

--- a/pkg/builder/servicemonitor_builder_test.go
+++ b/pkg/builder/servicemonitor_builder_test.go
@@ -1,36 +1,37 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"k8s.io/utils/ptr"
 )
 
-func TestServiceMonitorMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
-	tests := []struct {
-		name     string
-		mariadb  *mariadbv1alpha1.MariaDB
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+var _ = Describe("ServiceMonitorMeta", func() {
+	builder := newDefaultTestBuilder()
+
+	DescribeTable("should build ServiceMonitor with expected meta",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantMeta *mariadbv1alpha1.Metadata) {
+			svcMonitor, err := builder.BuildServiceMonitor(mariadb)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&svcMonitor.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
 						Enabled: true,
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "with meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("with meta",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Metrics: &mariadbv1alpha1.MariadbMetrics{
 						Enabled: true,
@@ -45,7 +46,7 @@ func TestServiceMonitorMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -53,67 +54,27 @@ func TestServiceMonitorMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			svcMonitor, err := builder.BuildServiceMonitor(tt.mariadb)
-			if err != nil {
-				t.Fatalf("unexpected error building ServiceMonitor: %v", err)
-			}
-			assertObjectMeta(t, &svcMonitor.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+		),
+	)
+})
 
-func TestRoleRelabelConfig(t *testing.T) {
-	tests := []struct {
-		name            string
-		podIndex        int
-		primaryPodIndex *int
-		wantRole        string
-	}{
-		{
-			name:            "primary index is nil",
-			podIndex:        0,
-			primaryPodIndex: nil,
-			wantRole:        "",
-		},
-		{
-			name:            "pod is primary",
-			podIndex:        0,
-			primaryPodIndex: ptr.To(0),
-			wantRole:        "primary",
-		},
-		{
-			name:            "pod is replica",
-			podIndex:        1,
-			primaryPodIndex: ptr.To(0),
-			wantRole:        "replica",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			roleRelabelConfig := roleRelabelConfig(tt.podIndex, tt.primaryPodIndex)
-			if tt.wantRole == "" {
-				if roleRelabelConfig != nil {
-					t.Errorf("expected empty relabel config, got %v", roleRelabelConfig)
-				}
+var _ = Describe("RoleRelabelConfig", func() {
+	DescribeTable("should build the role relabel config",
+		func(podIndex int, primaryPodIndex *int, wantRole string) {
+			relabelConfig := roleRelabelConfig(podIndex, primaryPodIndex)
+			if wantRole == "" {
+				Expect(relabelConfig).To(BeNil())
 				return
 			}
-			if len(roleRelabelConfig) != 1 {
-				t.Fatalf("expected 1 relabel config, got %d", len(roleRelabelConfig))
-			}
-			cfg := roleRelabelConfig[0]
-			if cfg.Action != "replace" {
-				t.Errorf("expected action 'replace', got %q", cfg.Action)
-			}
-			if cfg.TargetLabel != "role" {
-				t.Errorf("expected target label 'role', got %q", cfg.TargetLabel)
-			}
-			if cfg.Replacement == nil || *cfg.Replacement != tt.wantRole {
-				t.Errorf("expected role %q, got %v", tt.wantRole, cfg.Replacement)
-			}
-		})
-	}
-}
+			Expect(relabelConfig).To(HaveLen(1))
+			cfg := relabelConfig[0]
+			Expect(cfg.Action).To(Equal("replace"))
+			Expect(cfg.TargetLabel).To(Equal("role"))
+			Expect(cfg.Replacement).NotTo(BeNil())
+			Expect(*cfg.Replacement).To(Equal(wantRole))
+		},
+		Entry("primary index is nil", 0, nil, ""),
+		Entry("pod is primary", 0, ptr.To(0), "primary"),
+		Entry("pod is replica", 1, ptr.To(0), "replica"),
+	)
+})

--- a/pkg/builder/sql_builder_test.go
+++ b/pkg/builder/sql_builder_test.go
@@ -1,35 +1,34 @@
 package builder
 
 import (
-	"reflect"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
 
-func TestUserMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("UserMeta", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "user",
 	}
-	tests := []struct {
-		name     string
-		opts     UserOpts
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			opts: UserOpts{},
-			wantMeta: &mariadbv1alpha1.Metadata{
+	DescribeTable("BuildUser meta",
+		func(opts UserOpts, wantMeta *mariadbv1alpha1.Metadata) {
+			user, err := builder.BuildUser(key, &mariadbv1alpha1.MariaDB{}, opts)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&user.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			UserOpts{},
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			opts: UserOpts{
+		),
+		Entry("meta",
+			UserOpts{
 				Metadata: &mariadbv1alpha1.Metadata{
 					Labels: map[string]string{
 						"database.myorg.io": "mariadb",
@@ -39,7 +38,7 @@ func TestUserMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -47,76 +46,54 @@ func TestUserMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			user, err := builder.BuildUser(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
-			if err != nil {
-				t.Fatalf("unexpected error building User: %v", err)
-			}
-			assertObjectMeta(t, &user.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+		),
+	)
+})
 
-func TestUserCleanupPolicy(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("UserCleanupPolicy", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "user",
 	}
-	tests := []struct {
-		name              string
-		opts              UserOpts
-		wantCleanupPolicy *mariadbv1alpha1.CleanupPolicy
-	}{
-		{
-			name:              "no cleanupPolicy",
-			opts:              UserOpts{},
-			wantCleanupPolicy: nil,
+	DescribeTable("BuildUser cleanupPolicy",
+		func(opts UserOpts, wantCleanupPolicy *mariadbv1alpha1.CleanupPolicy) {
+			user, err := builder.BuildUser(key, &mariadbv1alpha1.MariaDB{}, opts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(user.Spec.CleanupPolicy).To(Equal(wantCleanupPolicy))
 		},
-		{
-			name: "cleanupPolicy",
-			opts: UserOpts{
+		Entry("no cleanupPolicy",
+			UserOpts{},
+			nil,
+		),
+		Entry("cleanupPolicy",
+			UserOpts{
 				CleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
 			},
-			wantCleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			user, err := builder.BuildUser(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
-			if err != nil {
-				t.Fatalf("unexpected error building User: %v", err)
-			}
-			if !reflect.DeepEqual(user.Spec.CleanupPolicy, tt.wantCleanupPolicy) {
-				t.Errorf("unexpected cleanupPolicy: got: %v, want: %v", user.Spec.CleanupPolicy, tt.wantCleanupPolicy)
-			}
-		})
-	}
-}
+			ptr.To(mariadbv1alpha1.CleanupPolicySkip),
+		),
+	)
+})
 
-func TestGrantMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GrantMeta", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "grant",
 	}
-	tests := []struct {
-		name     string
-		opts     GrantOpts
-		wantMeta *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "no meta",
-			opts: GrantOpts{},
-			wantMeta: &mariadbv1alpha1.Metadata{
+	DescribeTable("BuildGrant meta",
+		func(opts GrantOpts, wantMeta *mariadbv1alpha1.Metadata) {
+			grant, err := builder.BuildGrant(key, &mariadbv1alpha1.MariaDB{}, opts)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&grant.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+		},
+		Entry("no meta",
+			GrantOpts{},
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "meta",
-			opts: GrantOpts{
+		),
+		Entry("meta",
+			GrantOpts{
 				Metadata: &mariadbv1alpha1.Metadata{
 					Labels: map[string]string{
 						"database.myorg.io": "mariadb",
@@ -126,7 +103,7 @@ func TestGrantMeta(t *testing.T) {
 					},
 				},
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -134,87 +111,54 @@ func TestGrantMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			grant, err := builder.BuildGrant(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
-			if err != nil {
-				t.Fatalf("unexpected error building Grant: %v", err)
-			}
-			assertObjectMeta(t, &grant.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-		})
-	}
-}
+		),
+	)
+})
 
-func TestGrantCleanupPolicy(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("GrantCleanupPolicy", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "grant",
 	}
-	tests := []struct {
-		name              string
-		opts              GrantOpts
-		wantCleanupPolicy *mariadbv1alpha1.CleanupPolicy
-	}{
-		{
-			name:              "no cleanupPolicy",
-			opts:              GrantOpts{},
-			wantCleanupPolicy: nil,
+	DescribeTable("BuildGrant cleanupPolicy",
+		func(opts GrantOpts, wantCleanupPolicy *mariadbv1alpha1.CleanupPolicy) {
+			grant, err := builder.BuildGrant(key, &mariadbv1alpha1.MariaDB{}, opts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(grant.Spec.CleanupPolicy).To(Equal(wantCleanupPolicy))
 		},
-		{
-			name: "cleanupPolicy",
-			opts: GrantOpts{
+		Entry("no cleanupPolicy",
+			GrantOpts{},
+			nil,
+		),
+		Entry("cleanupPolicy",
+			GrantOpts{
 				CleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
 			},
-			wantCleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			grant, err := builder.BuildGrant(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
-			if err != nil {
-				t.Fatalf("unexpected error building Grant: %v", err)
-			}
-			if !reflect.DeepEqual(grant.Spec.CleanupPolicy, tt.wantCleanupPolicy) {
-				t.Errorf("unexpected cleanupPolicy: got: %v, want: %v", grant.Spec.CleanupPolicy, tt.wantCleanupPolicy)
-			}
-		})
-	}
-}
+			ptr.To(mariadbv1alpha1.CleanupPolicySkip),
+		),
+	)
+})
 
-func TestDatabaseCleanupPolicy(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("DatabaseCleanupPolicy", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name: "database",
 	}
-	tests := []struct {
-		name              string
-		opts              DatabaseOpts
-		wantCleanupPolicy *mariadbv1alpha1.CleanupPolicy
-	}{
-		{
-			name:              "no cleanupPolicy",
-			opts:              DatabaseOpts{},
-			wantCleanupPolicy: nil,
+	DescribeTable("BuildDatabase cleanupPolicy",
+		func(opts DatabaseOpts, wantCleanupPolicy *mariadbv1alpha1.CleanupPolicy) {
+			database, err := builder.BuildDatabase(key, &mariadbv1alpha1.MariaDB{}, opts)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(database.Spec.CleanupPolicy).To(Equal(wantCleanupPolicy))
 		},
-		{
-			name: "cleanupPolicy",
-			opts: DatabaseOpts{
+		Entry("no cleanupPolicy",
+			DatabaseOpts{},
+			nil,
+		),
+		Entry("cleanupPolicy",
+			DatabaseOpts{
 				CleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
 			},
-			wantCleanupPolicy: ptr.To(mariadbv1alpha1.CleanupPolicySkip),
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			database, err := builder.BuildDatabase(key, &mariadbv1alpha1.MariaDB{}, tt.opts)
-			if err != nil {
-				t.Fatalf("unexpected error building Database: %v", err)
-			}
-			if !reflect.DeepEqual(database.Spec.CleanupPolicy, tt.wantCleanupPolicy) {
-				t.Errorf("unexpected cleanupPolicy: got: %v, want: %v", database.Spec.CleanupPolicy, tt.wantCleanupPolicy)
-			}
-		})
-	}
-}
+			ptr.To(mariadbv1alpha1.CleanupPolicySkip),
+		),
+	)
+})

--- a/pkg/builder/statefulset_builder_test.go
+++ b/pkg/builder/statefulset_builder_test.go
@@ -1,8 +1,8 @@
 package builder
 
 import (
-	"reflect"
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	galeraresources "github.com/mariadb-operator/mariadb-operator/v26/pkg/controller/galera/resources"
@@ -19,21 +19,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func TestMariadbImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MariadbImagePullSecrets", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name:      "mariadb-image-pull-secrets",
 		Namespace: "test",
 	}
 
-	tests := []struct {
-		name            string
-		mariadb         *mariadbv1alpha1.MariaDB
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			mariadb: &mariadbv1alpha1.MariaDB{
+	DescribeTable("should build the expected ImagePullSecrets",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantPullSecrets []corev1.LocalObjectReference) {
+			job, err := builder.BuildMariadbStatefulSet(mariadb, client.ObjectKeyFromObject(mariadb), nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry("No Secrets",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					UpdateStrategy: mariadbv1alpha1.UpdateStrategy{
@@ -41,11 +41,10 @@ func TestMariadbImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MariaDB",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+		),
+		Entry("Secrets in MariaDB",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -60,50 +59,37 @@ func TestMariadbImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "mariadb-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildMariadbStatefulSet(tt.mariadb, client.ObjectKeyFromObject(tt.mariadb), nil, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building StatefulSet: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestMaxScaleImagePullSecrets(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MaxScaleImagePullSecrets", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name:      "maxscale-image-pull-secrets",
 		Namespace: "test",
 	}
 
-	tests := []struct {
-		name            string
-		maxScale        *mariadbv1alpha1.MaxScale
-		wantPullSecrets []corev1.LocalObjectReference
-	}{
-		{
-			name: "No Secrets",
-			maxScale: &mariadbv1alpha1.MaxScale{
+	DescribeTable("should build the expected ImagePullSecrets",
+		func(maxScale *mariadbv1alpha1.MaxScale, wantPullSecrets []corev1.LocalObjectReference) {
+			job, err := builder.BuildMaxscaleStatefulSet(maxScale, client.ObjectKeyFromObject(maxScale), nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(job.Spec.Template.Spec.ImagePullSecrets).To(Equal(wantPullSecrets))
+		},
+		Entry("No Secrets",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec:       mariadbv1alpha1.MaxScaleSpec{},
 			},
-			wantPullSecrets: nil,
-		},
-		{
-			name: "Secrets in MaxScale",
-			maxScale: &mariadbv1alpha1.MaxScale{
+			nil,
+		),
+		Entry("Secrets in MaxScale",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					MaxScalePodTemplate: mariadbv1alpha1.MaxScalePodTemplate{
@@ -115,45 +101,34 @@ func TestMaxScaleImagePullSecrets(t *testing.T) {
 					},
 				},
 			},
-			wantPullSecrets: []corev1.LocalObjectReference{
+			[]corev1.LocalObjectReference{
 				{
 					Name: "maxscale-registry",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			job, err := builder.BuildMaxscaleStatefulSet(tt.maxScale, client.ObjectKeyFromObject(tt.maxScale), nil)
-			if err != nil {
-				t.Fatalf("unexpected error building StatefulSet: %v", err)
-			}
-			if !reflect.DeepEqual(tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets) {
-				t.Errorf("unexpected ImagePullSecrets, want: %v  got: %v", tt.wantPullSecrets, job.Spec.Template.Spec.ImagePullSecrets)
-			}
-		})
-	}
-}
-
-func TestMariaDBStatefulSetMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MariaDBStatefulSetMeta", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name: "mariadb-obj",
 	}
 	key := types.NamespacedName{
 		Name: "mariadb-obj",
 	}
-	tests := []struct {
-		name           string
-		mariadb        *mariadbv1alpha1.MariaDB
-		podAnnotations map[string]string
-		wantMeta       *mariadbv1alpha1.Metadata
-		wantPodMeta    *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			mariadb: &mariadbv1alpha1.MariaDB{
+
+	DescribeTable("should build the expected meta",
+		func(mariadb *mariadbv1alpha1.MariaDB, podAnnotations map[string]string,
+			wantMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			sts, err := builder.BuildMariadbStatefulSet(mariadb, key, podAnnotations, nil)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&sts.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+			assertObjectMeta(&sts.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					UpdateStrategy: mariadbv1alpha1.UpdateStrategy{
@@ -161,22 +136,21 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "mariadb-obj",
 					"app.kubernetes.io/name":     "mariadb",
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit meta",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("inherit meta",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -192,8 +166,8 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -201,7 +175,7 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject":    "false",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -211,10 +185,9 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "HA",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("HA",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Galera: &mariadbv1alpha1.Galera{
@@ -225,15 +198,15 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{},
 				Annotations: map[string]string{
 					"k8s.mariadb.com/mariadb": "mariadb-obj",
 					"k8s.mariadb.com/galera":  "",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "mariadb-obj",
 					"app.kubernetes.io/name":     "mariadb",
@@ -243,10 +216,9 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					"k8s.mariadb.com/galera":  "",
 				},
 			},
-		},
-		{
-			name: "Pod annotations",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("Pod annotations",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
@@ -261,14 +233,14 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: map[string]string{
+			map[string]string{
 				"k8s.mariadb.com/config": "config-hash",
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "mariadb-obj",
 					"app.kubernetes.io/name":     "mariadb",
@@ -278,10 +250,9 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					"k8s.mariadb.com/config":   "config-hash",
 				},
 			},
-		},
-		{
-			name: "all",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("all",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -307,10 +278,10 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: map[string]string{
+			map[string]string{
 				"k8s.mariadb.com/config": "config-hash",
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io": "mariadb",
 				},
@@ -320,7 +291,7 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					"k8s.mariadb.com/galera":  "",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"database.myorg.io":          "mariadb",
 					"app.kubernetes.io/instance": "mariadb-obj",
@@ -334,42 +305,34 @@ func TestMariaDBStatefulSetMeta(t *testing.T) {
 					"k8s.mariadb.com/config":   "config-hash",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sts, err := builder.BuildMariadbStatefulSet(tt.mariadb, key, tt.podAnnotations, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building MariaDB StatefulSet: %v", err)
-			}
-			assertObjectMeta(t, &sts.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-			assertObjectMeta(t, &sts.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestMariaDBUpdateStrategy(t *testing.T) {
+var _ = Describe("MariaDBUpdateStrategy", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "mariadb-obj",
 	}
-	tests := []struct {
-		name               string
-		mariadb            *mariadbv1alpha1.MariaDB
-		wantUpdateStrategy *appsv1.StatefulSetUpdateStrategy
-		wantErr            bool
-	}{
-		{
-			name: "empty",
-			mariadb: &mariadbv1alpha1.MariaDB{
+
+	DescribeTable("should build the expected update strategy",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantUpdateStrategy *appsv1.StatefulSetUpdateStrategy, wantErr bool) {
+			stsStrategy, err := mariadbUpdateStrategy(mariadb)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+			Expect(stsStrategy).To(Equal(wantUpdateStrategy))
+		},
+		Entry("empty",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 			},
-			wantUpdateStrategy: nil,
-			wantErr:            true,
-		},
-		{
-			name: "replicas first primary last",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			nil,
+			true,
+		),
+		Entry("replicas first primary last",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					UpdateStrategy: mariadbv1alpha1.UpdateStrategy{
@@ -377,14 +340,13 @@ func TestMariaDBUpdateStrategy(t *testing.T) {
 					},
 				},
 			},
-			wantUpdateStrategy: &appsv1.StatefulSetUpdateStrategy{
+			&appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},
-			wantErr: false,
-		},
-		{
-			name: "rolling update",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("rolling update",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					UpdateStrategy: mariadbv1alpha1.UpdateStrategy{
@@ -395,17 +357,16 @@ func TestMariaDBUpdateStrategy(t *testing.T) {
 					},
 				},
 			},
-			wantUpdateStrategy: &appsv1.StatefulSetUpdateStrategy{
+			&appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
 					MaxUnavailable: ptr.To(intstr.FromInt(1)),
 				},
 			},
-			wantErr: false,
-		},
-		{
-			name: "on delete",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("on delete",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					UpdateStrategy: mariadbv1alpha1.UpdateStrategy{
@@ -413,14 +374,13 @@ func TestMariaDBUpdateStrategy(t *testing.T) {
 					},
 				},
 			},
-			wantUpdateStrategy: &appsv1.StatefulSetUpdateStrategy{
+			&appsv1.StatefulSetUpdateStrategy{
 				Type: appsv1.OnDeleteStatefulSetStrategyType,
 			},
-			wantErr: false,
-		},
-		{
-			name: "never",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			false,
+		),
+		Entry("never",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					UpdateStrategy: mariadbv1alpha1.UpdateStrategy{
@@ -428,53 +388,19 @@ func TestMariaDBUpdateStrategy(t *testing.T) {
 					},
 				},
 			},
-			wantUpdateStrategy: &appsv1.StatefulSetUpdateStrategy{},
-			wantErr:            false,
-		},
-	}
+			&appsv1.StatefulSetUpdateStrategy{},
+			false,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			stsStrategy, err := mariadbUpdateStrategy(tt.mariadb)
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected error building update strategy: %v", err)
-			}
-			if tt.wantErr && err == nil {
-				t.Errorf("expected error building update strategy, got nil")
-			}
-			if !reflect.DeepEqual(tt.wantUpdateStrategy, stsStrategy) {
-				t.Errorf("expecting mariadbUpdateStrategy returned value to be:\n%v\ngot:\n%v\n", tt.wantUpdateStrategy, stsStrategy)
-			}
-		})
-	}
-}
-
-func TestMariaDBPVCRetentionPolicy(t *testing.T) {
-	tests := []struct {
-		name       string
-		gitVersion string
-		wantSet    bool
-	}{
-		{
-			name:       "supported kubernetes version",
-			gitVersion: "v1.32.0",
-			wantSet:    true,
-		},
-		{
-			name:       "unsupported kubernetes version",
-			gitVersion: "v1.31.0",
-			wantSet:    false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+var _ = Describe("MariaDBPVCRetentionPolicy", func() {
+	DescribeTable("should set the expected PVC retention policy",
+		func(gitVersion string, wantSet bool) {
 			discoveryClient, err := discovery.NewFakeDiscoveryWithServerVersion(&version.Info{
-				GitVersion: tt.gitVersion,
+				GitVersion: gitVersion,
 			})
-			if err != nil {
-				t.Fatalf("unexpected error creating discovery: %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
 			builder := newTestBuilder(discoveryClient)
 			mariadb := &mariadbv1alpha1.MariaDB{
 				ObjectMeta: metav1.ObjectMeta{Name: "mariadb-obj"},
@@ -492,63 +418,59 @@ func TestMariaDBPVCRetentionPolicy(t *testing.T) {
 			}
 
 			sts, err := builder.BuildMariadbStatefulSet(mariadb, client.ObjectKeyFromObject(mariadb), nil, nil)
-			if err != nil {
-				t.Fatalf("unexpected error building StatefulSet: %v", err)
-			}
+			Expect(err).NotTo(HaveOccurred())
 
-			if tt.wantSet {
-				if sts.Spec.PersistentVolumeClaimRetentionPolicy == nil {
-					t.Fatal("expected pvcRetentionPolicy to be set")
-				}
-				if sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted != appsv1.DeletePersistentVolumeClaimRetentionPolicyType {
-					t.Errorf("unexpected whenDeleted value: %v", sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted)
-				}
-				if sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled != appsv1.RetainPersistentVolumeClaimRetentionPolicyType {
-					t.Errorf("unexpected whenScaled value: %v", sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled)
-				}
-			} else if sts.Spec.PersistentVolumeClaimRetentionPolicy != nil {
-				t.Fatal("expected pvcRetentionPolicy to be omitted for unsupported versions")
+			if wantSet {
+				Expect(sts.Spec.PersistentVolumeClaimRetentionPolicy).NotTo(BeNil())
+				Expect(sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted).
+					To(Equal(appsv1.DeletePersistentVolumeClaimRetentionPolicyType))
+				Expect(sts.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled).
+					To(Equal(appsv1.RetainPersistentVolumeClaimRetentionPolicyType))
+			} else {
+				Expect(sts.Spec.PersistentVolumeClaimRetentionPolicy).To(BeNil())
 			}
-		})
-	}
-}
+		},
+		Entry("supported kubernetes version", "v1.32.0", true),
+		Entry("unsupported kubernetes version", "v1.31.0", false),
+	)
+})
 
-func TestMaxScaleStatefulSetMeta(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("MaxScaleStatefulSetMeta", func() {
+	builder := newDefaultTestBuilder()
 	objMeta := metav1.ObjectMeta{
 		Name: "maxscale-obj",
 	}
 	key := types.NamespacedName{
 		Name: "maxscale-obj",
 	}
-	tests := []struct {
-		name           string
-		maxscale       *mariadbv1alpha1.MaxScale
-		podAnnotations map[string]string
-		wantMeta       *mariadbv1alpha1.Metadata
-		wantPodMeta    *mariadbv1alpha1.Metadata
-	}{
-		{
-			name: "empty",
-			maxscale: &mariadbv1alpha1.MaxScale{
+
+	DescribeTable("should build the expected meta",
+		func(maxscale *mariadbv1alpha1.MaxScale, podAnnotations map[string]string,
+			wantMeta *mariadbv1alpha1.Metadata, wantPodMeta *mariadbv1alpha1.Metadata) {
+			sts, err := builder.BuildMaxscaleStatefulSet(maxscale, key, podAnnotations)
+			Expect(err).NotTo(HaveOccurred())
+			assertObjectMeta(&sts.ObjectMeta, wantMeta.Labels, wantMeta.Annotations)
+			assertObjectMeta(&sts.Spec.Template.ObjectMeta, wantPodMeta.Labels, wantPodMeta.Annotations)
+		},
+		Entry("empty",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 			},
-			podAnnotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "maxscale-obj",
 					"app.kubernetes.io/name":     "maxscale",
 				},
 				Annotations: map[string]string{},
 			},
-		},
-		{
-			name: "inherit meta",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("inherit meta",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MaxScaleSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -561,8 +483,8 @@ func TestMaxScaleStatefulSetMeta(t *testing.T) {
 					},
 				},
 			},
-			podAnnotations: nil,
-			wantMeta: &mariadbv1alpha1.Metadata{
+			nil,
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"sidecar.istio.io/inject": "false",
 				},
@@ -570,7 +492,7 @@ func TestMaxScaleStatefulSetMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "maxscale-obj",
 					"app.kubernetes.io/name":     "maxscale",
@@ -580,20 +502,19 @@ func TestMaxScaleStatefulSetMeta(t *testing.T) {
 					"database.myorg.io": "mariadb",
 				},
 			},
-		},
-		{
-			name: "Pod annotations",
-			maxscale: &mariadbv1alpha1.MaxScale{
+		),
+		Entry("Pod annotations",
+			&mariadbv1alpha1.MaxScale{
 				ObjectMeta: objMeta,
 			},
-			podAnnotations: map[string]string{
+			map[string]string{
 				metadata.TLSServerCertAnnotation: "cert",
 			},
-			wantMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels:      map[string]string{},
 				Annotations: map[string]string{},
 			},
-			wantPodMeta: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Labels: map[string]string{
 					"app.kubernetes.io/instance": "maxscale-obj",
 					"app.kubernetes.io/name":     "maxscale",
@@ -602,33 +523,25 @@ func TestMaxScaleStatefulSetMeta(t *testing.T) {
 					metadata.TLSServerCertAnnotation: "cert",
 				},
 			},
-		},
-	}
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			sts, err := builder.BuildMaxscaleStatefulSet(tt.maxscale, key, tt.podAnnotations)
-			if err != nil {
-				t.Fatalf("unexpected error building MaxScale StatefulSet: %v", err)
-			}
-			assertObjectMeta(t, &sts.ObjectMeta, tt.wantMeta.Labels, tt.wantMeta.Annotations)
-			assertObjectMeta(t, &sts.Spec.Template.ObjectMeta, tt.wantPodMeta.Labels, tt.wantPodMeta.Annotations)
-		})
-	}
-}
-
-func TestMariaDBVolumeClaimTemplates(t *testing.T) {
+var _ = Describe("MariaDBVolumeClaimTemplates", func() {
 	objMeta := metav1.ObjectMeta{
 		Name: "mariadb-obj",
 	}
-	tests := []struct {
-		name        string
-		mariadb     *mariadbv1alpha1.MariaDB
-		wantVolumes []string
-	}{
-		{
-			name: "ephemeral",
-			mariadb: &mariadbv1alpha1.MariaDB{
+
+	DescribeTable("should build the expected volume claim templates",
+		func(mariadb *mariadbv1alpha1.MariaDB, wantVolumes []string) {
+			pvcs := mariadbVolumeClaimTemplates(mariadb)
+			Expect(pvcs).To(HaveLen(len(wantVolumes)))
+			for _, wantVolume := range wantVolumes {
+				Expect(hasVolume(pvcs, wantVolume)).To(BeTrue())
+			}
+		},
+		Entry("ephemeral",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Storage: mariadbv1alpha1.Storage{
@@ -636,11 +549,10 @@ func TestMariaDBVolumeClaimTemplates(t *testing.T) {
 					},
 				},
 			},
-			wantVolumes: []string{},
-		},
-		{
-			name: "standalone",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			[]string{},
+		),
+		Entry("standalone",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Storage: mariadbv1alpha1.Storage{
@@ -660,11 +572,10 @@ func TestMariaDBVolumeClaimTemplates(t *testing.T) {
 					},
 				},
 			},
-			wantVolumes: []string{StorageVolume},
-		},
-		{
-			name: "replication",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			[]string{StorageVolume},
+		),
+		Entry("replication",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Storage: mariadbv1alpha1.Storage{
@@ -687,11 +598,10 @@ func TestMariaDBVolumeClaimTemplates(t *testing.T) {
 					},
 				},
 			},
-			wantVolumes: []string{StorageVolume},
-		},
-		{
-			name: "galera",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			[]string{StorageVolume},
+		),
+		Entry("galera",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Storage: mariadbv1alpha1.Storage{
@@ -730,11 +640,10 @@ func TestMariaDBVolumeClaimTemplates(t *testing.T) {
 					},
 				},
 			},
-			wantVolumes: []string{StorageVolume, galeraresources.GaleraConfigVolume},
-		},
-		{
-			name: "galera reuse storage",
-			mariadb: &mariadbv1alpha1.MariaDB{
+			[]string{StorageVolume, galeraresources.GaleraConfigVolume},
+		),
+		Entry("galera reuse storage",
+			&mariadbv1alpha1.MariaDB{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Storage: mariadbv1alpha1.Storage{
@@ -762,24 +671,10 @@ func TestMariaDBVolumeClaimTemplates(t *testing.T) {
 					},
 				},
 			},
-			wantVolumes: []string{StorageVolume},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			pvcs := mariadbVolumeClaimTemplates(tt.mariadb)
-			if len(pvcs) != len(tt.wantVolumes) {
-				t.Errorf("unexpected number of PVCs, got: %v, want: %v", len(pvcs), len(tt.wantVolumes))
-			}
-			for _, wantVolume := range tt.wantVolumes {
-				if !hasVolume(pvcs, wantVolume) {
-					t.Errorf("expecting Volume \"%s\", but it was not found", wantVolume)
-				}
-			}
-		})
-	}
-}
+			[]string{StorageVolume},
+		),
+	)
+})
 
 func hasVolume(pvcs []corev1.PersistentVolumeClaim, volumeName string) bool {
 	for _, p := range pvcs {

--- a/pkg/builder/suite_test.go
+++ b/pkg/builder/suite_test.go
@@ -1,0 +1,13 @@
+package builder
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBuilder(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Builder Suite")
+}

--- a/pkg/builder/volumesnapshot_builder_test.go
+++ b/pkg/builder/volumesnapshot_builder_test.go
@@ -1,28 +1,31 @@
 package builder
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/metadata"
-	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-func TestInvalidVolumeSnapshot(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("InvalidVolumeSnapshot", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{Name: "test-snapshot", Namespace: "test-ns"}
 	pvcKey := types.NamespacedName{Name: "test-pvc"}
 
-	tests := []struct {
-		name    string
-		backup  *mariadbv1alpha1.PhysicalBackup
-		wantErr bool
-	}{
-		{
-			name: "VolumeSnapshot is nil returns error",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+	DescribeTable("BuildVolumeSnapshot",
+		func(backup *mariadbv1alpha1.PhysicalBackup, wantErr bool) {
+			_, err := builder.BuildVolumeSnapshot(key, backup, pvcKey, nil)
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		Entry("VolumeSnapshot is nil returns error",
+			&mariadbv1alpha1.PhysicalBackup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "backup-obj",
 					Namespace: "test-ns",
@@ -34,11 +37,10 @@ func TestInvalidVolumeSnapshot(t *testing.T) {
 					},
 				},
 			},
-			wantErr: true,
-		},
-		{
-			name: "VolumeSnapshot no error",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+			true,
+		),
+		Entry("VolumeSnapshot no error",
+			&mariadbv1alpha1.PhysicalBackup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "backup-obj",
 					Namespace: "test-ns",
@@ -52,24 +54,13 @@ func TestInvalidVolumeSnapshot(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
-		},
-	}
+			false,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := builder.BuildVolumeSnapshot(key, tt.backup, pvcKey, nil)
-			if tt.wantErr {
-				assert.Error(t, err, "expected error")
-			} else {
-				assert.NoError(t, err, "unexpected error")
-			}
-		})
-	}
-}
-
-func TestVolumeSnapshotMetadata(t *testing.T) {
-	builder := newDefaultTestBuilder(t)
+var _ = Describe("VolumeSnapshotMetadata", func() {
+	builder := newDefaultTestBuilder()
 	key := types.NamespacedName{
 		Name:      "test-snapshot",
 		Namespace: "test",
@@ -82,16 +73,27 @@ func TestVolumeSnapshotMetadata(t *testing.T) {
 		Namespace: "test",
 	}
 
-	tests := []struct {
-		name            string
-		backup          *mariadbv1alpha1.PhysicalBackup
-		metadata        *mariadbv1alpha1.Metadata
-		wantLabels      map[string]string
-		wantAnnotations map[string]string
-	}{
-		{
-			name: "No metadata",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+	DescribeTable("BuildVolumeSnapshot",
+		func(backup *mariadbv1alpha1.PhysicalBackup, meta *mariadbv1alpha1.Metadata,
+			wantLabels, wantAnnotations map[string]string) {
+			snapshot, err := builder.BuildVolumeSnapshot(key, backup, pvcKey, meta)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(snapshot).NotTo(BeNil())
+			Expect(snapshot.Name).To(Equal(key.Name))
+			Expect(snapshot.Namespace).To(Equal(key.Namespace))
+			Expect(*snapshot.Spec.VolumeSnapshotClassName).To(Equal("test-class"))
+			Expect(snapshot.Spec.Source.PersistentVolumeClaimName).NotTo(BeNil())
+			Expect(*snapshot.Spec.Source.PersistentVolumeClaimName).To(Equal(pvcKey.Name))
+
+			for k, v := range wantLabels {
+				Expect(snapshot.Labels[k]).To(Equal(v))
+			}
+			for k, v := range wantAnnotations {
+				Expect(snapshot.Annotations[k]).To(Equal(v))
+			}
+		},
+		Entry("No metadata",
+			&mariadbv1alpha1.PhysicalBackup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "backup-obj",
 					Namespace: "test-ns",
@@ -107,15 +109,14 @@ func TestVolumeSnapshotMetadata(t *testing.T) {
 					},
 				},
 			},
-			metadata: nil,
-			wantLabels: map[string]string{
+			nil,
+			map[string]string{
 				metadata.PhysicalBackupNameLabel: "backup-obj",
 			},
-			wantAnnotations: map[string]string{},
-		},
-		{
-			name: "Only snapshot metadata",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+			map[string]string{},
+		),
+		Entry("Only snapshot metadata",
+			&mariadbv1alpha1.PhysicalBackup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "backup-obj",
 					Namespace: "test-ns",
@@ -138,18 +139,17 @@ func TestVolumeSnapshotMetadata(t *testing.T) {
 					},
 				},
 			},
-			metadata: nil,
-			wantLabels: map[string]string{
+			nil,
+			map[string]string{
 				"snapshot-label":                 "snapshot-value",
 				metadata.PhysicalBackupNameLabel: "backup-obj",
 			},
-			wantAnnotations: map[string]string{
+			map[string]string{
 				"snapshot-annotation": "snapshot-annotation-value",
 			},
-		},
-		{
-			name: "Only inherit metadata",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+		),
+		Entry("Only inherit metadata",
+			&mariadbv1alpha1.PhysicalBackup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "backup-obj",
 					Namespace: "test-ns",
@@ -172,18 +172,17 @@ func TestVolumeSnapshotMetadata(t *testing.T) {
 					},
 				},
 			},
-			metadata: nil,
-			wantLabels: map[string]string{
+			nil,
+			map[string]string{
 				"custom-label":                   "custom-value",
 				metadata.PhysicalBackupNameLabel: "backup-obj",
 			},
-			wantAnnotations: map[string]string{
+			map[string]string{
 				"custom-annotation": "custom-annotation-value",
 			},
-		},
-		{
-			name: "Inherit and snapshot metadata merged",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+		),
+		Entry("Inherit and snapshot metadata merged",
+			&mariadbv1alpha1.PhysicalBackup{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					InheritMetadata: &mariadbv1alpha1.Metadata{
@@ -209,20 +208,19 @@ func TestVolumeSnapshotMetadata(t *testing.T) {
 					},
 				},
 			},
-			metadata: nil,
-			wantLabels: map[string]string{
+			nil,
+			map[string]string{
 				"custom-label":                   "custom-value",
 				"snapshot-label":                 "snapshot-value",
 				metadata.PhysicalBackupNameLabel: "backup-obj",
 			},
-			wantAnnotations: map[string]string{
+			map[string]string{
 				"custom-annotation":   "custom-annotation-value",
 				"snapshot-annotation": "snapshot-annotation-value",
 			},
-		},
-		{
-			name: "Metadata by argument",
-			backup: &mariadbv1alpha1.PhysicalBackup{
+		),
+		Entry("Metadata by argument",
+			&mariadbv1alpha1.PhysicalBackup{
 				ObjectMeta: objMeta,
 				Spec: mariadbv1alpha1.PhysicalBackupSpec{
 					Storage: mariadbv1alpha1.PhysicalBackupStorage{
@@ -240,37 +238,17 @@ func TestVolumeSnapshotMetadata(t *testing.T) {
 					},
 				},
 			},
-			metadata: &mariadbv1alpha1.Metadata{
+			&mariadbv1alpha1.Metadata{
 				Annotations: map[string]string{
 					metadata.GtidAnnotation: "0-10-1897",
 				},
 			},
-			wantLabels: map[string]string{
+			map[string]string{
 				metadata.PhysicalBackupNameLabel: "backup-obj",
 			},
-			wantAnnotations: map[string]string{
+			map[string]string{
 				metadata.GtidAnnotation: "0-10-1897",
 			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			snapshot, err := builder.BuildVolumeSnapshot(key, tt.backup, pvcKey, tt.metadata)
-			assert.NoError(t, err, "unexpected error building VolumeSnapshot")
-			assert.NotNil(t, snapshot, "expected snapshot to be created")
-			assert.Equal(t, key.Name, snapshot.Name)
-			assert.Equal(t, key.Namespace, snapshot.Namespace)
-			assert.Equal(t, "test-class", *snapshot.Spec.VolumeSnapshotClassName)
-			assert.NotNil(t, snapshot.Spec.Source.PersistentVolumeClaimName)
-			assert.Equal(t, pvcKey.Name, *snapshot.Spec.Source.PersistentVolumeClaimName)
-
-			for k, v := range tt.wantLabels {
-				assert.Equal(t, v, snapshot.Labels[k], "expected label %s to be %s", k, v)
-			}
-			for k, v := range tt.wantAnnotations {
-				assert.Equal(t, v, snapshot.Annotations[k], "expected annotation %s to be %s", k, v)
-			}
-		})
-	}
-}
+		),
+	)
+})


### PR DESCRIPTION
Migrates `pkg/builder` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified relative to the base branch.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- 21 `*_builder_test.go` files converted to `Describe` blocks with `DescribeTable` specs (326 entries). Entry/spec names match the original test / `t.Run()` names.

Verified with:
```
go test ./pkg/builder/...
```

Part of #368.
