### PR TITLE
fix: MinIO AWS S3 dualstack routing

### DIFF
--- a/pkg/minio/minio.go
+++ b/pkg/minio/minio.go
@@ -186,12 +186,28 @@ func NewMinioClient(basePath, bucket, endpoint string, mOpts ...MinioOpt) (*Clie
 	if err != nil {
 		return nil, fmt.Errorf("error creating Minio client: %v", err)
 	}
+
+	// minio-go silently rewrites Amazon S3 endpoints to their dual-stack variant
+	// (e.g. s3.<region>.amazonaws.com -> s3.dualstack.<region>.amazonaws.com) and
+	// enables it by default. That breaks setups where only the standard endpoint is
+	// routable, such as S3 gateway VPC endpoints. Honor the endpoint the user configured:
+	// only keep dual-stack when it was explicitly requested. This is a no-op for
+	// non-Amazon endpoints.
+	client.SetS3EnableDualstack(dualStackEnabled(endpoint))
 	return &Client{
 		Client:    client,
 		MinioOpts: opts,
 		basePath:  basePath,
 		bucket:    bucket,
 	}, nil
+}
+
+// dualStackEnabled reports whether the S3 client should use Amazon dual-stack
+// endpoints. minio-go turns dual-stack on by default for any Amazon endpoint and
+// rewrites the request host accordingly, discarding the configured endpoint. We
+// only want that when the user explicitly configured a dual-stack endpoint.
+func dualStackEnabled(endpoint string) bool {
+	return strings.Contains(endpoint, ".dualstack.")
 }
 
 func (c *Client) ListObjectsWithOptions(ctx context.Context) ([]string, error) {

--- a/pkg/minio/minio_test.go
+++ b/pkg/minio/minio_test.go
@@ -255,6 +255,52 @@ func TestPrefix(t *testing.T) {
 	}
 }
 
+func TestDualStackEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		endpoint string
+		want     bool
+	}{
+		{
+			name:     "standard AWS regional endpoint",
+			endpoint: "s3.eu-central-1.amazonaws.com",
+			want:     false,
+		},
+		{
+			name:     "global AWS endpoint",
+			endpoint: "s3.amazonaws.com",
+			want:     false,
+		},
+		{
+			name:     "explicit dual-stack endpoint",
+			endpoint: "s3.dualstack.eu-central-1.amazonaws.com",
+			want:     true,
+		},
+		{
+			name:     "explicit FIPS dual-stack endpoint",
+			endpoint: "s3-fips.dualstack.us-east-1.amazonaws.com",
+			want:     true,
+		},
+		{
+			name:     "non-AWS S3-compatible endpoint",
+			endpoint: "minio:9000",
+			want:     false,
+		},
+		{
+			name:     "empty endpoint",
+			endpoint: "",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dualStackEnabled(tt.endpoint); got != tt.want {
+				t.Errorf("unexpected dual-stack decision for %q, got: %t want: %t", tt.endpoint, got, tt.want)
+			}
+		})
+	}
+}
 func TestS3GetSSEC(t *testing.T) {
 	// Valid 32-byte key for AES-256
 	validKey := make([]byte, 32)


### PR DESCRIPTION
closes #1842 

EDIT:

before this change:

This IP is not expected:

```json
{
   "level":"error",
   "ts":1783945217.8035233,
   "msg":"error pushing target backup",
   "file":"/backup/backup.2026-07-13T12:00:03Z.sql.gz",
   "error":"Put \"https://test-mariadb-backup-dev.s3.dualstack.eu-central-1.amazonaws.com/test/mariadb/backup.2026-07-13T12%3A00%3A03Z.sql.gz\": dial tcp 3.5.135.64:443: i/o timeout",
   "stacktrace":"github.com/mariadb-operator/mariadb-operator/v26/cmd/backup.init.func1\n\t/app/cmd/backup/main.go:163\ngithub.com/spf13/cobra.(*Command).execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1019\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148\ngithub.com/spf13/cobra.(*Command).Execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071\nmain.main\n\t/app/cmd/controller/main.go:599\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:290"
}
```

after this change:

This IP is expected:

```json
{
   "level":"error",
   "ts":1784020254.2090642,
   "msg":"error pushing target backup",
   "file":"/backup/backup.2026-07-14T09:00:03Z.sql.gz",
   "error":"Put \"https://test-mariadb-backup-dev.s3.eu-central-1.amazonaws.com/test/mariadb/backup.2026-07-14T09%3A00%3A03Z.sql.gz\": dial tcp 10.100.179.107:443: i/o timeout",
   "stacktrace":"github.com/mariadb-operator/mariadb-operator/v26/cmd/backup.init.func1\n\t/app/cmd/backup/main.go:163\ngithub.com/spf13/cobra.(*Command).execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1019\ngithub.com/spf13/cobra.(*Command).ExecuteC\n\t/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148\ngithub.com/spf13/cobra.(*Command).Execute\n\t/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1071\nmain.main\n\t/app/cmd/controller/main.go:599\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:290"
}
```