### PR TITLE
fix: prevent replication switchover from deadlocking with the primary locked

### DIFF
--- a/api/v1alpha1/event_types.go
+++ b/api/v1alpha1/event_types.go
@@ -11,6 +11,11 @@ const (
 	ReasonReplicationReplicaSync = "ReplicaSync"
 	// ReasonReplicationReplicaSyncErr indicates that an error has happened while replicas were being synced with primary.
 	ReasonReplicationReplicaSyncErr = "ReplicaSyncErr"
+	// Indicates that a replica replicating from a wrong source is being reconnected to the current primary.
+	ReasonReplicationReplicaSourceFix = "ReplicaSourceFix"
+	// Indicates that a switchover attempt failed before promoting the new primary
+	// and the current primary has been unlocked until the next attempt.
+	ReasonReplicationSwitchoverRetry = "SwitchoverRetry"
 	// ReasonReplicationPrimaryNewSync indicates that the new primary is being synced.
 	ReasonReplicationPrimaryNewSync = "PrimaryNewSync"
 	// ReasonReplicationPrimaryNewSync indicates that an error has happened while the new primary was being synced.

--- a/pkg/controller/replication/switchover.go
+++ b/pkg/controller/replication/switchover.go
@@ -24,6 +24,9 @@ import (
 type switchoverPhase struct {
 	name      string
 	reconcile func(context.Context, *ReconcileRequest, logr.Logger) error
+	// Phases running before the new primary is configured: if one fails, the current primary
+	// can be safely unlocked until the next reconciliation.
+	prePromotion bool
 }
 
 func isSwitchoverStale(mdb *mariadbv1alpha1.MariaDB) bool {
@@ -70,16 +73,19 @@ func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *Re
 
 	phases := []switchoverPhase{
 		{
-			name:      "Lock primary with read lock",
-			reconcile: r.lockPrimaryWithReadLock,
+			name:         "Lock primary with read lock",
+			reconcile:    r.lockPrimaryWithReadLock,
+			prePromotion: true,
 		},
 		{
-			name:      "Set read_only in primary",
-			reconcile: r.setPrimaryReadOnly,
+			name:         "Set read_only in primary",
+			reconcile:    r.setPrimaryReadOnly,
+			prePromotion: true,
 		},
 		{
-			name:      "Wait sync",
-			reconcile: r.waitSync,
+			name:         "Wait sync",
+			reconcile:    r.waitSync,
+			prePromotion: true,
 		},
 		{
 			name:      "Configure new primary",
@@ -99,6 +105,17 @@ func (r *ReplicationReconciler) reconcileSwitchover(ctx context.Context, req *Re
 		if err := p.reconcile(ctx, req, logger.WithValues("phase", p.name)); err != nil {
 			if apierrors.IsNotFound(err) {
 				return err
+			}
+			// Keeping the primary locked across reconciliations would leave applications without
+			// writes indefinitely if the switchover is unable to complete.
+			if p.prePromotion && req.currentPrimaryReady {
+				if unlockErr := r.unlockPrimary(ctx, req, logger); unlockErr != nil {
+					logger.Error(unlockErr, "Error unlocking primary after switchover phase error", "phase", p.name)
+				} else {
+					r.recorder.Eventf(req.mariadb, nil, corev1.EventTypeWarning, mariadbv1alpha1.ReasonReplicationSwitchoverRetry,
+						mariadbv1alpha1.ReasonReplicationSwitchoverRetry,
+						"Switchover phase '%s' failed. Primary unlocked until next attempt", p.name)
+				}
 			}
 			return fmt.Errorf("error in %s switchover reconcile phase: %v", p.name, err)
 		}
@@ -126,6 +143,24 @@ func (r *ReplicationReconciler) reconcileStaleSwitchover(ctx context.Context, re
 		logger.Info("Skipped stale switchover reconciliation due to primary's non ready status")
 		return nil
 	}
+	if err := r.unlockPrimary(ctx, req, logger); err != nil {
+		return err
+	}
+
+	if err := r.patchStatus(ctx, req.mariadb, func(status *mariadbv1alpha1.MariaDBStatus) {
+		condition.SetPrimarySwitched(&req.mariadb.Status)
+	}); err != nil {
+		return fmt.Errorf("error patching MariaDB status: %v", err)
+	}
+
+	logger.Info("Stale switchover has been reset")
+	r.recorder.Eventf(req.mariadb, nil, corev1.EventTypeNormal, mariadbv1alpha1.ReasonReplicationResetStaleSwitchover,
+		mariadbv1alpha1.ReasonReplicationResetStaleSwitchover, "Stale switchover has been reset")
+	return nil
+}
+
+// Releases the read lock and readonly mode in the current primary.
+func (r *ReplicationReconciler) unlockPrimary(ctx context.Context, req *ReconcileRequest, logger logr.Logger) error {
 	currentPrimaryClient, err := req.replClientSet.currentPrimaryClient(ctx)
 	if err != nil {
 		return fmt.Errorf("error getting current primary client: %v", err)
@@ -140,16 +175,6 @@ func (r *ReplicationReconciler) reconcileStaleSwitchover(ctx context.Context, re
 	if err := currentPrimaryClient.DisableReadOnly(ctx); err != nil {
 		return fmt.Errorf("error disabling readonly in primary: %v", err)
 	}
-
-	if err := r.patchStatus(ctx, req.mariadb, func(status *mariadbv1alpha1.MariaDBStatus) {
-		condition.SetPrimarySwitched(&req.mariadb.Status)
-	}); err != nil {
-		return fmt.Errorf("error patching MariaDB status: %v", err)
-	}
-
-	logger.Info("Stale switchover has been reset")
-	r.recorder.Eventf(req.mariadb, nil, corev1.EventTypeNormal, mariadbv1alpha1.ReasonReplicationResetStaleSwitchover,
-		mariadbv1alpha1.ReasonReplicationResetStaleSwitchover, "Stale switchover has been reset")
 	return nil
 }
 
@@ -218,11 +243,18 @@ func (r *ReplicationReconciler) waitForReplicaSync(ctx context.Context, req *Rec
 		mariadbv1alpha1.ReasonReplicationReplicaSync, "Waiting for replicas to be synced with primary")
 	replication := ptr.Deref(req.mariadb.Spec.Replication, mariadbv1alpha1.Replication{})
 
+	currentPrimary := *req.mariadb.Status.CurrentPrimaryPodIndex
+	currentPrimaryHost := statefulset.PodFQDNWithService(
+		req.mariadb.ObjectMeta,
+		currentPrimary,
+		req.mariadb.InternalServiceKey().Name,
+	)
+
 	g := new(errgroup.Group)
 	g.SetLimit(int(req.mariadb.Spec.Replicas))
 
 	for i := 0; i < int(req.mariadb.Spec.Replicas); i++ {
-		if i == *req.mariadb.Status.CurrentPrimaryPodIndex {
+		if i == currentPrimary {
 			continue
 		}
 		g.Go(func() error {
@@ -230,6 +262,26 @@ func (r *ReplicationReconciler) waitForReplicaSync(ctx context.Context, req *Rec
 			if err != nil {
 				return fmt.Errorf("error getting replica '%d' client: %v", i, err)
 			}
+
+			// A replica replicating from a host other than the current primary (e.g. the new primary
+			// before promotion, which does not relay the current primary's events) would never reach
+			// the GTID, blocking the switchover and keeping the primary locked. See #1852.
+			sourceHost, err := replClient.ReplicaMasterHost(ctx)
+			if err != nil {
+				return fmt.Errorf("error getting replication source of replica '%d': %v", i, err)
+			}
+			if sourceHost != currentPrimaryHost {
+				logger.Info("Replica is not replicating from the current primary. Reconnecting it",
+					"replica", i, "source", sourceHost)
+				r.recorder.Eventf(req.mariadb, nil, corev1.EventTypeWarning, mariadbv1alpha1.ReasonReplicationReplicaSourceFix,
+					mariadbv1alpha1.ReasonReplicationReplicaSourceFix,
+					"Replica '%d' is replicating from '%s' instead of the current primary. Reconnecting it", i, sourceHost)
+				topology := r.topologyManager.TopologyForMariaDB(req.mariadb, logger.WithValues("replica", i))
+				if err := topology.ConfigureReplica(ctx, replClient, currentPrimary, WithResetMaster(false)); err != nil {
+					return fmt.Errorf("error reconnecting replica '%d' to the current primary: %v", i, err)
+				}
+			}
+
 			logger.V(1).Info("Syncing replica with primary GTID", "replica", i, "gtid", primaryGtid)
 			syncTimeout := ptr.Deref(replication.Replica.SyncTimeout, metav1.Duration{Duration: 10 * time.Second}).Duration
 

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -918,6 +918,19 @@ func (c Client) IsReplicationRunning(ctx context.Context, logger logr.Logger, re
 		replicaStatus.SlaveSQLRunning != nil && *replicaStatus.SlaveSQLRunning, nil
 }
 
+// Returns the replication source host, or an empty string when replication is not configured.
+func (c Client) ReplicaMasterHost(ctx context.Context, replOpts ...ReplicationOpt) (string, error) {
+	opts := getReplOpts(replOpts...)
+	rows, err := c.QueryColumnMaps(ctx, fmt.Sprintf("SHOW REPLICA %s STATUS", opts.ConnectionName))
+	if err != nil {
+		return "", err
+	}
+	if len(rows) == 0 {
+		return "", nil
+	}
+	return rows[0]["Master_Host"], nil
+}
+
 // See: https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/show/show-replica-status
 func (c Client) ReplicaStatus(ctx context.Context, logger logr.Logger,
 	replOpts ...ReplicationOpt) (*mariadbv1alpha1.ReplicaStatusVars, error) {


### PR DESCRIPTION
Closes #1852

## Problem

During a pending switchover, a replica whose replication connection points at a host other than the current primary — in our production incident, the new primary *before* promotion, wired there while a rolling update recreated the pod — reports `Slave_IO_Running: Yes`, `Seconds_Behind_Master: 0` and no errors, yet can never reach the GTID that the `Wait sync` phase waits for: the unpromoted target has nothing to relay (no `log_slave_updates`). Every reconciliation then times out in `waitForReplicaSync`, and the retry re-applies the read lock and `read_only` to the current primary. Net effect: the application loses writes indefinitely (2h20m in our case, until manual intervention) while the cluster looks healthy by every per-replica metric. #1499 appears to be the same failure mode.

## Fix

Two independent changes, either of which is sufficient to end the write outage; together they make the switchover both convergent and bounded:

1. **`Wait sync` verifies each replica's replication source first.** Before waiting for the primary's GTID, the replica's `Master_Host` is compared against the current primary's FQDN; on mismatch (including replication not configured), the replica is reconnected to the current primary via the existing `topology.ConfigureReplica` path (`WithResetMaster(false)`, GTID position untouched) and a `ReplicaSourceFix` warning event is emitted. The wait then converges instead of blocking forever. The sync requirement itself is unchanged — replicas must still fully reach the primary's GTID before promotion.

2. **Failed pre-promotion phases release the primary.** If a phase fails before `Configure new primary`, the read lock and `read_only` are released (reusing the unlock logic extracted from the stale-switchover path) and a `SwitchoverRetry` warning event is emitted. The next reconciliation re-locks and retries, so an unable-to-complete switchover costs one `syncTimeout` window of read-only per attempt instead of a sustained outage. No promotion-ordering change: unlocking only happens on failure paths that run strictly before the new primary is configured. With semi-sync, replicas are near-synced when the lock is taken, so convergence within a single attempt remains the normal case.

Also adds `sql.Client.ReplicaMasterHost` (reads `Master_Host` from `SHOW REPLICA STATUS`; empty string when replication is not configured) rather than extending `ReplicaStatusVars`, to avoid touching the CRD status API.

## Validation

- Production incident on 25.10.4 (detailed in #1852): the deadlock held the primary read-only for ~3h; after manually reconnecting the stale replica to the current primary — exactly what change 1 automates — the same switchover completed in ~10 seconds.
- `make build`, `make lint` (0 issues), `make helm-crds && make test` (all suites pass).
- No API/CRD changes, so no generated-file diffs.