### PR TITLE
fix(galera): do not recover a healthy Galera cluster

### DIFF
--- a/internal/controller/mariadb_controller_galera_test.go
+++ b/internal/controller/mariadb_controller_galera_test.go
@@ -7,6 +7,7 @@ import (
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/builder"
 	labels "github.com/mariadb-operator/mariadb-operator/v26/pkg/builder/labels"
+	condition "github.com/mariadb-operator/mariadb-operator/v26/pkg/condition"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/statefulset"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -318,6 +319,50 @@ var _ = Describe("MariaDB Galera lifecycle", Ordered, func() {
 				return false
 			}
 			return svc.Spec.Selector["statefulset.kubernetes.io/pod-name"] == statefulset.PodName(mdb.ObjectMeta, podIndex)
+		}, testTimeout, testInterval).Should(BeTrue())
+	})
+
+	It("should not recover a healthy Galera cluster", Label("basic"), func() {
+		By("Expecting MariaDB to be ready eventually")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, key, mdb); err != nil {
+				return false
+			}
+			return mdb.IsReady() && mdb.HasGaleraReadyCondition()
+		}, testHighTimeout, testInterval).Should(BeTrue())
+
+		By("Expecting all StatefulSet replicas to be ready")
+		Eventually(func(g Gomega) bool {
+			var sts appsv1.StatefulSet
+			g.Expect(k8sClient.Get(testCtx, key, &sts)).To(Succeed())
+			g.Expect(sts.Status.ReadyReplicas).To(BeEquivalentTo(mdb.Spec.Replicas))
+			return true
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Setting a stale GaleraReady=False condition")
+		Eventually(func(g Gomega) bool {
+			g.Expect(k8sClient.Get(testCtx, key, mdb)).To(Succeed())
+			patch := client.MergeFrom(mdb.DeepCopy())
+			mdb.Status.GaleraRecovery = nil
+			condition.SetGaleraNotReady(&mdb.Status)
+			g.Expect(k8sClient.Status().Patch(testCtx, mdb, patch)).To(Succeed())
+			return true
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Expecting the StatefulSet to never be downscaled")
+		Consistently(func(g Gomega) bool {
+			var sts appsv1.StatefulSet
+			g.Expect(k8sClient.Get(testCtx, key, &sts)).To(Succeed())
+			g.Expect(ptr.Deref(sts.Spec.Replicas, 0)).To(BeEquivalentTo(mdb.Spec.Replicas))
+			return true
+		}, 30*time.Second, testInterval).Should(BeTrue())
+
+		By("Expecting MariaDB to be Galera ready eventually")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, key, mdb); err != nil {
+				return false
+			}
+			return mdb.IsReady() && mdb.HasGaleraReadyCondition()
 		}, testTimeout, testInterval).Should(BeTrue())
 	})
 

--- a/pkg/controller/galera/controller.go
+++ b/pkg/controller/galera/controller.go
@@ -102,6 +102,21 @@ func shouldReconcileSwitchover(mdb *mariadbv1alpha1.MariaDB) bool {
 	return currentPodIndex != desiredPodIndex
 }
 
