### PR TITLE
Fix: Compose multi-domain GTIDs on multiCluster demote

### DIFF
--- a/internal/controller/mariadb_controller_multicluster.go
+++ b/internal/controller/mariadb_controller_multicluster.go
@@ -297,13 +297,32 @@ func (r *MariaDBReconciler) shouldReconcileMultiCluster(ctx context.Context, mdb
 }
 
 func composeGtids(rawGtid, rawExternalGtid string) (string, error) {
-	gtid, err := replication.ParseGtid(rawGtid)
+	gtids, err := parseGtids(rawGtid)
 	if err != nil {
 		return "", fmt.Errorf("error parsing GTID %s: %v", rawGtid, err)
 	}
-	externalGtid, err := replication.ParseGtid(rawExternalGtid)
+	externalGtids, err := parseGtids(rawExternalGtid)
 	if err != nil {
 		return "", fmt.Errorf("error parsing external GTID %s: %v", rawExternalGtid, err)
 	}
-	return replication.GtidsToString(*gtid, *externalGtid), nil
+
+	externalDomains := make(map[uint32]bool, len(externalGtids))
+	merged := make([]replication.Gtid, 0, len(gtids)+len(externalGtids))
+	for _, gtid := range externalGtids {
+		externalDomains[gtid.DomainID] = true
+		merged = append(merged, gtid)
+	}
+	for _, gtid := range gtids {
+		if !externalDomains[gtid.DomainID] {
+			merged = append(merged, gtid)
+		}
+	}
+	return replication.GtidsToString(merged...), nil
+}
+
+func parseGtids(rawGtid string) ([]replication.Gtid, error) {
+	if rawGtid == "" {
+		return nil, nil
+	}
+	return replication.ParseAllGtids(rawGtid)
 }

--- a/internal/controller/mariadb_controller_multicluster_unit_test.go
+++ b/internal/controller/mariadb_controller_multicluster_unit_test.go
@@ -1,0 +1,72 @@
+package controller
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestComposeGtids(t *testing.T) {
+	tests := []struct {
+		name        string
+		rawGtid     string
+		rawExternal string
+		expected    string
+		wantErr     bool
+	}{
+		{
+			name:        "single domain each",
+			rawGtid:     "2-211-5",
+			rawExternal: "1-10-9",
+			expected:    "1-10-9,2-211-5",
+		},
+		{
+			name:        "external multi-domain overrides shared domain",
+			rawGtid:     "2-211-5",
+			rawExternal: "1-10-9,2-211-30",
+			expected:    "1-10-9,2-211-30",
+		},
+		{
+			name:        "local multi-domain, external single overrides shared domain",
+			rawGtid:     "1-10-2,2-211-5",
+			rawExternal: "1-10-9",
+			expected:    "1-10-9,2-211-5",
+		},
+		{
+			name:        "empty local adopts external",
+			rawGtid:     "",
+			rawExternal: "1-10-9,2-211-30",
+			expected:    "1-10-9,2-211-30",
+		},
+		{
+			name:        "empty external keeps local",
+			rawGtid:     "1-10-2,2-211-5",
+			rawExternal: "",
+			expected:    "1-10-2,2-211-5",
+		},
+		{
+			name:        "both empty",
+			rawGtid:     "",
+			rawExternal: "",
+			expected:    "",
+		},
+		{
+			name:        "invalid external GTID",
+			rawGtid:     "1-10-2",
+			rawExternal: "1-10-216,2-211-18359-extra",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := composeGtids(tt.rawGtid, tt.rawExternal)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #1830 

Fixes the multiCluster demote path when the external primary's `gtid_binlog_pos` spans more than one GTID domain.

We hit this during a planned multi-site failover in our experiments: after promoting the remote site and letting the old site's history replicate over (`log_slave_updates`), the external primary's `gtid_binlog_pos` legitimately became multi-domain (e.g. 1-10-216,2-211-18359). On the next demote, `composeGtids()` errored out because it parsed both positions with the single-GTID ParseGtid, which rejects the comma-separated multi-domain list, so the reconcile failed on every attempt and `status.currentMultiClusterPrimary` never converged as we would expect.