### PR TITLE
test: migrate pkg/controller/maintenance tests to Ginkgo

### DIFF
--- a/pkg/controller/maintenance/read_only_test.go
+++ b/pkg/controller/maintenance/read_only_test.go
@@ -1,22 +1,21 @@
 package maintenance
 
 import (
-	"testing"
-
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
-	"github.com/stretchr/testify/assert"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/utils/ptr"
 )
 
-func TestGetReadOnlyDesiredPodState(t *testing.T) {
-	tests := []struct {
-		name          string
-		mariadb       *mariadbv1alpha1.MariaDB
-		expectedState map[int]bool
-	}{
-		{
-			name: "replication without maintenance",
-			mariadb: &mariadbv1alpha1.MariaDB{
+var _ = Describe("GetReadOnlyDesiredPodState", func() {
+	DescribeTable("computes the desired read-only pod state",
+		func(mariadb *mariadbv1alpha1.MariaDB, expectedState map[int]bool) {
+			r := &MaintenanceReconciler{}
+			got := r.getReadOnlyDesiredPodState(mariadb)
+			Expect(got).To(Equal(expectedState))
+		},
+		Entry("replication without maintenance",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Replication: &mariadbv1alpha1.Replication{
@@ -27,15 +26,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(0),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: false,
 				1: true,
 				2: true,
 			},
-		},
-		{
-			name: "replication without maintenance - primary at index 1",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("replication without maintenance - primary at index 1",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Replication: &mariadbv1alpha1.Replication{
@@ -46,15 +44,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(1),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: true,
 				1: false,
 				2: true,
 			},
-		},
-		{
-			name: "replication with maintenance and readOnly",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("replication with maintenance and readOnly",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Replication: &mariadbv1alpha1.Replication{
@@ -69,15 +66,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(0),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: true,
 				1: true,
 				2: true,
 			},
-		},
-		{
-			name: "replication with maintenance and readOnly - primary at index 1",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("replication with maintenance and readOnly - primary at index 1",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Replication: &mariadbv1alpha1.Replication{
@@ -92,15 +88,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(1),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: true,
 				1: true,
 				2: true,
 			},
-		},
-		{
-			name: "replication with maintenance without readOnly",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("replication with maintenance without readOnly",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Replication: &mariadbv1alpha1.Replication{
@@ -115,15 +110,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(0),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: false,
 				1: true,
 				2: true,
 			},
-		},
-		{
-			name: "replication with maintenance without readOnly - primary at index 1",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("replication with maintenance without readOnly - primary at index 1",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Replication: &mariadbv1alpha1.Replication{
@@ -138,26 +132,24 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(1),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: true,
 				1: false,
 				2: true,
 			},
-		},
-		{
-			name: "standalone without maintenance",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("standalone without maintenance",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 1,
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: false,
 			},
-		},
-		{
-			name: "standalone with maintenance and readOnly",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("standalone with maintenance and readOnly",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 1,
 					Maintenance: ptr.To(mariadbv1alpha1.MariaDBMaintenance{
@@ -166,13 +158,12 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					}),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: true,
 			},
-		},
-		{
-			name: "standalone with maintenance without readOnly",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("standalone with maintenance without readOnly",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 1,
 					Maintenance: ptr.To(mariadbv1alpha1.MariaDBMaintenance{
@@ -181,13 +172,12 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					}),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: false,
 			},
-		},
-		{
-			name: "galera without maintenance",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("galera without maintenance",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Galera: ptr.To(mariadbv1alpha1.Galera{
@@ -198,15 +188,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(0),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: false,
 				1: false,
 				2: false,
 			},
-		},
-		{
-			name: "galera without maintenance - primary at index 1",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("galera without maintenance - primary at index 1",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Galera: ptr.To(mariadbv1alpha1.Galera{
@@ -217,15 +206,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(1),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: false,
 				1: false,
 				2: false,
 			},
-		},
-		{
-			name: "galera with maintenance and readOnly",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("galera with maintenance and readOnly",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Galera: ptr.To(mariadbv1alpha1.Galera{
@@ -240,15 +228,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(0),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: true,
 				1: true,
 				2: true,
 			},
-		},
-		{
-			name: "galera with maintenance and readOnly - primary at index 1",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("galera with maintenance and readOnly - primary at index 1",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Galera: ptr.To(mariadbv1alpha1.Galera{
@@ -263,15 +250,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(1),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: true,
 				1: true,
 				2: true,
 			},
-		},
-		{
-			name: "galera with maintenance without readOnly",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("galera with maintenance without readOnly",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Galera: ptr.To(mariadbv1alpha1.Galera{
@@ -286,15 +272,14 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(0),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: false,
 				1: false,
 				2: false,
 			},
-		},
-		{
-			name: "galera with maintenance without readOnly - primary at index 1",
-			mariadb: &mariadbv1alpha1.MariaDB{
+		),
+		Entry("galera with maintenance without readOnly - primary at index 1",
+			&mariadbv1alpha1.MariaDB{
 				Spec: mariadbv1alpha1.MariaDBSpec{
 					Replicas: 3,
 					Galera: ptr.To(mariadbv1alpha1.Galera{
@@ -309,20 +294,11 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 					CurrentPrimaryPodIndex: ptr.To(1),
 				},
 			},
-			expectedState: map[int]bool{
+			map[int]bool{
 				0: false,
 				1: false,
 				2: false,
 			},
-		},
-	}
-
-	r := &MaintenanceReconciler{}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := r.getReadOnlyDesiredPodState(tt.mariadb)
-			assert.Equal(t, tt.expectedState, result, "ReadOnly state mismatch")
-		})
-	}
-}
+		),
+	)
+})

--- a/pkg/controller/maintenance/suite_test.go
+++ b/pkg/controller/maintenance/suite_test.go
@@ -1,0 +1,13 @@
+package maintenance
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMaintenance(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Maintenance Suite")
+}


### PR DESCRIPTION
Migrates `pkg/controller/maintenance` from standard Go tests to Ginkgo/Gomega as part of #368.

**This is a purely mechanical migration — no test cases added, removed, or modified.**

Changes:
- `suite_test.go`: new file, Ginkgo suite bootstrap
- `read_only_test.go` converted to a `Describe` block with a `DescribeTable` (15 entries). Entry/spec names match the original `t.Run()` / case names.

Verified with:
```
go test ./pkg/controller/maintenance/...
```

Part of #368.
