### PR TITLE
Fix pat-for-push in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     needs: args
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -104,6 +106,8 @@ jobs:
     needs:
       - args
       - release
+            permissions:
+              contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -181,4 +185,3 @@ jobs:
         run: |
           git tag "v${{ needs.args.outputs.VERSION }}"
           git push --tags
-


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

| Sev | Issue | Job | What changes |
| --- | ----- | --- | ------------ |
| 🟠 MED | `permissions-missing` | `release` | declare needed scopes |
| 🟠 MED | `permissions-missing` | `goreleaser` | declare needed scopes |

### 🟠 `permissions-missing` · `release`

In job 'release', the 'Login GHCR' step uses secrets.GITHUB_TOKEN and the 'Publish multi-arch Docker image' step performs a GHCR push. The comprehension records a GitHub-governed write of kind docker_push_ghcr requiring the packages scope, but the job has no declared permissions…

Reference: CWE-862 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

<details>
<summary>Evidence & diff</summary>

```diff
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,8 @@
     name: Release
     runs-on: ubuntu-latest
     needs: args
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -104,6 +106,8 @@
     needs:
       - args
       - release
+            permissions:
+              contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -181,4 +185,3 @@
         run: |
           git tag "v${{ needs.args.outputs.VERSION }}"
           git push --tags
-
```

</details>

### 🟠 `permissions-missing` · `goreleaser`

In job 'goreleaser', the 'GoReleaser' step uses secrets.GITHUB_TOKEN and the comprehension records GitHub-governed writes for git_tag_push and gh_release_create, both of which require contents: write. The job has no declared permissions block (effective_permissions is null), so…

Reference: CWE-862 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
