### PR TITLE
fix(security): replace world-writable 0777 modes with restrictive permissions

### DIFF
--- a/cmd/backup/restore.go
+++ b/cmd/backup/restore.go
@@ -130,7 +130,7 @@ func getTargetTime() (time.Time, error) {
 }
 
 func writeTargetFile(backupTargetFile string) error {
-	return os.WriteFile(targetFilePath, []byte(backupTargetFile), 0777)
+	return os.WriteFile(targetFilePath, []byte(backupTargetFile), 0600)
 }
 
 func getBackupCompressorWithFile(fileName string, processor backup.BackupProcessor) (mdbcompression.BackupCompressor, error) {

--- a/cmd/pitr/main.go
+++ b/cmd/pitr/main.go
@@ -348,5 +348,5 @@ func writeTargetFile(binlogPath []string) error {
 	for i, binlog := range binlogPath {
 		targetBinlogsWithLocalPath[i] = filepath.Join(path, binlog)
 	}
-	return os.WriteFile(targetFilePath, []byte(strings.Join(targetBinlogsWithLocalPath, " ")), 0777)
+	return os.WriteFile(targetFilePath, []byte(strings.Join(targetBinlogsWithLocalPath, " ")), 0600)
 }

--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -837,7 +837,7 @@ func (b *Builder) BuildGaleraInitJob(key types.NamespacedName, mariadb *mariadbv
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: mariadb.InitKey().Name,
 						},
-						DefaultMode: ptr.To(int32(0777)),
+						DefaultMode: ptr.To(int32(0555)),
 					},
 				},
 			},

--- a/pkg/filemanager/filemanager.go
+++ b/pkg/filemanager/filemanager.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	writeFileMode = fs.FileMode(0777)
+	writeFileMode = fs.FileMode(0600)
 )
 
 type FileManager struct {


### PR DESCRIPTION
Several files written by the operator use 0777 permissions - the filemanager writeFileMode constant, the backup and PITR restore target files, and the init-scripts ConfigMap volume DefaultMode. World-writable files inside a DB pod let any co-located process overwrite operator-managed config or replay targets. Changed data files to 0600 (owner read/write only) and the init-scripts volume to 0555 (owner read/execute, no world-write).