### PR TITLE
Pin unpinned-action references across 8 workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Detect no-op changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v5.3.1
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["*.md","*.md.gotmpl",".github/**","docs/**","examples/**"]'
@@ -32,16 +32,16 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
 
       - name: GolangCI Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: ${{ env.GOLANGCI_VERSION }}
 
@@ -52,10 +52,10 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Find typos
-        uses: crate-ci/typos@v1.47.0
+        uses: crate-ci/typos@f8a58b6b53f2279f71eb605f03a4ae4d10608f45
         with:
           files: ./api ./cmd ./internal ./pkg
           config: ./.typos.toml
@@ -67,10 +67,10 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -88,10 +88,10 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -107,10 +107,10 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -162,13 +162,13 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Generate
         run: make gen
 
       - name: Check diff
-        uses: mmontes11/diff-porcelain@v0.0.1
+        uses: mmontes11/diff-porcelain@898356c9a485a2085830d7fb29742fc11762648d
         with:
           message: Generated artifacts are not up to date. Run 'make gen' and commit the changes.
 

--- a/.github/workflows/helm-release-crds.yml
+++ b/.github/workflows/helm-release-crds.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
           MANIFESTS_CRDS_DIR: dist/crds
 
       - name: Update Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           tag_name: "${{ steps.tag.outputs.name }}"
           files: |

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
           MANIFESTS_DIR: dist/manifests
 
       - name: Update Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           tag_name: "${{ steps.tag.outputs.name }}"
           files: |
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 

--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -21,21 +21,21 @@ jobs:
       CT_CONFIG: hack/config/chart-testing/mariadb-cluster.yaml
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.9"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
 
       - name: List changed
         id: list-changed
@@ -56,21 +56,21 @@ jobs:
       CT_CONFIG: hack/config/chart-testing/mariadb-operator-crds.yaml
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.9"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
 
       - name: List changed
         id: list-changed
@@ -99,21 +99,21 @@ jobs:
       CT_CONFIG: hack/config/chart-testing/mariadb-operator.yaml
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.9"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
 
       - name: List changed
         id: list-changed
@@ -150,7 +150,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           token: "${{ secrets.GHA_TOKEN }}"
@@ -161,11 +161,11 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
       - name: Run chart-releaser
         id: chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f
         env:
           CR_TOKEN: "${{ secrets.GHA_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "{{ .Name }}-{{ .Version }}"
