### PR TITLE
fix: pass pod options to custom containers

### DIFF
--- a/pkg/builder/container_builder.go
+++ b/pkg/builder/container_builder.go
@@ -133,7 +133,7 @@ func (b *Builder) mariadbContainers(mariadb *mariadbv1alpha1.MariaDB, opts ...ma
 	}
 	if mariadb.Spec.SidecarContainers != nil && mariadbOpts.includeSidecarContainers {
 		for index, container := range mariadb.Spec.SidecarContainers {
-			sidecarContainer, err := b.buildContainer(mariadb, &container)
+			sidecarContainer, err := b.buildContainer(mariadb, &container, opts...)
 			if err != nil {
 				return nil, err
 			}
@@ -292,7 +292,7 @@ func (b *Builder) mariadbInitContainers(mariadb *mariadbv1alpha1.MariaDB, opts .
 	initContainers := []corev1.Container{}
 	if mariadb.Spec.InitContainers != nil && mariadbOpts.includeInitContainers {
 		for index, container := range mariadb.Spec.InitContainers {
-			initContainer, err := b.buildContainer(mariadb, &container)
+			initContainer, err := b.buildContainer(mariadb, &container, opts...)
 			if err != nil {
 				return nil, err
 			}
@@ -378,7 +378,8 @@ func (b *Builder) buildContainerWithTemplate(image string, pullPolicy corev1.Pul
 	return &container, nil
 }
 
-func (b *Builder) buildContainer(mdb *mariadbv1alpha1.MariaDB, mdbContainer *mariadbv1alpha1.Container) (*corev1.Container, error) {
+func (b *Builder) buildContainer(mdb *mariadbv1alpha1.MariaDB, mdbContainer *mariadbv1alpha1.Container,
+	opts ...mariadbPodOpt) (*corev1.Container, error) {
 	env, err := mariadbEnv(mdb)
 	if err != nil {
 		return nil, err
@@ -386,7 +387,7 @@ func (b *Builder) buildContainer(mdb *mariadbv1alpha1.MariaDB, mdbContainer *mar
 	if mdbContainer.Env != nil {
 		env = append(env, kadapter.ToKubernetesSlice(mdbContainer.Env)...)
 	}
-	volumeMounts, err := mariadbVolumeMounts(mdb)
+	volumeMounts, err := mariadbVolumeMounts(mdb, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/builder/container_builder_test.go
+++ b/pkg/builder/container_builder_test.go
@@ -2008,6 +2008,39 @@ func TestMariadbContainers(t *testing.T) {
 	}
 }
 
+func TestMariadbSidecarContainersRespectPodOpts(t *testing.T) {
+	builder := newDefaultTestBuilder(t)
+	mariadb := &mariadbv1alpha1.MariaDB{
+		Spec: mariadbv1alpha1.MariaDBSpec{
+			MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+				SidecarContainers: []mariadbv1alpha1.Container{
+					{
+						Name:  "sidecar",
+						Image: "busybox",
+					},
+				},
+			},
+			Galera: &mariadbv1alpha1.Galera{
+				Enabled: true,
+			},
+		},
+	}
+
+	containers, err := builder.mariadbContainers(
+		mariadb,
+		withDataPlane(false),
+		withServiceAccount(false),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error building containers: %v", err)
+	}
+
+	sidecar := containers[1]
+	if hasContainerVolumeMount(sidecar, ServiceAccountVolume) {
+		t.Errorf("did not expect sidecar container to have %q VolumeMount", ServiceAccountVolume)
+	}
+}
+
 func TestMariadbInitContainers(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -2171,6 +2204,45 @@ func TestMariadbInitContainers(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMariadbInitContainersRespectPodOpts(t *testing.T) {
+	builder := newDefaultTestBuilder(t)
+	mariadb := &mariadbv1alpha1.MariaDB{
+		Spec: mariadbv1alpha1.MariaDBSpec{
+			MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+				InitContainers: []mariadbv1alpha1.Container{
+					{
+						Name:  "init",
+						Image: "busybox",
+					},
+				},
+			},
+			Galera: &mariadbv1alpha1.Galera{
+				Enabled: true,
+			},
+		},
+	}
+
+	initContainers, err := builder.mariadbInitContainers(
+		mariadb,
+		withDataPlane(false),
+		withServiceAccount(false),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error building init containers: %v", err)
+	}
+
+	initContainer := initContainers[0]
+	if hasContainerVolumeMount(initContainer, ServiceAccountVolume) {
+		t.Errorf("did not expect init container to have %q VolumeMount", ServiceAccountVolume)
+	}
+}
+
+func hasContainerVolumeMount(container corev1.Container, name string) bool {
+	return datastructures.Find(container.VolumeMounts, func(volumeMount corev1.VolumeMount) bool {
+		return volumeMount.Name == name
+	}) != nil
 }
 
 func TestMaxscaleContainers(t *testing.T) {


### PR DESCRIPTION
## What

Pass `mariadbPodOpt` options through custom MariaDB init and sidecar container construction.

This makes custom containers use the same volumeMount option set as the Pod template being built. In particular, special builder paths that disable data-plane or service-account volumes no longer risk leaving custom containers with a `serviceaccount` volumeMount that has no matching Pod volume.

## Why

We hit a Galera recovery failure on `mariadb-operator` `25.10.2` where the generated recovery Job was rejected by Kubernetes:

```text
spec.template.spec.initContainers[0].volumeMounts[3].name: Not found: "serviceaccount"
```

The immediate Galera recovery Job path is already safer in `25.10.3+` because Galera init/recovery Jobs exclude custom init and sidecar containers. This PR hardens the shared builder path so custom containers consistently respect pod options when they are included by any specialized Pod/Job builder.

Fixes #1803.

## Validation

```bash
go test ./pkg/builder
```
