### PR TITLE
test: migrate pkg/binlog tests to Ginkgo

### DIFF
--- a/pkg/binlog/binlog_test.go
+++ b/pkg/binlog/binlog_test.go
@@ -4,53 +4,58 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/google/go-cmp/cmp"
 	mariadbrepl "github.com/mariadb-operator/mariadb-operator/v26/pkg/replication"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"sigs.k8s.io/yaml"
 )
 
-func TestBuildTimeline(t *testing.T) {
-	tests := []struct {
-		name       string
-		indexFile  *BinlogIndex
-		startGtid  *mariadbrepl.Gtid
-		targetTime time.Time
-		strictMode bool
-		wantPath   []string
-		wantErr    bool
-	}{
-		{
-			name:       "single binlog",
-			indexFile:  mustParseTestFile(t, "single-binlog.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: time.Now(),
-			strictMode: false,
-			wantPath: []string{
+var _ = Describe("BuildTimeline", func() {
+	parseTestFile := func(file string) *BinlogIndex {
+		testFile := filepath.Join("test", file)
+		bytes, err := os.ReadFile(testFile)
+		Expect(err).NotTo(HaveOccurred())
+		var bi BinlogIndex
+		Expect(yaml.Unmarshal(bytes, &bi)).To(Succeed())
+		return &bi
+	}
+	parseGtid := func(s string) *mariadbrepl.Gtid {
+		g, err := mariadbrepl.ParseGtid(s)
+		Expect(err).NotTo(HaveOccurred())
+		return g
+	}
+
+	DescribeTable("building a timeline",
+		func(file string, gtidStr string, targetTime time.Time, strictMode bool, wantPath []string, wantErr bool) {
+			indexFile := parseTestFile(file)
+			startGtid := parseGtid(gtidStr)
+
+			binlogMetas, err := indexFile.BuildTimeline(startGtid, targetTime, strictMode, logr.Discard())
+			if wantErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(getBinlogTimeline(binlogMetas)).To(Equal(wantPath))
+			}
+		},
+		Entry("single binlog",
+			"single-binlog.yaml", "0-10-1", time.Now(), false,
+			[]string{
 				"server-10/mariadb-repl-bin.000002",
 			},
-			wantErr: false,
-		},
-		{
-			name:       "single binlog - strict",
-			indexFile:  mustParseTestFile(t, "single-binlog.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: time.Now(),
-			strictMode: true,
-			wantPath:   nil,
-			wantErr:    true,
-		},
-		{
-			name:       "multiple binlogs",
-			indexFile:  mustParseTestFile(t, "multiple-binlogs.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: mustParseDate(t, "2026-01-20T11:11:26Z"),
-			strictMode: false,
-			wantPath: []string{
+			false,
+		),
+		Entry("single binlog - strict",
+			"single-binlog.yaml", "0-10-1", time.Now(), true,
+			nil,
+			true,
+		),
+		Entry("multiple binlogs",
+			"multiple-binlogs.yaml", "0-10-1", mustParseDate("2026-01-20T11:11:26Z"), false,
+			[]string{
 				"server-10/mariadb-repl-bin.000002",
 				"server-10/mariadb-repl-bin.000003",
 				"server-10/mariadb-repl-bin.000004",
@@ -62,99 +67,67 @@ func TestBuildTimeline(t *testing.T) {
 				"server-10/mariadb-repl-bin.000010",
 				"server-10/mariadb-repl-bin.000011",
 			},
-			wantErr: false,
-		},
-		{
-			name:       "multiple binlogs - strict",
-			indexFile:  mustParseTestFile(t, "multiple-binlogs.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: time.Now(),
-			strictMode: true,
-			wantPath:   nil,
-			wantErr:    true,
-		},
-		{
-			name:       "filter by server-10 gtid and date",
-			indexFile:  mustParseTestFile(t, "failover-1205-1208.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-40"),
-			targetTime: mustParseDate(t, "2026-02-04T12:05:00Z"),
-			strictMode: true,
-			wantPath: []string{
+			false,
+		),
+		Entry("multiple binlogs - strict",
+			"multiple-binlogs.yaml", "0-10-1", time.Now(), true,
+			nil,
+			true,
+		),
+		Entry("filter by server-10 gtid and date",
+			"failover-1205-1208.yaml", "0-10-40", mustParseDate("2026-02-04T12:05:00Z"), true,
+			[]string{
 				"server-10/mariadb-repl-bin.000004",
 				"server-10/mariadb-repl-bin.000005",
 				"server-10/mariadb-repl-bin.000006",
 			},
-			wantErr: false,
-		},
-		{
-			name:       "filter by server-11 gtid and date",
-			indexFile:  mustParseTestFile(t, "failover-1205-1208.yaml"),
-			startGtid:  mustParseGtid(t, "0-11-100"),
-			targetTime: mustParseDate(t, "2026-02-04T12:06:56Z"),
-			strictMode: true,
-			wantPath: []string{
+			false,
+		),
+		Entry("filter by server-11 gtid and date",
+			"failover-1205-1208.yaml", "0-11-100", mustParseDate("2026-02-04T12:06:56Z"), true,
+			[]string{
 				"server-11/mariadb-repl-bin.000002",
 				"server-11/mariadb-repl-bin.000003",
 				"server-11/mariadb-repl-bin.000004",
 				"server-11/mariadb-repl-bin.000005",
 				"server-11/mariadb-repl-bin.000006",
 			},
-			wantErr: false,
-		},
-		{
-			name:       "failover",
-			indexFile:  mustParseTestFile(t, "failover.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: time.Now(),
-			strictMode: false,
-			wantPath: []string{
+			false,
+		),
+		Entry("failover",
+			"failover.yaml", "0-10-1", time.Now(), false,
+			[]string{
 				"server-10/mariadb-repl-bin.000002",
 				"server-10/mariadb-repl-bin.000003",
 				"server-10/mariadb-repl-bin.000004",
 				"server-10/mariadb-repl-bin.000005",
 			},
-			wantErr: false,
-		},
-		{
-			name:       "failover - strict",
-			indexFile:  mustParseTestFile(t, "failover.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: time.Now(),
-			strictMode: true,
-			wantPath:   nil,
-			wantErr:    true,
-		},
-		{
-			name:       "failover no stop event",
-			indexFile:  mustParseTestFile(t, "failover-no-stop-event.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: time.Now(),
-			strictMode: false,
-			wantPath: []string{
+			false,
+		),
+		Entry("failover - strict",
+			"failover.yaml", "0-10-1", time.Now(), true,
+			nil,
+			true,
+		),
+		Entry("failover no stop event",
+			"failover-no-stop-event.yaml", "0-10-1", time.Now(), false,
+			[]string{
 				"server-10/mariadb-repl-bin.000002",
 				"server-10/mariadb-repl-bin.000003",
 				"server-10/mariadb-repl-bin.000004",
 				"server-10/mariadb-repl-bin.000005",
 				"server-10/mariadb-repl-bin.000006",
 			},
-			wantErr: false,
-		},
-		{
-			name:       "failover no stop event - strict",
-			indexFile:  mustParseTestFile(t, "failover-no-stop-event.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: time.Now(),
-			strictMode: true,
-			wantPath:   nil,
-			wantErr:    true,
-		},
-		{
-			name:       "failover at 12:05",
-			indexFile:  mustParseTestFile(t, "failover-1205-1208.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: mustParseDate(t, "2026-02-04T12:06:39Z"),
-			strictMode: false,
-			wantPath: []string{
+			false,
+		),
+		Entry("failover no stop event - strict",
+			"failover-no-stop-event.yaml", "0-10-1", time.Now(), true,
+			nil,
+			true,
+		),
+		Entry("failover at 12:05",
+			"failover-1205-1208.yaml", "0-10-1", mustParseDate("2026-02-04T12:06:39Z"), false,
+			[]string{
 				"server-10/mariadb-repl-bin.000002",
 				"server-10/mariadb-repl-bin.000003",
 				"server-10/mariadb-repl-bin.000004",
@@ -167,15 +140,11 @@ func TestBuildTimeline(t *testing.T) {
 				"server-11/mariadb-repl-bin.000004",
 				"server-11/mariadb-repl-bin.000005",
 			},
-			wantErr: false,
-		},
-		{
-			name:       "failover at 12:05 - strict",
-			indexFile:  mustParseTestFile(t, "failover-1205-1208.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: mustParseDate(t, "2026-02-04T12:06:39Z"),
-			strictMode: true,
-			wantPath: []string{
+			false,
+		),
+		Entry("failover at 12:05 - strict",
+			"failover-1205-1208.yaml", "0-10-1", mustParseDate("2026-02-04T12:06:39Z"), true,
+			[]string{
 				"server-10/mariadb-repl-bin.000002",
 				"server-10/mariadb-repl-bin.000003",
 				"server-10/mariadb-repl-bin.000004",
@@ -189,15 +158,11 @@ func TestBuildTimeline(t *testing.T) {
 				"server-11/mariadb-repl-bin.000005",
 				// FAILOVER to server-10
 			},
-			wantErr: false,
-		},
-		{
-			name:       "failover at 12:05 and 12:08",
-			indexFile:  mustParseTestFile(t, "failover-1205-1208.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: mustParseDate(t, "2026-02-04T12:08:32Z"), // server-10/mariadb-repl-bin.000008
-			strictMode: false,
-			wantPath: []string{
+			false,
+		),
+		Entry("failover at 12:05 and 12:08",
+			"failover-1205-1208.yaml", "0-10-1", mustParseDate("2026-02-04T12:08:32Z"), false,
+			[]string{
 				"server-10/mariadb-repl-bin.000002",
 				"server-10/mariadb-repl-bin.000003",
 				"server-10/mariadb-repl-bin.000004",
@@ -215,81 +180,41 @@ func TestBuildTimeline(t *testing.T) {
 				"server-11/mariadb-repl-bin.000009",
 				// FAILOVER to server-10
 			},
-			wantErr: false,
-		},
-		{
-			name:       "failover at 12:05 and 12:08 - strict",
-			indexFile:  mustParseTestFile(t, "failover-1205-1208.yaml"),
-			startGtid:  mustParseGtid(t, "0-10-1"),
-			targetTime: mustParseDate(t, "2026-02-04T12:08:32Z"), // server-10/mariadb-repl-bin.000008
-			strictMode: true,
-			wantPath:   nil,
-			wantErr:    true,
-		},
-	}
+			false,
+		),
+		Entry("failover at 12:05 and 12:08 - strict",
+			"failover-1205-1208.yaml", "0-10-1", mustParseDate("2026-02-04T12:08:32Z"), true,
+			nil,
+			true,
+		),
+	)
+})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			binlogMetas, err := tt.indexFile.BuildTimeline(tt.startGtid, tt.targetTime, tt.strictMode, logr.Discard())
-			if tt.wantErr {
-				assert.Error(t, err, "expected error")
-			} else {
-				assert.NoError(t, err, "unexpected error")
-				if diff := cmp.Diff(getBinlogTimeline(binlogMetas), tt.wantPath); diff != "" {
-					t.Errorf("unexpected binlog timeline (-want +got):\n%s", diff)
-				}
-			}
-		})
-	}
-}
+var _ = Describe("ErrNoBinlogs", func() {
+	It("should return ErrNoBinlogs when there are no binlogs", func() {
+		binlogIndex := &BinlogIndex{
+			APIVersion: BinlogIndexV1,
+			Binlogs:    make(map[string][]BinlogMetadata),
+		}
+		startGtid := &mariadbrepl.Gtid{
+			DomainID:   1,
+			ServerID:   1,
+			SequenceID: 1,
+		}
+		targetTime := time.Now()
 
-func TestErrNoBinlogs(t *testing.T) {
-	binlogIndex := &BinlogIndex{
-		APIVersion: BinlogIndexV1,
-		Binlogs:    make(map[string][]BinlogMetadata),
-	}
-	startGtid := &mariadbrepl.Gtid{
-		DomainID:   1,
-		ServerID:   1,
-		SequenceID: 1,
-	}
-	targetTime := time.Now()
+		result, err := binlogIndex.BuildTimeline(startGtid, targetTime, false, logr.Discard())
 
-	result, err := binlogIndex.BuildTimeline(startGtid, targetTime, false, logr.Discard())
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrNoBinlogs)).To(BeTrue())
+		Expect(result).To(BeNil())
+	})
+})
 
-	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrNoBinlogs))
-	assert.Nil(t, result)
-}
-
-func mustParseTestFile(t *testing.T, file string) *BinlogIndex {
-	t.Helper()
-	testFile := filepath.Join("test", file)
-	bytes, err := os.ReadFile(testFile)
-	if err != nil {
-		t.Fatalf("failed to parse test file %s: %v", testFile, err)
-	}
-	var bi BinlogIndex
-	if err := yaml.Unmarshal(bytes, &bi); err != nil {
-		t.Fatalf("failed to unmarshal test file %s: %v", testFile, err)
-	}
-	return &bi
-}
-
-func mustParseGtid(t *testing.T, s string) *mariadbrepl.Gtid {
-	t.Helper()
-	g, err := mariadbrepl.ParseGtid(s)
-	if err != nil {
-		t.Fatalf("failed to parse gtid %s: %v", s, err)
-	}
-	return g
-}
-
-func mustParseDate(t *testing.T, s string) time.Time {
-	t.Helper()
+func mustParseDate(s string) time.Time {
 	d, err := time.Parse(time.RFC3339, s)
 	if err != nil {
-		t.Fatalf("failed to parse date %s: %v", s, err)
+		panic(err)
 	}
 	return d
 }

--- a/pkg/binlog/suite_test.go
+++ b/pkg/binlog/suite_test.go
@@ -1,0 +1,13 @@
+package binlog
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBinlog(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Binlog Suite")
+}


### PR DESCRIPTION
Migrates `pkg/binlog` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `binlog_test.go` converted to a `DescribeTable` (14 entries) plus an `It` spec; input parsing moved into the spec body (Ginkgo evaluates Entry args before specs run). Entry/spec names match the original `t.Run()` / case names.

Verified with:
```
go test ./pkg/binlog/...
```

Part of #368.
