### PR TITLE
feat: clean up historical jobs for one-off backups

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -12,14 +13,18 @@ import (
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/controller/batch"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/controller/rbac"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/interfaces"
+	jobpkg "github.com/mariadb-operator/mariadb-operator/v26/pkg/job"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/refresolver"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // BackupReconciler reconciles a Backup object
@@ -47,6 +52,13 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	var backup mariadbv1alpha1.Backup
 	if err := r.Get(ctx, req.NamespacedName, &backup); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if backup.Spec.Schedule == nil && backup.IsComplete() {
+		if err := r.cleanupJobs(ctx, &backup); err != nil {
+			return ctrl.Result{}, fmt.Errorf("error cleaning up Job: %v", err)
+		}
+		return ctrl.Result{}, nil
 	}
 	mariaDb, err := r.RefResolver.MariaDBObject(ctx, &backup.Spec.MariaDBRef, backup.Namespace)
 	if err != nil {
@@ -146,4 +158,77 @@ func (r *BackupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&batchv1.Job{}).
 		Owns(&corev1.PersistentVolumeClaim{}).
 		Complete(r)
+}
+
+func (r *BackupReconciler) cleanupJobs(ctx context.Context, backup *mariadbv1alpha1.Backup) error {
+	logger := log.FromContext(ctx).WithName("cleanup")
+	var jobList batchv1.JobList
+	if err := r.List(ctx, &jobList, client.InNamespace(backup.Namespace)); err != nil {
+		return fmt.Errorf("error listing Jobs: %v", err)
+	}
+
+	var oneOffBackupJobs []batchv1.Job
+	for _, job := range jobList.Items {
+		owner := metav1.GetControllerOf(&job)
+		if owner == nil || owner.Kind != "Backup" || owner.APIVersion != mariadbv1alpha1.GroupVersion.String() {
+			continue
+		}
+
+		var parentBackup mariadbv1alpha1.Backup
+		parentKey := types.NamespacedName{
+			Name:      owner.Name,
+			Namespace: job.Namespace,
+		}
+		if err := r.Get(ctx, parentKey, &parentBackup); err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return fmt.Errorf("error getting parent Backup: %v", err)
+		}
+
+		if parentBackup.Spec.Schedule == nil && parentBackup.Spec.MariaDBRef.Name == backup.Spec.MariaDBRef.Name {
+			oneOffBackupJobs = append(oneOffBackupJobs, job)
+		}
+	}
+
+	sort.Slice(oneOffBackupJobs, func(i, j int) bool {
+		return oneOffBackupJobs[i].CreationTimestamp.Before(&oneOffBackupJobs[j].CreationTimestamp)
+	})
+
+	var completeJobs []*batchv1.Job
+	var failedJobs []*batchv1.Job
+	for i := range oneOffBackupJobs {
+		job := &oneOffBackupJobs[i]
+		if jobpkg.IsJobComplete(job) {
+			completeJobs = append(completeJobs, job)
+		} else if jobpkg.IsJobFailed(job) {
+			failedJobs = append(failedJobs, job)
+		}
+	}
+
+	maxHistory := int(ptr.Deref(backup.Spec.SuccessfulJobsHistoryLimit, 5))
+	if len(completeJobs) > maxHistory {
+		for i := 0; i < len(completeJobs)-maxHistory; i++ {
+			logger.Info("Deleting completed one-off Backup Job", "job", completeJobs[i].Name)
+			if err := r.Delete(ctx, completeJobs[i], &client.DeleteOptions{
+				PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
+			}); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+		}
+	}
+
+	maxFailedHistory := int(ptr.Deref(backup.Spec.FailedJobsHistoryLimit, 5))
+	if len(failedJobs) > maxFailedHistory {
+		for i := 0; i < len(failedJobs)-maxFailedHistory; i++ {
+			logger.Info("Deleting failed one-off Backup Job", "job", failedJobs[i].Name)
+			if err := r.Delete(ctx, failedJobs[i], &client.DeleteOptions{
+				PropagationPolicy: ptr.To(metav1.DeletePropagationBackground),
+			}); err != nil {
+				return client.IgnoreNotFound(err)
+			}
+		}
+	}
+
+	return nil
 }

