### PR TITLE
test: migrate pkg/agent/handler tests to Ginkgo

### DIFF
--- a/pkg/agent/handler/environment_test.go
+++ b/pkg/agent/handler/environment_test.go
@@ -6,91 +6,81 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"testing"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/environment"
 	mdbhttp "github.com/mariadb-operator/mariadb-operator/v26/pkg/http"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestSetValue(t *testing.T) {
-	testCases := []struct {
-		name               string
-		requestBody        interface{}
-		expectedStatusCode int
-		expectedResponse   map[string]string
-		expectFieldUpdate  bool
-		updatedValue       string
-		initialPassword    string
-	}{
-		{
-			name: "Successful Update",
-			requestBody: map[string]string{
-				"key":   "MARIADB_ROOT_PASSWORD",
-				"value": "new-password",
-			},
-			expectedStatusCode: http.StatusOK,
-			expectedResponse: map[string]string{
-				"message": "'MARIADB_ROOT_PASSWORD' set successfully",
-			},
-			expectFieldUpdate: true,
-			updatedValue:      "new-password",
-			initialPassword:   "initial-password",
-		},
-		{
-			name: "Key Not Found",
-			requestBody: map[string]string{
-				"key":   "NON_EXISTENT_KEY",
-				"value": "some-value",
-			},
-			expectedStatusCode: http.StatusNotFound,
-			expectedResponse: map[string]string{
-				"message": "key 'NON_EXISTENT_KEY' not found",
-			},
-			expectFieldUpdate: false,
-			initialPassword:   "initial-password",
-		},
-		{
-			name:               "Invalid Request Body - Malformed JSON",
-			requestBody:        "invalid-json",
-			expectedStatusCode: http.StatusBadRequest,
-			expectedResponse: map[string]string{
-				"message": "json: cannot unmarshal string into Go value of type handler.setValueRequest",
-			},
-			expectFieldUpdate: false,
-			initialPassword:   "initial-password",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+var _ = Describe("EnvironmentHandler", func() {
+	DescribeTable("SetValue",
+		func(requestBody interface{}, expectedStatusCode int, expectedResponse map[string]string,
+			expectFieldUpdate bool, updatedValue, initialPassword string) {
 			podEnv := &environment.PodEnvironment{
-				MariadbRootPassword: tc.initialPassword,
+				MariadbRootPassword: initialPassword,
 			}
 			logger := logr.Discard()
 			responseWriter := mdbhttp.NewResponseWriter(&logger)
 			handler := NewEnvironmentHandler(podEnv, responseWriter, &logger).(*EnvironmentHandler)
 
-			bodyBytes, _ := json.Marshal(tc.requestBody)
+			bodyBytes, _ := json.Marshal(requestBody)
 			req := httptest.NewRequestWithContext(context.Background(), "PUT", "/environment", bytes.NewBuffer(bodyBytes))
 			req.Header.Set("Content-Type", "application/json")
 			rr := httptest.NewRecorder()
 
 			handler.SetValue(rr, req)
 
-			assert.Equal(t, tc.expectedStatusCode, rr.Code, "status code should match")
+			Expect(rr.Code).To(Equal(expectedStatusCode))
 
 			var responseBody map[string]string
 			err := json.Unmarshal(rr.Body.Bytes(), &responseBody)
-			assert.NoError(t, err, "response body should be valid json")
-			assert.Equal(t, tc.expectedResponse, responseBody, "response body should match")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(responseBody).To(Equal(expectedResponse))
 
-			if tc.expectFieldUpdate {
-				assert.Equal(t, tc.updatedValue, podEnv.MariadbRootPassword, "field should be updated")
+			if expectFieldUpdate {
+				Expect(podEnv.MariadbRootPassword).To(Equal(updatedValue))
 			} else {
-				assert.Equal(t, tc.initialPassword, podEnv.MariadbRootPassword, "field should not be updated")
+				Expect(podEnv.MariadbRootPassword).To(Equal(initialPassword))
 			}
-		})
-	}
-}
+		},
+		Entry("Successful Update",
+			map[string]string{
+				"key":   "MARIADB_ROOT_PASSWORD",
+				"value": "new-password",
+			},
+			http.StatusOK,
+			map[string]string{
+				"message": "'MARIADB_ROOT_PASSWORD' set successfully",
+			},
+			true,
+			"new-password",
+			"initial-password",
+		),
+		Entry("Key Not Found",
+			map[string]string{
+				"key":   "NON_EXISTENT_KEY",
+				"value": "some-value",
+			},
+			http.StatusNotFound,
+			map[string]string{
+				"message": "key 'NON_EXISTENT_KEY' not found",
+			},
+			false,
+			"",
+			"initial-password",
+		),
+		Entry("Invalid Request Body - Malformed JSON",
+			"invalid-json",
+			http.StatusBadRequest,
+			map[string]string{
+				"message": "json: cannot unmarshal string into Go value of type handler.setValueRequest",
+			},
+			false,
+			"",
+			"initial-password",
+		),
+	)
+})

--- a/pkg/agent/handler/suite_test.go
+++ b/pkg/agent/handler/suite_test.go
@@ -1,0 +1,13 @@
+package handler
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHandler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Handler Suite")
+}


### PR DESCRIPTION
Migrates `pkg/agent/handler` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `environment_test.go` converted to a `Describe` block with a `DescribeTable` (3 entries). Entry/spec names match the original `t.Run()` / case names.

Verified with:
```
go test ./pkg/agent/handler/...
```

Part of #368.
