### PR TITLE
fix: [Bug] Deleting completed one-off backup Jobs triggers recreation/re-run

### DIFF
--- a/internal/controller/backup_controller.go
+++ b/internal/controller/backup_controller.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // BackupReconciler reconciles a Backup object
@@ -48,6 +49,11 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.Get(ctx, req.NamespacedName, &backup); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	if backup.Spec.Schedule == nil && backup.IsComplete() {
+		log.FromContext(ctx).WithName("backup").V(1).Info("Backup is complete, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
+
 	mariaDb, err := r.RefResolver.MariaDBObject(ctx, &backup.Spec.MariaDBRef, backup.Namespace)
 	if err != nil {
 		var mariaDbErr *multierror.Error

--- a/internal/controller/backup_controller_test.go
+++ b/internal/controller/backup_controller_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"reflect"
+	"time"
 
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
@@ -9,7 +10,9 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -207,6 +210,36 @@ var _ = Describe("Backup", Label("basic"), func() {
 			testS3Backup,
 		),
 	)
+
+	It("should not recreate the Job of a completed one-off Backup", func() {
+		key := types.NamespacedName{
+			Name:      "backup-completed-job-deleted-test",
+			Namespace: testNamespace,
+		}
+		backup := getBackupWithPVCStorage(key)
+		testBackup(backup)
+
+		By("Deleting the completed Job")
+		var completedJob batchv1.Job
+		Expect(k8sClient.Get(testCtx, key, &completedJob)).To(Succeed())
+		Expect(
+			k8sClient.Delete(testCtx, &completedJob, client.PropagationPolicy(metav1.DeletePropagationBackground)),
+		).To(Succeed())
+
+		By("Expecting the Job to be deleted eventually")
+		Eventually(func() bool {
+			var job batchv1.Job
+			return apierrors.IsNotFound(k8sClient.Get(testCtx, key, &job))
+		}, testTimeout, testInterval).Should(BeTrue())
+
+		By("Expecting the Job not to be recreated and the Backup to remain complete")
+		Consistently(func(g Gomega) {
+			var job batchv1.Job
+			g.Expect(apierrors.IsNotFound(k8sClient.Get(testCtx, key, &job))).To(BeTrue())
+			g.Expect(k8sClient.Get(testCtx, key, backup)).To(Succeed())
+			g.Expect(backup.IsComplete()).To(BeTrue())
+		}, 10*time.Second, testInterval).Should(Succeed())
+	})
 })
 
 var _ = Describe("Backup from external MariaDB", func() {

--- a/internal/controller/physicalbackup_controller.go
+++ b/internal/controller/physicalbackup_controller.go
@@ -69,6 +69,10 @@ func (r *PhysicalBackupReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err := r.Get(ctx, req.NamespacedName, &backup); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+	if backup.Spec.Schedule == nil && backup.IsComplete() {
+		log.FromContext(ctx).WithName("physicalbackup").V(1).Info("PhysicalBackup is complete, skipping reconciliation")
+		return ctrl.Result{}, nil
+	}
 
 	mariadb, err := r.RefResolver.MariaDB(ctx, &backup.Spec.MariaDBRef, backup.Namespace)
 	if err != nil {

--- a/internal/controller/physicalbackup_controller_test.go
+++ b/internal/controller/physicalbackup_controller_test.go
@@ -3,13 +3,17 @@ package controller
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/go-logr/logr"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
+	"github.com/mariadb-operator/mariadb-operator/v26/pkg/job"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("PhysicalBackup", Label("basic"), func() {
@@ -164,6 +168,39 @@ var _ = Describe("PhysicalBackup", Label("basic"), func() {
 			testPhysicalBackup,
 		),
 	)
+
+	It("should not recreate the Jobs of a completed one-off PhysicalBackup", func() {
+		key := types.NamespacedName{
+			Name:      "physicalbackup-completed-job-deleted-test",
+			Namespace: testNamespace,
+		}
+		backup := buildPhysicalBackupWithPVCStorage(testMdbkey)(key)
+		testPhysicalBackup(backup)
+
+		By("Deleting the completed Jobs")
+		jobList, err := job.ListJobs(testCtx, k8sClient, backup)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(jobList.Items).ToNot(BeEmpty())
+		for _, j := range jobList.Items {
+			Expect(k8sClient.Delete(testCtx, &j, client.PropagationPolicy(metav1.DeletePropagationBackground))).To(Succeed())
+		}
+
+		By("Expecting the Jobs to be deleted eventually")
+		Eventually(func(g Gomega) {
+			jobList, err := job.ListJobs(testCtx, k8sClient, backup)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(jobList.Items).To(BeEmpty())
+		}, testTimeout, testInterval).Should(Succeed())
+
+		By("Expecting the Jobs not to be recreated and the PhysicalBackup to remain complete")
+		Consistently(func(g Gomega) {
+			jobList, err := job.ListJobs(testCtx, k8sClient, backup)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(jobList.Items).To(BeEmpty())
+			g.Expect(k8sClient.Get(testCtx, key, backup)).To(Succeed())
+			g.Expect(backup.IsComplete()).To(BeTrue())
+		}, 10*time.Second, testInterval).Should(Succeed())
+	})
 })
 
 var _ = Describe("PhysicalBackup target", Label("basic"), func() {


### PR DESCRIPTION
Fixes #1860

## Root cause

One-off Backup/PhysicalBackup reconcilers ignore the terminal Complete condition and recreate deleted child Jobs

## Changes

- Short-circuit reconciliation in the Backup and PhysicalBackup controllers when the resource is one-off (spec.schedule unset) and already has Complete=True, so neither the status is reset nor a new Job/VolumeSnapshot is created. Added integration regression specs (Label("basic")) that delete the completed Job and assert it is not recreated and the CR stays complete.