+// isClusterHealthy determines whether all the Galera replicas are Ready. The readiness probe reports a Pod as Ready
+// only when its Galera node is in Synced state, hence all replicas being Ready implies that they are all part of the
+// primary component and that there is nothing to recover.
+func isClusterHealthy(mdb *mariadbv1alpha1.MariaDB, sts *appsv1.StatefulSet) bool {
+	return sts.Status.ReadyReplicas == mdb.Spec.Replicas
+}
+
+func shouldReconcileRecovery(mdb *mariadbv1alpha1.MariaDB, sts *appsv1.StatefulSet) bool {
+	if !mdb.HasGaleraNotReadyCondition() {
+		return false
+	}
+	// A healthy cluster has nothing to recover: the GaleraReady condition is stale and it gets cleared by adopting the cluster.
+	return !isClusterHealthy(mdb, sts)
+}
+
 func (r *GaleraReconciler) Reconcile(ctx context.Context, mariadb *mariadbv1alpha1.MariaDB) (ctrl.Result, error) {
 	if !mariadb.IsGaleraEnabled() {
 		return ctrl.Result{}, nil
@@ -119,13 +134,13 @@ func (r *GaleraReconciler) Reconcile(ctx context.Context, mariadb *mariadbv1alph
 	}
 	topology := r.topologyManager.TopologyForMariaDB(mariadb, logger)
 
-	if mariadb.HasGaleraNotReadyCondition() {
+	if shouldReconcileRecovery(mariadb, &sts) {
 		if result, err := r.reconcileRecovery(ctx, mariadb, logger.WithName("recovery")); !result.IsZero() || err != nil {
 			return result, err
 		}
 	}
 
-	if !mariadb.HasGaleraReadyCondition() && sts.Status.ReadyReplicas == mariadb.Spec.Replicas {
+	if !mariadb.HasGaleraReadyCondition() && isClusterHealthy(mariadb, &sts) {
 		if err := r.disableBootstrap(ctx, mariadb, logger); err != nil {
 			return ctrl.Result{}, err
 		}

--- a/pkg/controller/galera/controller_test.go
+++ b/pkg/controller/galera/controller_test.go
@@ -1,0 +1,130 @@
+package galera
+
+import (
+	"testing"
+
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestShouldReconcileRecovery(t *testing.T) {
+	tests := []struct {
+		name   string
+		mdb    *mariadbv1alpha1.MariaDB
+		sts    *appsv1.StatefulSet
+		wantOk bool
+	}{
+		{
+			name:   "no Galera conditions",
+			mdb:    testMariadbWithGaleraCondition(nil),
+			sts:    testStatefulSetWithReadyReplicas(3),
+			wantOk: false,
+		},
+		{
+			name:   "Galera ready",
+			mdb:    testMariadbWithGaleraCondition(ptr.To(metav1.ConditionTrue)),
+			sts:    testStatefulSetWithReadyReplicas(3),
+			wantOk: false,
+		},
+		{
+			name:   "Galera not ready and unhealthy cluster",
+			mdb:    testMariadbWithGaleraCondition(ptr.To(metav1.ConditionFalse)),
+			sts:    testStatefulSetWithReadyReplicas(0),
+			wantOk: true,
+		},
+		{
+			name:   "Galera not ready and partially healthy cluster",
+			mdb:    testMariadbWithGaleraCondition(ptr.To(metav1.ConditionFalse)),
+			sts:    testStatefulSetWithReadyReplicas(2),
+			wantOk: true,
+		},
+		{
+			name:   "Galera not ready and healthy cluster",
+			mdb:    testMariadbWithGaleraCondition(ptr.To(metav1.ConditionFalse)),
+			sts:    testStatefulSetWithReadyReplicas(3),
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOk := shouldReconcileRecovery(tt.mdb, tt.sts)
+			if tt.wantOk != gotOk {
+				t.Errorf("unexpected shouldReconcileRecovery value: expected: %v, got: %v", tt.wantOk, gotOk)
+			}
+		})
+	}
+}
+
+func TestIsClusterHealthy(t *testing.T) {
+	tests := []struct {
+		name   string
+		mdb    *mariadbv1alpha1.MariaDB
+		sts    *appsv1.StatefulSet
+		wantOk bool
+	}{
+		{
+			name:   "no ready replicas",
+			mdb:    testMariadbWithGaleraCondition(nil),
+			sts:    testStatefulSetWithReadyReplicas(0),
+			wantOk: false,
+		},
+		{
+			name:   "some ready replicas",
+			mdb:    testMariadbWithGaleraCondition(nil),
+			sts:    testStatefulSetWithReadyReplicas(2),
+			wantOk: false,
+		},
+		{
+			name:   "all ready replicas",
+			mdb:    testMariadbWithGaleraCondition(nil),
+			sts:    testStatefulSetWithReadyReplicas(3),
+			wantOk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOk := isClusterHealthy(tt.mdb, tt.sts)
+			if tt.wantOk != gotOk {
+				t.Errorf("unexpected isClusterHealthy value: expected: %v, got: %v", tt.wantOk, gotOk)
+			}
+		})
+	}
+}
+
+func testMariadbWithGaleraCondition(galeraReady *metav1.ConditionStatus) *mariadbv1alpha1.MariaDB {
+	mdb := &mariadbv1alpha1.MariaDB{
+		Spec: mariadbv1alpha1.MariaDBSpec{
+			Galera: &mariadbv1alpha1.Galera{
+				Enabled: true,
+				GaleraSpec: mariadbv1alpha1.GaleraSpec{
+					Recovery: &mariadbv1alpha1.GaleraRecovery{
+						Enabled: true,
+					},
+				},
+			},
+			Replicas: 3,
+		},
+	}
+	if galeraReady != nil {
+		mdb.Status.Conditions = []metav1.Condition{
+			{
+				Type:   mariadbv1alpha1.ConditionTypeGaleraReady,
+				Status: *galeraReady,
+				Reason: "test",
+			},
+		}
+	}
+	return mdb
+}
+
+func testStatefulSetWithReadyReplicas(readyReplicas int32) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: readyReplicas,
+		},
+	}
+}


### PR DESCRIPTION
## Problem

The `GaleraReady=False` condition acts as a latch. It is set by the health monitor in `StatefulSetGaleraReconciler`, and it is only ever cleared by the cluster adoption branch in the Galera reconciler, which is ordered *after* the recovery branch. `reconcileRecovery` itself never checks cluster health.

As a result, whenever a Galera cluster becomes healthy by any route other than the operator's own recovery, the next reconciliation performs a full recovery against a perfectly healthy cluster. With an empty `status.galeraRecovery`, neither `isBootstrapping` nor `podsRestarted` hold, so `recoverCluster` runs, finds no valid bootstrap source (a live `mariadbd` reports `seqno: -1`, which is expected) and falls through to `recoverGaleraState`, which downscales the StatefulSet to 0 replicas. It then upscales and bootstraps again, taking a healthy cluster down for the duration and risking data loss on an unlucky bootstrap source selection.

Reachable in several ways, all of which leave the latch set while the cluster is healthy:

- a cluster repaired by hand
- an operator scaling to 0 and back up during maintenance
- a cluster that self-heals while the operator is unavailable

This came out of reviewing an incident in which a three-node cluster lost cross-node connectivity and had to be repaired by hand. The condition survives such a repair, which leaves the operator poised to recover a cluster that is already healthy.

## Reproduction

```bash
make cluster && make install && make net
# deploy a 3-node Galera MariaDB and wait until Ready=True, GaleraReady=True

kubectl patch mariadb <name> --subresource=status --type=merge \
  -p '{"status":{"conditions":[{"type":"GaleraReady","status":"False","reason":"GaleraNotReady","lastTransitionTime":"2026-01-01T00:00:00Z","message":"forced"}]}}'
```

Before this change the operator downscales the StatefulSet to 0 and recovers a perfectly healthy cluster. After it, the cluster is adopted and `GaleraReady=True` is set.

## Fix

Guard the recovery branch on cluster health, sharing a single health predicate with the adoption branch that already follows it. The Galera readiness probe reports a Pod as Ready only when its node is in `Synced` state, so all replicas being Ready implies they are all part of the same primary component and that there is nothing to recover. When the guard skips recovery, the adoption branch disables bootstrap on all Pods and clears the latch, which is exactly the cleanup the tail of a recovery would have performed.

An alternative considered was evaluating the adoption branch before recovery and returning early. That reorder also fixes the bug, but it defers the multi-cluster and switchover logic that currently runs in the same pass, so the guard was preferred as the smaller and more contained change. Happy to switch if you prefer the reorder.

## Testing

- Unit table tests for the new guard and health predicate in `pkg/controller/galera`.
- Integration spec (`basic`) asserting that a healthy three-node cluster with a stale `GaleraReady=False` converges back to `GaleraReady=True` without the StatefulSet ever being downscaled.
- Confirmed the spec fails without the fix: pre-fix the operator logs `Downscaling cluster` roughly one second after the stale condition is set, with all three members reporting `seqno: -1` and a valid UUID.
- The spec forces the condition with the same helper the health monitor uses (`SetGaleraNotReady`, plus clearing `status.galeraRecovery`) rather than reproducing a crash and manual repair: the operator runs in-process in the integration suite, so there is nothing to take offline, and a hand repair means performing the bootstrap the operator would otherwise do. The existing recovery specs already cover that a real crash produces exactly that condition.
- `make gen` produces no diff; `make lint` and `make test` clean; `make test-int` green for the Galera lifecycle specs.