### PR TITLE
fix: restore Galera logical backups and preserve repeatable backup args

### DIFF
--- a/docs/logical_backup.md
+++ b/docs/logical_backup.md
@@ -545,6 +545,18 @@ Also, to avoid situations where `mysql.global_priv` is unreplicated, all the ent
 - Rely on the [`User`](https://github.com/mariadb-operator/mariadb-operator/blob/main/examples/manifests/user.yaml) and [`Grant`](https://github.com/mariadb-operator/mariadb-operator/blob/main/examples/manifests/grant.yaml) CRs to create additional users and grants. Refer to the [SQL resource documentation](./sql_resources.md) for further detail.
 
 
+#### `mysql.wsrep_*`
+
+Galera manages its own set of system tables in the `mysql` database: `mysql.wsrep_cluster`, `mysql.wsrep_cluster_members`, `mysql.wsrep_streaming_log` and `mysql.wsrep_allowlist`. These tables hold Galera cluster runtime state and are recreated by Galera when a node bootstraps.
+
+A logical dump taken with `--all-databases` includes these tables, so the backup file contains a `DROP TABLE IF EXISTS` statement for each of them. On restore, Galera denies `DROP` on the `wsrep_*` tables even to `root`, so the restore aborts:
+
+```text
+ERROR 1142 (42000) at line 2646: DROP command denied to user 'root'@'...' for table `mysql`.`wsrep_streaming_log`
+```
+
+This makes disaster recovery from a default logical backup of a Galera cluster impossible. To address this, when backing up `MariaDB` instances with Galera enabled, the operator automatically excludes these tables from the dump using the `--ignore-table` option with `mariadb-dump`. Since Galera recreates them on bootstrap, no cluster state is lost.
+
 #### `LOCK TABLES` 
 
 Galera is not compatible with the `LOCK TABLES` statement:
@@ -566,7 +578,7 @@ mariadb-dump --user=${MARIADB_USER} --password=${MARIADB_PASSWORD} --host=${MARI
 > If you are using Galera or planning to migrate to a Galera instance, make sure you understand the [Galera backup limitations](#galera-backup-limitations) and use the following command instead:
 
 ```bash
-mariadb-dump --user=${MARIADB_USER} --password=${MARIADB_PASSWORD} --host=${MARIADB_HOST} --single-transaction --events --routines --all-databases --skip-add-locks --ignore-table=mysql.global_priv > backup.2024-08-26T12:24:34Z.sql
+mariadb-dump --user=${MARIADB_USER} --password=${MARIADB_PASSWORD} --host=${MARIADB_HOST} --single-transaction --events --routines --all-databases --skip-add-locks --ignore-table=mysql.global_priv --ignore-table=mysql.wsrep_cluster --ignore-table=mysql.wsrep_cluster_members --ignore-table=mysql.wsrep_streaming_log --ignore-table=mysql.wsrep_allowlist > backup.2024-08-26T12:24:34Z.sql
 ```
 
 2. Ensure that your backup file is named in the following format: `backup.2024-08-26T12:24:34Z.sql`. If the file name does not follow this format, it will be ignored by the operator.

--- a/docs/logical_backup.md
+++ b/docs/logical_backup.md
@@ -557,6 +557,9 @@ ERROR 1142 (42000) at line 2646: DROP command denied to user 'root'@'...' for ta
 
 This makes disaster recovery from a default logical backup of a Galera cluster impossible. To address this, when backing up `MariaDB` instances with Galera enabled, the operator automatically excludes these tables from the dump using the `--ignore-table` option with `mariadb-dump`. Since Galera recreates them on bootstrap, no cluster state is lost.
 
+> [!IMPORTANT]
+> Galera logical backups taken *before* this fix still contain the `mysql.wsrep_*` tables and remain unrestorable. Retake them once the operator includes this change.
+
 #### `LOCK TABLES` 
 
 Galera is not compatible with the `LOCK TABLES` statement:

--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -18,6 +18,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// galeraSystemTables are the mysql.wsrep_* system tables managed by Galera. They are
+// excluded from logical dumps because Galera denies DROP on them even to root, which
+// would otherwise make a restore fail. See mariadbDumpArgs and issue #1757.
+var galeraSystemTables = []string{
+	"mysql.wsrep_cluster",
+	"mysql.wsrep_cluster_members",
+	"mysql.wsrep_streaming_log",
+	"mysql.wsrep_allowlist",
+}
+
 type BackupOpts struct {
 	CommandOpts
 	Path                 string
@@ -572,6 +582,15 @@ func (b *BackupCommand) mariadbDumpArgs(backup *mariadbv1alpha1.Backup, mariadb 
 	// LOCK TABLES is not compatible with Galera: https://mariadb.com/kb/en/lock-tables/#limitations
 	if mariadb.IsGaleraEnabled() {
 		args = append(args, "--skip-add-locks")
+		// Galera manages the mysql.wsrep_* system tables and denies DROP on them even to
+		// root. A logical dump emits DROP TABLE IF EXISTS for them, so the restore aborts
+		// with "DROP command denied to user 'root'" and the MariaDB never becomes ready.
+		// Exclude them so a logical backup is restorable out of the box; Galera recreates
+		// these tables on bootstrap, so nothing is lost.
+		// See: https://github.com/mariadb-operator/mariadb-operator/issues/1757
+		for _, table := range galeraSystemTables {
+			args = append(args, fmt.Sprintf("--ignore-table=%s", table))
+		}
 	}
 	// Galera only replicates InnoDB tables and mysql.global_priv uses the MyISAM engine.
 	// Ignoring this table enables a clean restore without replicas getting restarted
@@ -629,12 +648,25 @@ func (b *BackupCommand) mariadbBackupArgs(mariadb *mariadbv1alpha1.MariaDB, targ
 	backupOpts := make([]string, len(b.ExtraOpts))
 	copy(backupOpts, b.ExtraOpts)
 
+	// mariadb-backup's --databases-exclude takes a single space-separated value and is
+	// last-wins (not repeatable), so a user-supplied --databases-exclude would silently
+	// drop the built-in lost+found exclusion. Merge both into a single flag instead (#1758).
+	// The ext4 filesystem creates a lost+found directory by default, which causes
+	// mariadb-backup to include it in the backup file as a database.
+	databasesExclude := []string{"lost+found"}
+	for _, opt := range backupOpts {
+		if isDatabasesExcludeOpt(opt) {
+			if value := databasesExcludeValue(opt); value != "" {
+				databasesExclude = append(databasesExclude, value)
+			}
+		}
+	}
+	backupOpts = ds.Remove(backupOpts, isDatabasesExcludeOpt)
+
 	args := []string{
 		"--backup",
 		"--stream=xbstream",
-		// The ext4 filesystem creates a lost+found directory by default,
-		// which causes mariadb-backup to include it in the backup file as a database.
-		"--databases-exclude='lost+found'",
+		fmt.Sprintf("--databases-exclude=%s", shellSingleQuote(strings.Join(databasesExclude, " "))),
 	}
 	if mariadb.IsTLSEnabled() {
 		args = append(args, b.tlsArgs(mariadb)...)
@@ -648,6 +680,31 @@ func (b *BackupCommand) mariadbBackupArgs(mariadb *mariadbv1alpha1.MariaDB, targ
 	}
 
 	return ds.UniqueArgs(ds.Merge(args, backupOpts)...)
+}
+
+// isDatabasesExcludeOpt reports whether opt is a --databases-exclude flag carrying a
+// value, in either the --databases-exclude=<value> or space-separated
+// --databases-exclude <value> form (mariadb-backup accepts both). A bare
+// --databases-exclude with the value in a separate argv element is intentionally not
+// matched, so it is left untouched rather than orphaning its value.
+func isDatabasesExcludeOpt(opt string) bool {
+	opt = strings.TrimSpace(opt)
+	return strings.HasPrefix(opt, "--databases-exclude=") || strings.HasPrefix(opt, "--databases-exclude ")
+}
+
+// databasesExcludeValue extracts the value of a --databases-exclude option, supporting
+// both the --databases-exclude=<value> and space-separated --databases-exclude <value>
+// forms and stripping any surrounding single or double quotes.
+func databasesExcludeValue(opt string) string {
+	rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(opt), "--databases-exclude"))
+	rest = strings.TrimSpace(strings.TrimPrefix(rest, "="))
+	return strings.Trim(rest, `'"`)
+}
+
+// shellSingleQuote wraps s in single quotes safe for a POSIX shell, escaping any embedded
+// single quotes so user-provided values cannot break out of the generated bash command.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func (b *BackupCommand) mariadbRestoreArgs(restore *mariadbv1alpha1.Restore, mariadb interfaces.TLSProvider) []string {

--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -18,6 +18,16 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// galeraSystemTables are the mysql.wsrep_* system tables managed by Galera. They are
+// excluded from logical dumps because Galera denies DROP on them even to root, which
+// would otherwise make a restore fail. See mariadbDumpArgs and issue #1757.
+var galeraSystemTables = []string{
+	"mysql.wsrep_cluster",
+	"mysql.wsrep_cluster_members",
+	"mysql.wsrep_streaming_log",
+	"mysql.wsrep_allowlist",
+}
+
 type BackupOpts struct {
 	CommandOpts
 	Path                 string
@@ -591,6 +601,15 @@ func (b *BackupCommand) mariadbDumpArgs(backup *mariadbv1alpha1.Backup, mariadb 
 	// LOCK TABLES is not compatible with Galera: https://mariadb.com/kb/en/lock-tables/#limitations
 	if mariadb.IsGaleraEnabled() {
 		args = append(args, "--skip-add-locks")
+		// Galera manages the mysql.wsrep_* system tables and denies DROP on them even to
+		// root. A logical dump emits DROP TABLE IF EXISTS for them, so the restore aborts
+		// with "DROP command denied to user 'root'" and the MariaDB never becomes ready.
+		// Exclude them so a logical backup is restorable out of the box; Galera recreates
+		// these tables on bootstrap, so nothing is lost.
+		// See: https://github.com/mariadb-operator/mariadb-operator/issues/1757
+		for _, table := range galeraSystemTables {
+			args = append(args, fmt.Sprintf("--ignore-table=%s", table))
+		}
 	}
 	// Galera only replicates InnoDB tables and mysql.global_priv uses the MyISAM engine.
 	// Ignoring this table enables a clean restore without replicas getting restarted
@@ -648,12 +667,25 @@ func (b *BackupCommand) mariadbBackupArgs(mariadb *mariadbv1alpha1.MariaDB, targ
 	backupOpts := make([]string, len(b.ExtraOpts))
 	copy(backupOpts, b.ExtraOpts)
 
+	// mariadb-backup's --databases-exclude takes a single space-separated value and is
+	// last-wins (not repeatable), so a user-supplied --databases-exclude would silently
+	// drop the built-in lost+found exclusion. Merge both into a single flag instead (#1758).
+	// The ext4 filesystem creates a lost+found directory by default, which causes
+	// mariadb-backup to include it in the backup file as a database.
+	databasesExclude := []string{"lost+found"}
+	for _, opt := range backupOpts {
+		if isDatabasesExcludeOpt(opt) {
+			if value := databasesExcludeValue(opt); value != "" {
+				databasesExclude = append(databasesExclude, value)
+			}
+		}
+	}
+	backupOpts = ds.Remove(backupOpts, isDatabasesExcludeOpt)
+
 	args := []string{
 		"--backup",
 		"--stream=xbstream",
-		// The ext4 filesystem creates a lost+found directory by default,
-		// which causes mariadb-backup to include it in the backup file as a database.
-		"--databases-exclude='lost+found'",
+		fmt.Sprintf("--databases-exclude=%s", shellSingleQuote(strings.Join(databasesExclude, " "))),
 	}
 	if mariadb.IsTLSEnabled() {
 		args = append(args, b.tlsArgs(mariadb)...)
@@ -667,6 +699,31 @@ func (b *BackupCommand) mariadbBackupArgs(mariadb *mariadbv1alpha1.MariaDB, targ
 	}
 
 	return ds.UniqueArgs(ds.Merge(args, backupOpts)...)
+}
+
+// isDatabasesExcludeOpt reports whether opt is a --databases-exclude flag carrying a
+// value, in either the --databases-exclude=<value> or space-separated
+// --databases-exclude <value> form (mariadb-backup accepts both). A bare
+// --databases-exclude with the value in a separate argv element is intentionally not
+// matched, so it is left untouched rather than orphaning its value.
+func isDatabasesExcludeOpt(opt string) bool {
+	opt = strings.TrimSpace(opt)
+	return strings.HasPrefix(opt, "--databases-exclude=") || strings.HasPrefix(opt, "--databases-exclude ")
+}
+
+// databasesExcludeValue extracts the value of a --databases-exclude option, supporting
+// both the --databases-exclude=<value> and space-separated --databases-exclude <value>
+// forms and stripping any surrounding single or double quotes.
+func databasesExcludeValue(opt string) string {
+	rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(opt), "--databases-exclude"))
+	rest = strings.TrimSpace(strings.TrimPrefix(rest, "="))
+	return strings.Trim(rest, `'"`)
+}
+
+// shellSingleQuote wraps s in single quotes safe for a POSIX shell, escaping any embedded
+// single quotes so user-provided values cannot break out of the generated bash command.
+func shellSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }
 
 func (b *BackupCommand) mariadbRestoreArgs(restore *mariadbv1alpha1.Restore, mariadb interfaces.TLSProvider) []string {

--- a/pkg/command/backup.go
+++ b/pkg/command/backup.go
@@ -669,18 +669,43 @@ func (b *BackupCommand) mariadbBackupArgs(mariadb *mariadbv1alpha1.MariaDB, targ
 
 	// mariadb-backup's --databases-exclude takes a single space-separated value and is
 	// last-wins (not repeatable), so a user-supplied --databases-exclude would silently
-	// drop the built-in lost+found exclusion. Merge both into a single flag instead (#1758).
-	// The ext4 filesystem creates a lost+found directory by default, which causes
-	// mariadb-backup to include it in the backup file as a database.
-	databasesExclude := []string{"lost+found"}
-	for _, opt := range backupOpts {
-		if isDatabasesExcludeOpt(opt) {
-			if value := databasesExcludeValue(opt); value != "" {
-				databasesExclude = append(databasesExclude, value)
+	// drop the built-in lost+found exclusion. Collect every excluded database (the built-in
+	// lost+found plus any from spec.args, in all supported forms) and emit them as a single
+	// flag instead (#1758). The ext4 filesystem creates a lost+found directory by default,
+	// which mariadb-backup would otherwise include as a database.
+	seen := make(map[string]bool)
+	var databasesExclude []string
+	addDatabasesExclude := func(value string) {
+		// A value may itself be a space-separated list; split it and dedupe database names,
+		// preserving first-seen order for a deterministic command.
+		for _, name := range strings.Fields(value) {
+			if !seen[name] {
+				seen[name] = true
+				databasesExclude = append(databasesExclude, name)
 			}
 		}
 	}
-	backupOpts = ds.Remove(backupOpts, isDatabasesExcludeOpt)
+	addDatabasesExclude("lost+found")
+
+	var remainingOpts []string
+	for i := 0; i < len(backupOpts); i++ {
+		opt := backupOpts[i]
+		// Single-element forms: --databases-exclude=<value> or --databases-exclude <value>.
+		if isDatabasesExcludeOpt(opt) {
+			addDatabasesExclude(databasesExcludeValue(opt))
+			continue
+		}
+		// Two-element form: a bare --databases-exclude with its value as the next entry.
+		if strings.TrimSpace(opt) == "--databases-exclude" {
+			if i+1 < len(backupOpts) {
+				addDatabasesExclude(trimQuotes(backupOpts[i+1]))
+				i++ // consume the value entry
+			}
+			continue
+		}
+		remainingOpts = append(remainingOpts, opt)
+	}
+	backupOpts = remainingOpts
 
 	args := []string{
 		"--backup",
@@ -701,23 +726,29 @@ func (b *BackupCommand) mariadbBackupArgs(mariadb *mariadbv1alpha1.MariaDB, targ
 	return ds.UniqueArgs(ds.Merge(args, backupOpts)...)
 }
 
-// isDatabasesExcludeOpt reports whether opt is a --databases-exclude flag carrying a
-// value, in either the --databases-exclude=<value> or space-separated
-// --databases-exclude <value> form (mariadb-backup accepts both). A bare
-// --databases-exclude with the value in a separate argv element is intentionally not
-// matched, so it is left untouched rather than orphaning its value.
+// isDatabasesExcludeOpt reports whether opt is a single-element --databases-exclude flag
+// carrying a value, in either the --databases-exclude=<value> or space-separated
+// --databases-exclude <value> form (mariadb-backup accepts both). The bare
+// --databases-exclude form, with the value in a separate argv element, is handled
+// directly in mariadbBackupArgs, which needs the following element.
 func isDatabasesExcludeOpt(opt string) bool {
 	opt = strings.TrimSpace(opt)
 	return strings.HasPrefix(opt, "--databases-exclude=") || strings.HasPrefix(opt, "--databases-exclude ")
 }
 
-// databasesExcludeValue extracts the value of a --databases-exclude option, supporting
-// both the --databases-exclude=<value> and space-separated --databases-exclude <value>
-// forms and stripping any surrounding single or double quotes.
+// databasesExcludeValue extracts the value of a single-element --databases-exclude option,
+// supporting both the --databases-exclude=<value> and space-separated
+// --databases-exclude <value> forms and stripping any surrounding quotes.
 func databasesExcludeValue(opt string) string {
 	rest := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(opt), "--databases-exclude"))
-	rest = strings.TrimSpace(strings.TrimPrefix(rest, "="))
-	return strings.Trim(rest, `'"`)
+	rest = strings.TrimPrefix(rest, "=")
+	return trimQuotes(rest)
+}
+
+// trimQuotes strips surrounding whitespace and a single layer of surrounding single or
+// double quotes from s.
+func trimQuotes(s string) string {
+	return strings.Trim(strings.TrimSpace(s), `'"`)
 }
 
 // shellSingleQuote wraps s in single quotes safe for a POSIX shell, escaping any embedded

--- a/pkg/command/backup_test.go
+++ b/pkg/command/backup_test.go
@@ -146,6 +146,10 @@ func TestMariadbDumpArgs(t *testing.T) {
 				"--routines",
 				"--all-databases",
 				"--skip-add-locks",
+				"--ignore-table=mysql.wsrep_cluster",
+				"--ignore-table=mysql.wsrep_cluster_members",
+				"--ignore-table=mysql.wsrep_streaming_log",
+				"--ignore-table=mysql.wsrep_allowlist",
 			},
 		},
 		{
@@ -219,9 +223,53 @@ func TestMariadbDumpArgs(t *testing.T) {
 				"--routines",
 				"--all-databases",
 				"--skip-add-locks",
+				"--ignore-table=mysql.wsrep_cluster",
+				"--ignore-table=mysql.wsrep_cluster_members",
+				"--ignore-table=mysql.wsrep_streaming_log",
+				"--ignore-table=mysql.wsrep_allowlist",
 				"--ignore-table=mysql.global_priv",
 				"--verbose",
 				"--add-drop-table",
+			},
+		},
+		{
+			// Galera-managed wsrep_* exclusions (#1757) coexist with the operator's
+			// global_priv exclusion and user-supplied repeatable --ignore-table args (#1758)
+			// instead of collapsing to a single --ignore-table value.
+			name: "Galera wsrep exclusions coexist with user ignore-table",
+			backupCmd: &BackupCommand{
+				BackupOpts{
+					ExtraOpts: []string{
+						"--ignore-table=wordpress.argtest_one",
+						"--ignore-table=wordpress.argtest_two",
+					},
+				},
+			},
+			backup: &mariadbv1alpha1.Backup{
+				Spec: mariadbv1alpha1.BackupSpec{
+					IgnoreGlobalPriv: ptr.To(true),
+				},
+			},
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					Galera: &mariadbv1alpha1.Galera{
+						Enabled: true,
+					},
+				},
+			},
+			wantArgs: []string{
+				"--single-transaction",
+				"--events",
+				"--routines",
+				"--all-databases",
+				"--skip-add-locks",
+				"--ignore-table=mysql.wsrep_cluster",
+				"--ignore-table=mysql.wsrep_cluster_members",
+				"--ignore-table=mysql.wsrep_streaming_log",
+				"--ignore-table=mysql.wsrep_allowlist",
+				"--ignore-table=mysql.global_priv",
+				"--ignore-table=wordpress.argtest_one",
+				"--ignore-table=wordpress.argtest_two",
 			},
 		},
 		{
@@ -348,6 +396,10 @@ func TestMariadbDumpArgs(t *testing.T) {
 				"--routines",
 				"--databases db1 db2 db3",
 				"--skip-add-locks",
+				"--ignore-table=mysql.wsrep_cluster",
+				"--ignore-table=mysql.wsrep_cluster_members",
+				"--ignore-table=mysql.wsrep_streaming_log",
+				"--ignore-table=mysql.wsrep_allowlist",
 				"--ignore-table=mysql.global_priv",
 				"--verbose",
 				"--add-drop-table",
@@ -489,6 +541,78 @@ func TestMariadbBackupArgs(t *testing.T) {
 				"--databases-exclude='lost+found'",
 				"--slave-info",
 				"--safe-slave-backup",
+			},
+		},
+		{
+			// mariadb-backup's --databases-exclude is last-wins, so a user-supplied value
+			// must be merged with the built-in lost+found exclusion into a single flag
+			// instead of overriding it (#1758).
+			name: "user databases-exclude merged with lost+found",
+			backupCmd: &BackupCommand{
+				BackupOpts: BackupOpts{
+					ExtraOpts: []string{"--databases-exclude=mysql"},
+				},
+			},
+			mariadb:        &mariadbv1alpha1.MariaDB{},
+			targetPodIndex: 0,
+			wantArgs: []string{
+				"--backup",
+				"--stream=xbstream",
+				"--databases-exclude='lost+found mysql'",
+			},
+		},
+		{
+			name: "multiple quoted databases-exclude merged with lost+found",
+			backupCmd: &BackupCommand{
+				BackupOpts: BackupOpts{
+					ExtraOpts: []string{
+						"--databases-exclude='mysql sys'",
+						"--databases-exclude=test",
+						"--compress",
+					},
+				},
+			},
+			mariadb:        &mariadbv1alpha1.MariaDB{},
+			targetPodIndex: 0,
+			wantArgs: []string{
+				"--backup",
+				"--stream=xbstream",
+				"--databases-exclude='lost+found mysql sys test'",
+				"--compress",
+			},
+		},
+		{
+			// mariadb-backup also accepts the space-separated long-option form, which must
+			// be merged as well instead of overriding lost+found.
+			name: "space-separated databases-exclude merged with lost+found",
+			backupCmd: &BackupCommand{
+				BackupOpts: BackupOpts{
+					ExtraOpts: []string{"--databases-exclude mysql"},
+				},
+			},
+			mariadb:        &mariadbv1alpha1.MariaDB{},
+			targetPodIndex: 0,
+			wantArgs: []string{
+				"--backup",
+				"--stream=xbstream",
+				"--databases-exclude='lost+found mysql'",
+			},
+		},
+		{
+			// A single quote in a user-supplied value must not break out of the
+			// single-quoted shell fragment that reaches bash -c.
+			name: "databases-exclude value with single quote is shell-escaped",
+			backupCmd: &BackupCommand{
+				BackupOpts: BackupOpts{
+					ExtraOpts: []string{`--databases-exclude=od'd`},
+				},
+			},
+			mariadb:        &mariadbv1alpha1.MariaDB{},
+			targetPodIndex: 0,
+			wantArgs: []string{
+				"--backup",
+				"--stream=xbstream",
+				`--databases-exclude='lost+found od'\''d'`,
 			},
 		},
 	}

--- a/pkg/command/backup_test.go
+++ b/pkg/command/backup_test.go
@@ -599,6 +599,47 @@ func TestMariadbBackupArgs(t *testing.T) {
 			},
 		},
 		{
+			// mariadb-backup also accepts the flag and value as two separate argv
+			// elements. That form must be merged too, otherwise the bare user flag would
+			// last-win and silently drop the built-in lost+found exclusion.
+			name: "two-element databases-exclude merged with lost+found",
+			backupCmd: &BackupCommand{
+				BackupOpts: BackupOpts{
+					ExtraOpts: []string{"--databases-exclude", "mysql", "--compress"},
+				},
+			},
+			mariadb:        &mariadbv1alpha1.MariaDB{},
+			targetPodIndex: 0,
+			wantArgs: []string{
+				"--backup",
+				"--stream=xbstream",
+				"--databases-exclude='lost+found mysql'",
+				"--compress",
+			},
+		},
+		{
+			// Duplicate database names across forms collapse to a single entry, preserving
+			// first-seen order for a deterministic command.
+			name: "duplicate databases-exclude names are deduplicated",
+			backupCmd: &BackupCommand{
+				BackupOpts: BackupOpts{
+					ExtraOpts: []string{
+						"--databases-exclude=mysql sys",
+						"--databases-exclude",
+						"mysql",
+						"--databases-exclude=lost+found",
+					},
+				},
+			},
+			mariadb:        &mariadbv1alpha1.MariaDB{},
+			targetPodIndex: 0,
+			wantArgs: []string{
+				"--backup",
+				"--stream=xbstream",
+				"--databases-exclude='lost+found mysql sys'",
+			},
+		},
+		{
 			// A single quote in a user-supplied value must not break out of the
 			// single-quoted shell fragment that reaches bash -c.
 			name: "databases-exclude value with single quote is shell-escaped",

--- a/pkg/datastructures/datastructures.go
+++ b/pkg/datastructures/datastructures.go
@@ -127,10 +127,31 @@ func Unique[T comparable](elements ...T) []T {
 	return result
 }
 
+// repeatableFlags are CLI flags whose mariadb-dump semantics let the user pass
+// the option multiple times, each value adding another table to the ignore list
+// rather than overriding the previous one. UniqueArgs must keep every distinct
+// occurrence of these flags; collapsing them to the last one would silently drop
+// user-supplied entries as well as operator-injected defaults that share the same
+// flag name (e.g. --ignore-table=mysql.global_priv and the Galera mysql.wsrep_*
+// exclusions). See https://github.com/mariadb-operator/mariadb-operator/issues/1691
+// and https://github.com/mariadb-operator/mariadb-operator/issues/1757.
+//
+// Only flags documented as repeatable by mariadb-dump are listed here. Options
+// that take a single space-separated value and are last-wins (e.g. mariadb-backup
+// --databases-exclude) must NOT be added: keeping several occurrences would not
+// merge them, the tool would still honour only the last one.
+var repeatableFlags = map[string]struct{}{
+	"--ignore-table":      {},
+	"--ignore-table-data": {},
+}
+
 // UniqueArgs returns unique CLI arguments with smart deduplication:
-//   - For exact duplicates (same string), keeps the first occurrence to preserve order
+//   - For repeatable flags (e.g. --ignore-table) every distinct occurrence is
+//     kept regardless of value; only exact-string duplicates are folded.
+//   - For other exact duplicates (same string), keeps the first occurrence to
+//     preserve order.
 //   - For flag name conflicts with different values (e.g., --flag vs --flag=value),
-//     keeps the last occurrence so user-specified args can override defaults
+//     keeps the last occurrence so user-specified args can override defaults.
 func UniqueArgs(args ...string) []string {
 	type occurrence struct {
 		index int
@@ -146,26 +167,41 @@ func UniqueArgs(args ...string) []string {
 
 	// Determine which index to keep for each flag
 	keepIndex := make(map[int]bool)
-	for _, occurrences := range flagOccurrences {
+	for flagName, occurrences := range flagOccurrences {
 		if len(occurrences) == 1 {
 			keepIndex[occurrences[0].index] = true
-		} else {
-			// Check if all args are identical (exact duplicates)
-			allSame := true
-			first := occurrences[0].arg
-			for _, occ := range occurrences[1:] {
-				if occ.arg != first {
-					allSame = false
-					break
+			continue
+		}
+
+		if _, repeatable := repeatableFlags[flagName]; repeatable {
+			// Repeatable flags: keep every distinct full-string occurrence,
+			// collapsing only exact-string duplicates so argv does not grow when
+			// user args overlap with operator defaults.
+			seen := make(map[string]bool, len(occurrences))
+			for _, occ := range occurrences {
+				if !seen[occ.arg] {
+					seen[occ.arg] = true
+					keepIndex[occ.index] = true
 				}
 			}
-			if allSame {
-				// Keep first for exact duplicates (preserve order)
-				keepIndex[occurrences[0].index] = true
-			} else {
-				// Keep last for value overrides (user args win)
-				keepIndex[occurrences[len(occurrences)-1].index] = true
+			continue
+		}
+
+		// Check if all args are identical (exact duplicates)
+		allSame := true
+		first := occurrences[0].arg
+		for _, occ := range occurrences[1:] {
+			if occ.arg != first {
+				allSame = false
+				break
 			}
+		}
+		if allSame {
+			// Keep first for exact duplicates (preserve order)
+			keepIndex[occurrences[0].index] = true
+		} else {
+			// Keep last for value overrides (user args win)
+			keepIndex[occurrences[len(occurrences)-1].index] = true
 		}
 	}
 

--- a/pkg/datastructures/datastructures.go
+++ b/pkg/datastructures/datastructures.go
@@ -139,7 +139,7 @@ func Unique[T comparable](elements ...T) []T {
 // Only flags documented as repeatable by mariadb-dump are listed here. Options
 // that take a single space-separated value and are last-wins (e.g. mariadb-backup
 // --databases-exclude) must NOT be added: keeping several occurrences would not
-// merge them, the tool would still honour only the last one.
+// merge them, the tool would still honor only the last one.
 var repeatableFlags = map[string]struct{}{
 	"--ignore-table":      {},
 	"--ignore-table-data": {},

--- a/pkg/datastructures/datastructures_test.go
+++ b/pkg/datastructures/datastructures_test.go
@@ -405,6 +405,71 @@ func TestUniqueArgs(t *testing.T) {
 			},
 		},
 		{
+			// mariadb-dump's --ignore-table is repeatable: each instance adds
+			// another table to ignore. UniqueArgs must not collapse distinct
+			// values (#1691).
+			name: "repeatable --ignore-table flags are preserved",
+			args: []string{
+				"--single-transaction",
+				"--all-databases",
+				"--ignore-table=mysql.help_category",
+				"--ignore-table=mysql.help_relation",
+				"--ignore-table=mysql.help_topic",
+			},
+			wantElements: []string{
+				"--single-transaction",
+				"--all-databases",
+				"--ignore-table=mysql.help_category",
+				"--ignore-table=mysql.help_relation",
+				"--ignore-table=mysql.help_topic",
+			},
+		},
+		{
+			// Operator-injected --ignore-table defaults (global_priv, Galera
+			// wsrep_*) must survive alongside user-supplied --ignore-table args
+			// instead of being collapsed to a single value (#1757).
+			name: "operator and user --ignore-table flags coexist",
+			args: []string{
+				"--all-databases",
+				"--ignore-table=mysql.global_priv",
+				"--ignore-table=mysql.wsrep_cluster",
+				"--ignore-table=mysql.wsrep_streaming_log",
+				"--ignore-table=wordpress.custom",
+			},
+			wantElements: []string{
+				"--all-databases",
+				"--ignore-table=mysql.global_priv",
+				"--ignore-table=mysql.wsrep_cluster",
+				"--ignore-table=mysql.wsrep_streaming_log",
+				"--ignore-table=wordpress.custom",
+			},
+		},
+		{
+			// Exact-string repeats of a repeatable flag are still collapsed so we
+			// don't grow argv when defaults overlap with user args.
+			name: "repeatable flag exact duplicates are collapsed",
+			args: []string{
+				"--ignore-table=mysql.global_priv",
+				"--ignore-table=mysql.help_category",
+				"--ignore-table=mysql.global_priv",
+			},
+			wantElements: []string{
+				"--ignore-table=mysql.global_priv",
+				"--ignore-table=mysql.help_category",
+			},
+		},
+		{
+			name: "repeatable --ignore-table-data flags are preserved",
+			args: []string{
+				"--ignore-table-data=db_c.t1",
+				"--ignore-table-data=db_c.t2",
+			},
+			wantElements: []string{
+				"--ignore-table-data=db_c.t1",
+				"--ignore-table-data=db_c.t2",
+			},
+		},
+		{
 			name: "mixed exact and value duplicates",
 			args: []string{
 				"--single-transaction",


### PR DESCRIPTION
Close MDB-17

## Summary

Fixes two coupled bugs that make disaster recovery from a logical `Backup` of a Galera cluster impossible.

### #1757 — Galera logical backups are not restorable

A logical dump runs with `--all-databases` and includes the Galera-managed `mysql.wsrep_*` system tables. On restore the dump issues `DROP TABLE IF EXISTS` for them, which Galera denies even to `root`, so the restore aborts and the `MariaDB` never becomes ready:

```text
ERROR 1142 (42000) at line 2646: DROP command denied to user 'root'@'...' for table `mysql`.`wsrep_streaming_log`
```

We now exclude `mysql.wsrep_cluster`, `mysql.wsrep_cluster_members`, `mysql.wsrep_streaming_log` and `mysql.wsrep_allowlist` from the dump — the same way `mysql.global_priv` already is (#556). Galera recreates these tables on bootstrap, so nothing is lost.

### #1758 / #1691 — `spec.args` dropped repeated same-name flags

`UniqueArgs` collapsed repeated same-name flags to a single value, so multiple `--ignore-table` args (and the operator's own injected excludes) were silently dropped — which also blocked the fix for #1757. `UniqueArgs` now preserves every distinct occurrence of the repeatable `mariadb-dump` flags (`--ignore-table`, `--ignore-table-data`), collapsing only exact duplicates; scalar flags keep their last-wins override. This builds on the approach proposed by @SAY-5 in #1721 (credited as co-author).

Additionally, `mariadb-backup`'s `--databases-exclude` is a single-value, last-wins flag (accepting a space-separated list), so a user-supplied `--databases-exclude` silently dropped the built-in `lost+found` exclusion. Operator default and user values (in both `--databases-exclude=<v>` and `--databases-exclude <v>` forms) are now merged into a single, shell-escaped flag.

Closes #1757.
Closes #1758.
Closes #1691.

Supersedes #1721.

## Test plan

- New/updated unit tests in `pkg/datastructures` (repeatable flags preserved, operator + user `--ignore-table` coexist) and `pkg/command` (Galera `wsrep_*` excludes, `--databases-exclude` merge incl. space form and single-quote escaping).
- `go test ./pkg/command/... ./pkg/datastructures/...`, `go vet`, `gofmt`, `go build ./...` — all green.
- No API/CRD changes, so no codegen diff.