@@ -177,7 +177,7 @@ jobs:
 
       # See: https://github.com/helm/chart-releaser/issues/183
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       RELEASE_ARGS: ${{ steps.args.outputs.RELEASE_ARGS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -60,26 +60,26 @@ jobs:
     needs: args
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
         id: buildx
 
       - name: Login GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
 
       - name: Publish multi-arch Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}
@@ -106,7 +106,7 @@ jobs:
       - release
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -117,7 +117,7 @@ jobs:
         run: echo "GORELEASER_PREVIOUS_TAG=$(git tag -l --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 2 | tail -n 1)" >> $GITHUB_ENV
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89
         with:
           version: ${{ env.GORELEASER_VERSION }}
           args: ${{ needs.args.outputs.RELEASE_ARGS }}
@@ -132,7 +132,7 @@ jobs:
       - goreleaser
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           token: "${{ secrets.GHA_TOKEN }}"
@@ -166,7 +166,7 @@ jobs:
       - helm
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           token: "${{ secrets.GHA_TOKEN }}"

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'

--- a/.github/workflows/test-image-ubi.yml
+++ b/.github/workflows/test-image-ubi.yml
@@ -22,10 +22,10 @@ jobs:
           docker run --rm ${{ inputs.mariadb_image }} mariadbd --version
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -50,7 +50,7 @@ jobs:
 
       - name: Tell the MariaDB Folks that failed
         if: ${{ failure() && contains(inputs.mariadb_image, 'mariadb-foundation') }}
-        uses: zulip/github-actions-zulip/send-message@v2
+        uses: zulip/github-actions-zulip/send-message@f675f2b4eb2a95fae974215476dcb7ad8dfeff6b
         with:
           api-key: ${{ secrets.MARIADB_ZULIP_API_KEY }}
           email: "mariadb-operator-bot@mariadb.zulipchat.com"

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -22,10 +22,10 @@ jobs:
           docker run --rm ${{ inputs.mariadb_image }} mariadbd --version
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -49,7 +49,7 @@ jobs:
 
       - name: Tell the MariaDB Folks that failed
         if: ${{ failure() && contains(inputs.mariadb_image, 'mariadb-foundation') }}
-        uses: zulip/github-actions-zulip/send-message@v2
+        uses: zulip/github-actions-zulip/send-message@f675f2b4eb2a95fae974215476dcb7ad8dfeff6b
         with:
           api-key: ${{ secrets.MARIADB_ZULIP_API_KEY }}
           email: "mariadb-operator-bot@mariadb.zulipchat.com"


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/ci.yml`

- 🟠 MED `fkirc/skip-duplicate-actions` (job `detect-noop`)
- 🟠 MED `golangci/golangci-lint-action` (job `lint`)
- 🟠 MED `crate-ci/typos` (job `typos`)
- 🟠 MED `mmontes11/diff-porcelain` (job `artifacts`)
- ⚪ LOW `actions/checkout` (job `lint`)
- ⚪ LOW `actions/setup-go` (job `lint`)
- ⚪ LOW `actions/checkout` (job `typos`)
- ⚪ LOW `actions/checkout` (job `build`)
- ⚪ LOW `actions/setup-go` (job `build`)
- ⚪ LOW `actions/checkout` (job `unit-test`)
- ⚪ LOW `actions/setup-go` (job `unit-test`)
- ⚪ LOW `actions/checkout` (job `integration-test`)
- ⚪ LOW `actions/setup-go` (job `integration-test`)
- ⚪ LOW `actions/checkout` (job `artifacts`)

<details>
<summary>Diff</summary>

```diff
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Detect no-op changes
         id: noop
-        uses: fkirc/skip-duplicate-actions@v5.3.1
+        uses: fkirc/skip-duplicate-actions@f75f66ce1886f00957d99748a42c724f4330bdcf
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           paths_ignore: '["*.md","*.md.gotmpl",".github/**","docs/**","examples/**"]'
@@ -32,16 +32,16 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
 
       - name: GolangCI Lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee
         with:
           version: ${{ env.GOLANGCI_VERSION }}
 
@@ -52,10 +52,10 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Find typos
-        uses: crate-ci/typos@v1.47.0
+        uses: crate-ci/typos@f8a58b6b53f2279f71eb605f03a4ae4d10608f45
         with:
           files: ./api ./cmd ./internal ./pkg
           config: ./.typos.toml
@@ -67,10 +67,10 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -88,10 +88,10 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -107,10 +107,10 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -162,13 +162,13 @@ jobs:
     if: ${{ needs.detect-noop.outputs.noop != 'true' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Generate
         run: make gen
 
       - name: Check diff
-        uses: mmontes11/diff-porcelain@v0.0.1
+        uses: mmontes11/diff-porcelain@898356c9a485a2085830d7fb29742fc11762648d
         with:
           message: Generated artifacts are not up to date. Run 'make gen' and commit the changes.
```

</details>

### `.github/workflows/helm-release-crds.yml`

- 🟠 MED `softprops/action-gh-release` (job `manifests`)
- ⚪ LOW `actions/checkout` (job `manifests`)

<details>
<summary>Diff</summary>

```diff
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
           MANIFESTS_CRDS_DIR: dist/crds
 
       - name: Update Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           tag_name: "${{ steps.tag.outputs.name }}"
           files: |
```

</details>

### `.github/workflows/helm-release.yml`

- 🟠 MED `softprops/action-gh-release` (job `manifests`)
- ⚪ LOW `actions/checkout` (job `manifests`)
- ⚪ LOW `actions/checkout` (job `olm`)

<details>
<summary>Diff</summary>

```diff
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
           MANIFESTS_DIR: dist/manifests
 
       - name: Update Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
           tag_name: "${{ steps.tag.outputs.name }}"
           files: |
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
```

</details>

### `.github/workflows/helm.yml`

- 🟠 MED `azure/setup-helm` (job `lint-cluster`)
- 🟠 MED `helm/chart-testing-action` (job `lint-cluster`)
- 🟠 MED `azure/setup-helm` (job `lint-crds`)
- 🟠 MED `helm/chart-testing-action` (job `lint-crds`)
- 🟠 MED `azure/setup-helm` (job `lint-operator`)
- 🟠 MED `helm/chart-testing-action` (job `lint-operator`)
- 🟠 MED `azure/setup-helm` (job `release`)
- 🟠 MED `helm/chart-releaser-action` (job `release`)
- ⚪ LOW `actions/checkout` (job `lint-cluster`)
- ⚪ LOW `actions/setup-python` (job `lint-cluster`)
- ⚪ LOW `actions/checkout` (job `lint-crds`)
- ⚪ LOW `actions/setup-python` (job `lint-crds`)
- ⚪ LOW `actions/checkout` (job `lint-operator`)
- ⚪ LOW `actions/setup-python` (job `lint-operator`)
- ⚪ LOW `actions/checkout` (job `release`)
- ⚪ LOW `docker/login-action` (job `release`)

<details>
<summary>Diff</summary>

```diff
@@ -21,21 +21,21 @@ jobs:
       CT_CONFIG: hack/config/chart-testing/mariadb-cluster.yaml
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.9"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
 
       - name: List changed
         id: list-changed
@@ -56,21 +56,21 @@ jobs:
       CT_CONFIG: hack/config/chart-testing/mariadb-operator-crds.yaml
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.9"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
 
       - name: List changed
         id: list-changed
@@ -99,21 +99,21 @@ jobs:
       CT_CONFIG: hack/config/chart-testing/mariadb-operator.yaml
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: Setup Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
         with:
           version: ${{ env.HELM_VERSION }}
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.9"
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.8.0
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f
 
       - name: List changed
         id: list-changed
@@ -150,7 +150,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           token: "${{ secrets.GHA_TOKEN }}"
@@ -161,11 +161,11 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2
 
       - name: Run chart-releaser
         id: chart-releaser
-        uses: helm/chart-releaser-action@v1.7.0
+        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f
         env:
           CR_TOKEN: "${{ secrets.GHA_TOKEN }}"
           CR_RELEASE_NAME_TEMPLATE: "{{ .Name }}-{{ .Version }}"
@@ -177,7 +177,7 @@ jobs:
 
       # See: https://github.com/helm/chart-releaser/issues/183
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
```

</details>

### `.github/workflows/release.yml`

- 🟠 MED `goreleaser/goreleaser-action` (job `goreleaser`)
- ⚪ LOW `actions/checkout` (job `args`)
- ⚪ LOW `actions/checkout` (job `release`)
- ⚪ LOW `docker/setup-qemu-action` (job `release`)
- ⚪ LOW `docker/setup-buildx-action` (job `release`)
- ⚪ LOW `docker/login-action` (job `release`)
- ⚪ LOW `docker/build-push-action` (job `release`)
- ⚪ LOW `actions/checkout` (job `goreleaser`)
- ⚪ LOW `actions/checkout` (job `helm`)
- ⚪ LOW `actions/checkout` (job `gopkg`)

<details>
<summary>Diff</summary>

```diff
@@ -18,7 +18,7 @@ jobs:
       RELEASE_ARGS: ${{ steps.args.outputs.RELEASE_ARGS }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -60,26 +60,26 @@ jobs:
     needs: args
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
         id: buildx
 
       - name: Login GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
         with:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
 
       - name: Publish multi-arch Docker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
         with:
           push: true
           builder: ${{ steps.buildx.outputs.name }}
@@ -106,7 +106,7 @@ jobs:
       - release
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
 
@@ -117,7 +117,7 @@ jobs:
         run: echo "GORELEASER_PREVIOUS_TAG=$(git tag -l --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -n 2 | tail -n 1)" >> $GITHUB_ENV
 
       - name: GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89
         with:
           version: ${{ env.GORELEASER_VERSION }}
           args: ${{ needs.args.outputs.RELEASE_ARGS }}
@@ -132,7 +132,7 @@ jobs:
       - goreleaser
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           token: "${{ secrets.GHA_TOKEN }}"
@@ -166,7 +166,7 @@ jobs:
       - helm
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
           fetch-depth: 0
           token: "${{ secrets.GHA_TOKEN }}"
```

</details>

### `.github/workflows/stale.yaml`

- ⚪ LOW `actions/stale` (job `stale`)

<details>
<summary>Diff</summary>

```diff
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity.'
```

</details>

### `.github/workflows/test-image-ubi.yml`

- 🟠 MED `zulip/github-actions-zulip/send-message` (job `test`)
- ⚪ LOW `actions/checkout` (job `test`)
- ⚪ LOW `actions/setup-go` (job `test`)

<details>
<summary>Diff</summary>

```diff
@@ -22,10 +22,10 @@ jobs:
           docker run --rm ${{ inputs.mariadb_image }} mariadbd --version
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -50,7 +50,7 @@ jobs:
 
       - name: Tell the MariaDB Folks that failed
         if: ${{ failure() && contains(inputs.mariadb_image, 'mariadb-foundation') }}
-        uses: zulip/github-actions-zulip/send-message@v2
+        uses: zulip/github-actions-zulip/send-message@f675f2b4eb2a95fae974215476dcb7ad8dfeff6b
         with:
           api-key: ${{ secrets.MARIADB_ZULIP_API_KEY }}
           email: "mariadb-operator-bot@mariadb.zulipchat.com"
```

</details>

### `.github/workflows/test-image.yml`

- 🟠 MED `zulip/github-actions-zulip/send-message` (job `test`)
- ⚪ LOW `actions/checkout` (job `test`)
- ⚪ LOW `actions/setup-go` (job `test`)

<details>
<summary>Diff</summary>

```diff
@@ -22,10 +22,10 @@ jobs:
           docker run --rm ${{ inputs.mariadb_image }} mariadbd --version
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
 
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version-file: "go.mod"
           cache: true
@@ -49,7 +49,7 @@ jobs:
 
       - name: Tell the MariaDB Folks that failed
         if: ${{ failure() && contains(inputs.mariadb_image, 'mariadb-foundation') }}
-        uses: zulip/github-actions-zulip/send-message@v2
+        uses: zulip/github-actions-zulip/send-message@f675f2b4eb2a95fae974215476dcb7ad8dfeff6b
         with:
           api-key: ${{ secrets.MARIADB_ZULIP_API_KEY }}
           email: "mariadb-operator-bot@mariadb.zulipchat.com"
```

</details>


---

_AI-generated. Review the diff before merging._
