### PR TITLE
fix: invalid value for constant `ConditionReasonCronJobFailed`

### DIFF
--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -80,7 +80,7 @@ const (
 	ConditionReasonSnapshotNotComplete string = "SnapshotNotComplete"
 
 	ConditionReasonCronJobScheduled string = "CronJobScheduled"
-	ConditionReasonCronJobFailed    string = "CronJobScheduled"
+	ConditionReasonCronJobFailed    string = "CronJobFailed"
 	ConditionReasonCronJobRunning   string = "CronJobRunning"
 	ConditionReasonCronJobSuccess   string = "CronJobSuccess"
 

--- a/pkg/condition/complete_test.go
+++ b/pkg/condition/complete_test.go
@@ -1,0 +1,199 @@
+package conditions
+
+import (
+	"testing"
+	"time"
+
+	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type testConditioner struct {
+	conditions []metav1.Condition
+}
+
+func (c *testConditioner) SetCondition(condition metav1.Condition) {
+	c.conditions = append(c.conditions, condition)
+}
+
+// Condition reasons are asserted as literals on purpose: they are part of the status API that users and
+// monitoring match on, so a change to the constant value must show up as a test failure.
+func TestSetCompleteWithCronJob(t *testing.T) {
+	scheduleTime := metav1.NewTime(time.Now())
+	beforeScheduleTime := metav1.NewTime(scheduleTime.Add(-1 * time.Minute))
+	afterScheduleTime := metav1.NewTime(scheduleTime.Add(1 * time.Minute))
+
+	tests := []struct {
+		name        string
+		cronJob     *batchv1.CronJob
+		wantStatus  metav1.ConditionStatus
+		wantReason  string
+		wantMessage string
+	}{
+		{
+			name:        "not scheduled",
+			cronJob:     &batchv1.CronJob{},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "CronJobScheduled",
+			wantMessage: "Scheduled",
+		},
+		{
+			name: "scheduled without successful run",
+			cronJob: &batchv1.CronJob{
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime: &scheduleTime,
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "CronJobScheduled",
+			wantMessage: "Scheduled",
+		},
+		{
+			name: "running",
+			cronJob: &batchv1.CronJob{
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime:   &scheduleTime,
+					LastSuccessfulTime: &beforeScheduleTime,
+					Active: []corev1.ObjectReference{
+						{
+							Name: "job",
+						},
+					},
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "CronJobRunning",
+			wantMessage: "Running",
+		},
+		{
+			name: "failed",
+			cronJob: &batchv1.CronJob{
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime:   &scheduleTime,
+					LastSuccessfulTime: &beforeScheduleTime,
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "CronJobFailed",
+			wantMessage: "Failed",
+		},
+		{
+			name: "success",
+			cronJob: &batchv1.CronJob{
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime:   &scheduleTime,
+					LastSuccessfulTime: &scheduleTime,
+				},
+			},
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  "CronJobSuccess",
+			wantMessage: "Success",
+		},
+		{
+			name: "success after being rescheduled",
+			cronJob: &batchv1.CronJob{
+				Status: batchv1.CronJobStatus{
+					LastScheduleTime:   &scheduleTime,
+					LastSuccessfulTime: &afterScheduleTime,
+				},
+			},
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  "CronJobSuccess",
+			wantMessage: "Success",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c testConditioner
+			SetCompleteWithCronJob(&c, tt.cronJob)
+
+			assertCondition(t, &c, tt.wantStatus, tt.wantReason, tt.wantMessage)
+		})
+	}
+}
+
+func TestSetCompleteWithJob(t *testing.T) {
+	jobWithCondition := func(conditionType batchv1.JobConditionType) *batchv1.Job {
+		return &batchv1.Job{
+			Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   conditionType,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		job         *batchv1.Job
+		wantStatus  metav1.ConditionStatus
+		wantReason  string
+		wantMessage string
+	}{
+		{
+			name:        "running",
+			job:         &batchv1.Job{},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "JobRunning",
+			wantMessage: "Running",
+		},
+		{
+			name:        "failed",
+			job:         jobWithCondition(batchv1.JobFailed),
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  "JobFailed",
+			wantMessage: "Failed",
+		},
+		{
+			name:        "suspended",
+			job:         jobWithCondition(batchv1.JobSuspended),
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  "JobSuspended",
+			wantMessage: "Suspended",
+		},
+		{
+			name:        "complete",
+			job:         jobWithCondition(batchv1.JobComplete),
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  "JobComplete",
+			wantMessage: "Success",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c testConditioner
+			SetCompleteWithJob(&c, tt.job)
+
+			assertCondition(t, &c, tt.wantStatus, tt.wantReason, tt.wantMessage)
+		})
+	}
+}
+
+func assertCondition(t *testing.T, c *testConditioner, status metav1.ConditionStatus, reason, message string) {
+	t.Helper()
+
+	if len(c.conditions) != 1 {
+		t.Fatalf("expecting exactly one condition to be set, got %d", len(c.conditions))
+	}
+	condition := c.conditions[0]
+
+	if condition.Type != mariadbv1alpha1.ConditionTypeComplete {
+		t.Errorf("expecting condition type to be %q, got %q", mariadbv1alpha1.ConditionTypeComplete, condition.Type)
+	}
+	if condition.Status != status {
+		t.Errorf("expecting condition status to be %q, got %q", status, condition.Status)
+	}
+	if condition.Reason != reason {
+		t.Errorf("expecting condition reason to be %q, got %q", reason, condition.Reason)
+	}
+	if condition.Message != message {
+		t.Errorf("expecting condition message to be %q, got %q", message, condition.Message)
+	}
+}


### PR DESCRIPTION
Close MDB-5

Hey there! 👋

We tried to add metrics to the to our MariaDB-Backups in order to have alerting when a backup failed (but not when it's not done yet or still in progress, etc.). We use `kube-state-metrics` to export `.status.conditions` from the `Backup`-CR to `prometheus`. As the `status` of the "Complete"-condition does not fit our needs (e.g. it is "true" even a backup failed) we use the `reason` for in-depth-analysis. But we had to notice that there is a little tiny bug in the operator-code: For the reason `CronJobFailed`, it actually says `"CronJobScheduled"`.

### What

`ConditionReasonCronJobFailed` was defined as `"CronJobScheduled"` instead of `"CronJobFailed"` in `api/v1alpha1/condition_types.go` - might be a copy/paste slip from the constant declared right above it.

### Impact

Scheduled `Backup` and `SqlJob` resources (those with `spec.schedule` set) report their `Complete` condition through `SetCompleteWithCronJob`. When the last run had failed, the condition was set to `status=False, reason=CronJobScheduled, message=Failed` - carrying the same reason as a resource that has merely been scheduled and never run, so the two states were indistinguishable for anyone matching on `reason`.

This only makes the status more precise: `CronJobScheduled` never conveyed "failed" to begin with, so no working selector loses meaning.

### Why this wasn't caught

`pkg/condition/` had no unit tests at all, and the integration tests assert completion exclusively via `IsComplete()`, which only checks `meta.IsStatusConditionTrue(...)` - never the reason or message.

### Tests

Adds `pkg/condition/complete_test.go`: table-driven tests covering every branch of `SetCompleteWithCronJob` (Scheduled / Running / Failed / Success) and `SetCompleteWithJob` (Running / Failed / Suspended / Complete), asserting type, status, reason and message.

The expected reasons are asserted as string literals rather than against the constants. This is deliberate: a test comparing against `mariadbv1alpha1.ConditionReasonCronJobFailed` still passes because both sides work with the same constant. Condition reasons are part of the status API that users and monitoring match on, so pinning the literal is what actually guards them.

Disclaimer: While I fixed `api/v1alpha1/condition_types.go` by hand, the test was written by Claude Code.