### PR TITLE
docs: document WATCH_NAMESPACE for watching specific namespaces

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -124,6 +124,26 @@ helm install mariadb-operator \
   mariadb-operator/mariadb-operator
 ```
 
+#### Specific namespaces
+
+To watch a set of namespaces rather than all of them or just the operator's own, set the `WATCH_NAMESPACE` environment variable to a comma-separated list. RBAC stays cluster-wide, so leave `currentNamespaceOnly` at its default:
+
+```bash
+helm install mariadb-operator \
+  -n databases --create-namespace \
+  --set 'extraEnv[0].name=WATCH_NAMESPACE' \
+  --set 'extraEnv[0].value=app-a\,app-b' \
+  mariadb-operator/mariadb-operator
+```
+
+The operator logs the namespaces it ends up watching on startup:
+
+```
+Watching namespaces {"namespaces": ["app-a", "app-b"]}
+```
+
+Setting `currentNamespaceOnly=true` is equivalent to setting `WATCH_NAMESPACE` to the release namespace.
+
 ## Updates
 
 > [!IMPORTANT]  

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -138,9 +138,11 @@ helm install mariadb-operator \
 
 The operator logs the namespaces it ends up watching on startup:
 
+```json
+{"level":"info","ts":1756742400.123,"logger":"setup","msg":"Watching namespaces","namespaces":["app-a","app-b"]}
 ```
-Watching namespaces {"namespaces": ["app-a", "app-b"]}
-```
+
+The timestamp and encoding follow the `--log-time-encoder` and `--log-dev` flags, so grep for `Watching namespaces` rather than the whole line.
 
 Setting `currentNamespaceOnly=true` is equivalent to setting `WATCH_NAMESPACE` to the release namespace.
 


### PR DESCRIPTION
Close MDB-4

Fixes #567.

`WATCH_NAMESPACE` is read in `pkg/environment` and feeds `mgrOpts.Cache.DefaultNamespaces` in `cmd/controller/main.go`, and it accepts a comma-separated list. The helm docs only describe the two extremes — cluster-wide, and `currentNamespaceOnly=true` for the release namespace — so scoping the operator to a specific set of namespaces is not discoverable, which is what the issue reports.

Adds a "Specific namespaces" subsection to the deployment modes in `docs/helm.md`: how to set the variable through `extraEnv`, the startup log line that confirms which namespaces were picked up, and a note that `currentNamespaceOnly=true` is the same thing scoped to the release namespace.

Docs only, no code changes.
