### PR TITLE
Fix pat-for-push in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,12 +164,13 @@ jobs:
     needs:
       - args
       - helm
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: "${{ secrets.GHA_TOKEN }}"
           ref: "${{ github.event.repository.default_branch }}"
 
       - name: Configure Git
@@ -181,4 +182,3 @@ jobs:
         run: |
           git tag "v${{ needs.args.outputs.VERSION }}"
           git push --tags
-


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

### 🔴 `pat-for-push` · `gopkg`

**Blast radius.**

Today: `actions/checkout` in `gopkg` (L168) authenticates with `${{ secrets.GHA_TOKEN }}` — a personal access token. A PAT typically grants standing access to *all* repositories the issuing user can reach, with no automatic expiry.

After this PR: the job uses the built-in `GITHUB_TOKEN` scoped to `contents: write` — limited to *this* repository and automatically revoked when the job ends.

Reference: CWE-522 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,12 +164,13 @@
     needs:
       - args
       - helm
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: "${{ secrets.GHA_TOKEN }}"
           ref: "${{ github.event.repository.default_branch }}"
 
       - name: Configure Git
@@ -181,4 +182,3 @@
         run: |
           git tag "v${{ needs.args.outputs.VERSION }}"
           git push --tags
-
```

</details>


---

_AI-generated. Review the diff before merging._