--- a/internal/controller/physicalbackup_controller.go
+++ b/internal/controller/physicalbackup_controller.go
@@ -70,6 +70,10 @@ func (r *PhysicalBackupReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
+	if backup.Spec.Schedule == nil && backup.IsComplete() {
+		return ctrl.Result{}, nil
+	}
+
 	mariadb, err := r.RefResolver.MariaDB(ctx, &backup.Spec.MariaDBRef, backup.Namespace)
 	if err != nil {
 		var mariaDbErr *multierror.Error

--- a/internal/controller/physicalbackup_controller_job.go
+++ b/internal/controller/physicalbackup_controller_job.go
@@ -178,17 +178,48 @@ func (r *PhysicalBackupReconciler) reconcileJobStatus(ctx context.Context, backu
 
 func (r *PhysicalBackupReconciler) cleanupJobs(ctx context.Context, backup *mariadbv1alpha1.PhysicalBackup,
 	jobList *batchv1.JobList, logger logr.Logger) error {
+
+	var jobs []batchv1.Job
 	if backup.Spec.Schedule == nil {
-		return nil
+		var allJobList batchv1.JobList
+		if err := r.List(ctx, &allJobList, client.InNamespace(backup.Namespace)); err != nil {
+			return fmt.Errorf("error listing Jobs: %v", err)
+		}
+
+		for _, job := range allJobList.Items {
+			owner := metav1.GetControllerOf(&job)
+			if owner == nil || owner.Kind != "PhysicalBackup" || owner.APIVersion != mariadbv1alpha1.GroupVersion.String() {
+				continue
+			}
+
+			var parentBackup mariadbv1alpha1.PhysicalBackup
+			parentKey := types.NamespacedName{
+				Name:      owner.Name,
+				Namespace: job.Namespace,
+			}
+			if err := r.Get(ctx, parentKey, &parentBackup); err != nil {
+				if apierrors.IsNotFound(err) {
+					continue
+				}
+				return fmt.Errorf("error getting parent PhysicalBackup: %v", err)
+			}
+
+			if parentBackup.Spec.Schedule == nil && parentBackup.Spec.MariaDBRef.Name == backup.Spec.MariaDBRef.Name {
+				jobs = append(jobs, job)
+			}
+		}
+	} else {
+		jobs = append(jobs, jobList.Items...)
 	}
 
 	var completeJobs []*batchv1.Job
 	var failedJobs []*batchv1.Job
-	for _, job := range jobList.Items {
-		if jobpkg.IsJobComplete(&job) {
-			completeJobs = append(completeJobs, &job)
-		} else if jobpkg.IsJobFailed(&job) {
-			failedJobs = append(failedJobs, &job)
+	for i := range jobs {
+		job := &jobs[i]
+		if jobpkg.IsJobComplete(job) {
+			completeJobs = append(completeJobs, job)
+		} else if jobpkg.IsJobFailed(job) {
+			failedJobs = append(failedJobs, job)
 		}
 	}
 	maxHistory := int(ptr.Deref(backup.Spec.SuccessfulJobsHistoryLimit, 5))


### PR DESCRIPTION
## Description

This PR implements history-limit enforcement and cleanup for **one-off (non-scheduled)** Backup and PhysicalBackup Jobs.

Previously, historical Job cleanup only occurred under scheduled execution models. With these changes:
- When a one-off `Backup` or `PhysicalBackup` runs and completes, the reconciler triggers cleanup for any older completed/failed one-off Jobs targeting the same MariaDB instance.
- The reconciler respects `SuccessfulJobsHistoryLimit` (defaulting to 5) and `FailedJobsHistoryLimit` (defaulting to 5).
- Cleaned up a `staticcheck` warning (simplification of append loop) in `physicalbackup_controller_job.go`.

## Testing
- Ran `make test` locally to verify unit tests pass.
- Ran `make lint` locally to confirm zero linting errors.