### PR TITLE
ci: generate release notes for Helm chart releases

### DIFF
--- a/.github/workflows/helm-release-crds.yml
+++ b/.github/workflows/helm-release-crds.yml
@@ -19,6 +19,19 @@ jobs:
         id: tag
         run: echo "name=mariadb-operator-crds-$(make helm-crds-version)" >> $GITHUB_OUTPUT
 
+      - name: Previous tag
+        id: prev
+        run: |
+          git fetch --force --tags
+          CUR="${{ steps.tag.outputs.name }}"
+          # Greatest CRDs chart tag strictly below the current one.
+          # sort -V orders ascending, so the line before CUR is its predecessor.
+          PREV=$( { git tag -l 'mariadb-operator-crds-*' \
+              | grep -E '^mariadb-operator-crds-[0-9]+\.[0-9]+\.[0-9]+$'; echo "$CUR"; } \
+            | sort -V | uniq | grep -xF -B1 -- "$CUR" | head -n 1 )
+          [ "$PREV" = "$CUR" ] && PREV=""   # no predecessor -> let GitHub auto-detect
+          echo "name=${PREV}" >> $GITHUB_OUTPUT
+
       - name: Helm generate
         run: make helm-gen
 
@@ -31,6 +44,8 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: "${{ steps.tag.outputs.name }}"
+          previous_tag: "${{ steps.prev.outputs.name }}"
+          generate_release_notes: true
           files: |
             dist/crds/crds.yaml
         env:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -19,6 +19,19 @@ jobs:
         id: tag
         run: echo "name=mariadb-operator-$(make helm-version)" >> $GITHUB_OUTPUT
 
+      - name: Previous tag
+        id: prev
+        run: |
+          git fetch --force --tags
+          CUR="${{ steps.tag.outputs.name }}"
+          # Greatest operator chart tag strictly below the current one.
+          # sort -V orders ascending, so the line before CUR is its predecessor.
+          PREV=$( { git tag -l 'mariadb-operator-*' \
+              | grep -E '^mariadb-operator-[0-9]+\.[0-9]+\.[0-9]+$'; echo "$CUR"; } \
+            | sort -V | uniq | grep -xF -B1 -- "$CUR" | head -n 1 )
+          [ "$PREV" = "$CUR" ] && PREV=""   # no predecessor -> let GitHub auto-detect
+          echo "name=${PREV}" >> $GITHUB_OUTPUT
+
       - name: Helm generate
         run: make helm-gen
       
@@ -31,6 +44,8 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           tag_name: "${{ steps.tag.outputs.name }}"
+          previous_tag: "${{ steps.prev.outputs.name }}"
+          generate_release_notes: true
           files: |
             dist/manifests/manifests.yaml
             dist/manifests/manifests.min.yaml


### PR DESCRIPTION
Close MDB-19

Fixes #1372.

## Problem

The chart releases (the `mariadb-operator-*` and `mariadb-operator-crds-*` tags) only show the chart's one-line description as their release body. The bare version release like `25.8.3` gets a full changelog from goreleaser, but the chart ones get nothing useful. Renovate and Dependabot read that body to show what changed between versions, so on chart bumps there's nothing for them to display.

## Change

This turns on `generate_release_notes: true` for the `action-gh-release` step in both `helm-release.yml` and `helm-release-crds.yml`, so GitHub builds the "What's Changed" list from merged PRs.

I also pin the comparison base with `previous_tag`. All the tags share one namespace (`mariadb-operator-*`, `mariadb-operator-crds-*`, and the bare `25.8.3` tags), so if you let GitHub guess the base it can pick the wrong tag and produce a garbage diff. The previous tag is resolved as the greatest chart tag strictly below the current one:

```bash
PREV=$( { git tag -l 'mariadb-operator-*' \
    | grep -E '^mariadb-operator-[0-9]+\.[0-9]+\.[0-9]+$'; echo "$CUR"; } \
  | sort -V | uniq | grep -xF -B1 -- "$CUR" | head -n 1 )
[ "$PREV" = "$CUR" ] && PREV=""
```

`sort -V` puts the tags in ascending order, so the line right before the current tag is its real predecessor. This also survives backports: cutting `mariadb-operator-25.10.5` while `26.6.0` already exists resolves to `25.10.4`, not the newest tag overall. If there's no predecessor (a chart's first release) `previous_tag` is left empty and GitHub falls back to its own detection.

## Testing

Ran the resolution against the existing tags:

| Current tag | Resolved previous |
|---|---|
| `mariadb-operator-26.6.0` | `mariadb-operator-26.3.0` |
| `mariadb-operator-25.10.5` (backport) | `mariadb-operator-25.10.4` |
| `mariadb-operator-25.10.3` | `mariadb-operator-25.10.2` |
| first release | empty (auto-detect) |
