### PR TITLE
Tolerate error-free administrative SQL thread stops in replication liveness probe

### DIFF
--- a/pkg/agent/handler/replication/probe.go
+++ b/pkg/agent/handler/replication/probe.go
@@ -78,9 +78,21 @@ func (p *ReplicationProbe) Liveness(w http.ResponseWriter, r *http.Request) {
 		}
 		replicaSQLRunning := ptr.Deref(status.SlaveSQLRunning, false)
 		if !replicaSQLRunning {
-			p.livenessLogger.Error(nil, "Replica SQL thread not running")
-			p.responseWriter.WriteError(w, "Replica SQL thread not running")
-			return
+			// A stopped SQL thread with no error (Last_SQL_Errno == 0) is an administrative stop:
+			// --safe-slave-backup, a DBA running STOP SLAVE SQL_THREAD, maintenance, etc. Restarting
+			// the container does not remediate an intentional stop, it only disrupts whatever operation
+			// caused it, so this must not fail liveness. A stop accompanied by an error is a genuine
+			// replication failure and is still treated as fatal.
+			lastSQLErrno := ptr.Deref(status.LastSQLErrno, 0)
+			if lastSQLErrno != 0 {
+				p.livenessLogger.Error(nil, "Replica SQL thread not running",
+					"Last_SQL_Errno", lastSQLErrno,
+					"Last_SQL_Error", ptr.Deref(status.LastSQLError, ""),
+				)
+				p.responseWriter.WriteErrorf(w, "Replica SQL thread not running (Last_SQL_Errno: %d)", lastSQLErrno)
+				return
+			}
+			p.livenessLogger.Info("Replica SQL thread stopped without error, treating as administrative stop")
 		}
 
 		p.livenessLogger.V(1).Info(


### PR DESCRIPTION
## What

When a replica's SQL thread is stopped, the replication liveness probe fails the container and kubelet restarts the Pod.

The common case is `mariadb-backup --safe-slave-backup`, which stops the replica SQL thread for the duration of a physical backup. This surfaces as `Slave_SQL_Running: No` with `Last_SQL_Errno == 0`, and the stop window easily exceeds `failureThreshold: 3 x 5s`, so the Pod is killed mid-backup. The same applies to a DBA running `STOP SLAVE SQL_THREAD` or any maintenance operation: a restart does not remediate an intentional stop, it only destroys the operation that caused it.

`pkg/agent/handler/replication/probe.go:79` — in `ReplicationProbe.Liveness`, when `Slave_SQL_Running: No`:

- `Last_SQL_Errno == 0` — administrative / error-free stop. Logged at info level, liveness passes.
- `Last_SQL_Errno != 0` — genuine replication failure, still fatal, now with `Last_SQL_Errno` and `Last_SQL_Error` surfaced in both the log and the HTTP response.

`Last_SQL_Errno` / `Last_SQL_Error` are already parsed into `ReplicaStatusVars` (`pkg/sql/sql.go:943`), so no plumbing was needed. No API surface change, no operator/agent coordination.

## Out of scope

- No default flip on `--safe-slave-backup`; that belongs as a field on the `PhysicalBackup` spec.
- Readiness probe unchanged.
- IO thread check unchanged.

## Verification

- `go build ./...` — passes.
- `go vet ./pkg/agent/...` — passes.
- `make lint` — `0 issues`.
- `make test-pkg` — `Ginkgo ran 32 suites`, `Test Suite Passed`.

Not verified against a live cluster in this change. `ReplicationProbe` has no existing test coverage; a table-driven test over the SQL-thread branch (running / stopped-no-error / stopped-with-error) would require injecting the SQL client and could follow separately.

Closes MDB-7
