### PR TITLE
fix(maintenance): Only gate readonly reconciliation on readiness when MaxScale is enabled

### DIFF
--- a/pkg/controller/maintenance/read_only.go
+++ b/pkg/controller/maintenance/read_only.go
@@ -90,30 +90,36 @@ func shouldReconcileReadOnly(mdb *mariadbv1alpha1.MariaDB, logger logr.Logger) b
 	if mdb.IsCordoned() {
 		return true
 	}
-	// Reconciling readonly when MariaDB is not ready has multiple negative effects. For example:
-	// If the readonly reconciliation happens while MaxScale is performing a failover, the failover could hang with the following MaxScale logs:
-	//
-	// [mariadbmon] Failover 'mariadb-eu-central-1' -> 'mariadb-eu-central-0' performed.
-	// notice : Server changed state: mariadb-eu-central-0[mariadb-eu-central-0.mariadb-eu-central-internal.default.svc.cluster.local:3306]: new_master. [Slave, Running] -> [Master, Running]
-	// warning: [mariadbmon] The current primary server 'mariadb-eu-central-0' is no longer valid because it is in read-only mode, but there is no valid alternative to swap to.
-	// notice : Server changed state: mariadb-eu-central-0[mariadb-eu-central-0.mariadb-eu-central-internal.default.svc.cluster.local:3306]: new_slave. [Master, Running] -> [Slave, Running]
-	// error  : [readwritesplit] (rw-router); Couldn't find suitable Primary from 2 candidates.
-	// error  : (rw-router); Failed to create new router session for service 'rw-router'. See previous errors for more details.
-	//
-	// Preventing this readonly reconciliation from triggering using this guard, the failover succeeds:
-	//
-	// notice : [mariadbmon] Failover 'mariadb-eu-central-0' -> 'mariadb-eu-central-1' performed.
-	// notice : Server changed state: mariadb-eu-central-1[mariadb-eu-central-1.mariadb-eu-central-internal.default.svc.cluster.local:3306]: new_master. [Slave, Running] -> [Master, Running]
-	// notice : Server changed state: mariadb-eu-central-0[mariadb-eu-central-0.mariadb-eu-central-internal.default.svc.cluster.local:3306]: server_up. [Down] -> [Running]
-	// notice : [mariadbmon] Server 'mariadb-eu-central-0' is replicating from a server other than 'mariadb-eu-central-1', redirecting it to 'mariadb-eu-central-1'.
-	// notice : [mariadbmon] 1 server(s) redirected or rejoined the cluster.
-	// notice : Server changed state: mariadb-eu-central-0[mariadb-eu-central-0.mariadb-eu-central-internal.default.svc.cluster.local:3306]: new_slave. [Running] -> [Slave, Running]
-	//
-	// It is important to note that this issue only happens with the MaxScale failover, as it runs in parallel with the MariaDB controller i.e. race condition.
-	// MariaDB failover is not affected, as it is handled by a previous stage in the same MariaDB controller.
-	if !mdb.IsReady() {
-		logger.V(1).Info("MariaDB is not ready. Skipping readonly reconciliation...")
-		return false
+	if mdb.IsMaxScaleEnabled() {
+		// Reconciling readonly when MariaDB is not ready AND MaxScale is enabled has multiple negative effects:
+		// If the readonly reconciliation happens while MaxScale is performing a failover, the failover could hang with the following MaxScale logs:
+		//
+		// [mariadbmon] Failover 'mariadb-eu-central-1' -> 'mariadb-eu-central-0' performed.
+		// notice : Server changed state: mariadb-eu-central-0[mariadb-eu-central-0.mariadb-eu-central-internal.default.svc.cluster.local:3306]: new_master. [Slave, Running] -> [Master, Running]
+		// warning: [mariadbmon] The current primary server 'mariadb-eu-central-0' is no longer valid because it is in read-only mode, but there is no valid alternative to swap to.
+		// notice : Server changed state: mariadb-eu-central-0[mariadb-eu-central-0.mariadb-eu-central-internal.default.svc.cluster.local:3306]: new_slave. [Master, Running] -> [Slave, Running]
+		// error  : [readwritesplit] (rw-router); Couldn't find suitable Primary from 2 candidates.
+		// error  : (rw-router); Failed to create new router session for service 'rw-router'. See previous errors for more details.
+		//
+		// Preventing this readonly reconciliation from triggering using this guard, the failover succeeds:
+		//
+		// notice : [mariadbmon] Failover 'mariadb-eu-central-0' -> 'mariadb-eu-central-1' performed.
+		// notice : Server changed state: mariadb-eu-central-1[mariadb-eu-central-1.mariadb-eu-central-internal.default.svc.cluster.local:3306]: new_master. [Slave, Running] -> [Master, Running]
+		// notice : Server changed state: mariadb-eu-central-0[mariadb-eu-central-0.mariadb-eu-central-internal.default.svc.cluster.local:3306]: server_up. [Down] -> [Running]
+		// notice : [mariadbmon] Server 'mariadb-eu-central-0' is replicating from a server other than 'mariadb-eu-central-1', redirecting it to 'mariadb-eu-central-1'.
+		// notice : [mariadbmon] 1 server(s) redirected or rejoined the cluster.
+		// notice : Server changed state: mariadb-eu-central-0[mariadb-eu-central-0.mariadb-eu-central-internal.default.svc.cluster.local:3306]: new_slave. [Running] -> [Slave, Running]
+		//
+		// It is important to note that this issue only happens with the MaxScale failover, as it runs in parallel with the MariaDB controller i.e. race condition.
+		// MariaDB failover is not affected, as it is handled by a previous stage in the same MariaDB controller.
+		if !mdb.IsReady() {
+			logger.V(1).Info("MariaDB is not ready. Skipping readonly reconciliation...")
+			return false
+		}
 	}
+	// Without MaxScale, the operator is the only actor that promotes and demotes nodes, so the race condition described above cannot
+	// happen: failover and switchover are handled by a previous stage in this same controller, never in parallel with this one.
+	// Reconciling readonly is therefore always safe here, and skipping it would be harmful: read_only is not persisted in the MariaDB
+	// configuration, so a replica that is unable to become ready would stay writable indefinitely after a restart.
 	return true
 }

--- a/pkg/controller/maintenance/read_only_test.go
+++ b/pkg/controller/maintenance/read_only_test.go
@@ -3,8 +3,10 @@ package maintenance
 import (
 	"testing"
 
+	"github.com/go-logr/logr"
 	mariadbv1alpha1 "github.com/mariadb-operator/mariadb-operator/v26/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 )
 
@@ -323,6 +325,116 @@ func TestGetReadOnlyDesiredPodState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := r.getReadOnlyDesiredPodState(tt.mariadb)
 			assert.Equal(t, tt.expectedState, result, "ReadOnly state mismatch")
+		})
+	}
+}
+
+func TestShouldReconcileReadOnly(t *testing.T) {
+	maxScaleRef := &mariadbv1alpha1.ObjectReference{
+		Name: "maxscale",
+	}
+	readyCondition := func(status metav1.ConditionStatus, reason string) []metav1.Condition {
+		return []metav1.Condition{
+			{
+				Type:   mariadbv1alpha1.ConditionTypeReady,
+				Status: status,
+				Reason: reason,
+			},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		mariadb        *mariadbv1alpha1.MariaDB
+		wantReconciled bool
+	}{
+		{
+			name: "MaxScale and ready",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MaxScaleRef: maxScaleRef,
+				},
+				Status: mariadbv1alpha1.MariaDBStatus{
+					Conditions: readyCondition(metav1.ConditionTrue, mariadbv1alpha1.ConditionReasonStatefulSetReady),
+				},
+			},
+			wantReconciled: true,
+		},
+		{
+			// The MaxScale failover runs in parallel with the MariaDB controller, so reconciling readonly
+			// while MaxScale is promoting a node could hang the failover. This guard must be preserved.
+			name: "MaxScale and not ready",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MaxScaleRef: maxScaleRef,
+				},
+				Status: mariadbv1alpha1.MariaDBStatus{
+					Conditions: readyCondition(metav1.ConditionFalse, mariadbv1alpha1.ConditionReasonStatefulSetNotReady),
+				},
+			},
+			wantReconciled: false,
+		},
+		{
+			name: "MaxScale and cordoned",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MaxScaleRef: maxScaleRef,
+				},
+				Status: mariadbv1alpha1.MariaDBStatus{
+					Conditions: readyCondition(metav1.ConditionFalse, mariadbv1alpha1.ConditionReasonCordoned),
+				},
+			},
+			wantReconciled: true,
+		},
+		{
+			name: "MaxScale without conditions",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MaxScaleRef: maxScaleRef,
+				},
+			},
+			wantReconciled: false,
+		},
+		{
+			name: "no MaxScale and ready",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Status: mariadbv1alpha1.MariaDBStatus{
+					Conditions: readyCondition(metav1.ConditionTrue, mariadbv1alpha1.ConditionReasonStatefulSetReady),
+				},
+			},
+			wantReconciled: true,
+		},
+		{
+			// Without MaxScale there is no out of band actor to race with, and readonly must be reconciled
+			// so that a replica that is unable to become ready does not stay writable indefinitely.
+			name: "no MaxScale and not ready",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Status: mariadbv1alpha1.MariaDBStatus{
+					Conditions: readyCondition(metav1.ConditionFalse, mariadbv1alpha1.ConditionReasonStatefulSetNotReady),
+				},
+			},
+			wantReconciled: true,
+		},
+		{
+			name: "no MaxScale and cordoned",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Status: mariadbv1alpha1.MariaDBStatus{
+					Conditions: readyCondition(metav1.ConditionFalse, mariadbv1alpha1.ConditionReasonCordoned),
+				},
+			},
+			wantReconciled: true,
+		},
+		{
+			name:           "no MaxScale without conditions",
+			mariadb:        &mariadbv1alpha1.MariaDB{},
+			wantReconciled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := shouldReconcileReadOnly(tt.mariadb, logr.Discard())
+			assert.Equal(t, tt.wantReconciled, result, "ShouldReconcileReadOnly mismatch")
 		})
 	}
 }


### PR DESCRIPTION
Closes MDB-11

## Problem

A replica can stay **writable indefinitely** after a restart.

`read_only` is runtime-only state. Every call site issues `SET @@global.read_only` (`pkg/sql/sql.go`), and `0-replication.cnf` (`pkg/controller/replication/config.go`) sets `log_bin`, `server_id`, the `gtid` and `rpl_semi_sync` options — but never `read_only`. So each replica restart resets it to `0`.

Nothing put it back:

- `ConfigureReplica` — the only replica `EnableReadOnly` caller — is latched off by `status.replication.roles[pod] == Replica` (`pkg/controller/replication/controller.go`). That role is derived from the persistent `master.info`, so the latch survives the restart that wiped `read_only`.
- The drift-correction loop in `pkg/controller/maintenance/read_only.go` had the correct desired state (`getReadOnlyDesiredPodState`: every non-primary pod → `read_only=1`) but returned early on `!mdb.IsReady()`.

A replica broken on error 1236 has a dead IO thread → `Seconds_Behind_Master = NULL` → readiness probe fails (`probe.go`, "could not determine replica lag") → not Ready → loop skipped. **The guard was closed exactly when the protection mattered.**

## Why the guard was over-broad

The hazard it defends against needs a second, out-of-band actor: `mariadbmon` is a separate process on its own timer. When MaxScale is attached the operator deliberately does not drive switchover — `shouldReconcileSwitchover` returns early on `IsMaxScaleEnabled()` (`pkg/controller/replication/switchover.go:34`).

Without MaxScale, every primary transition is the operator's own and is already fenced upstream: automatic failover only patches `spec.replication.primary.podIndex` (`pod_replication_controller.go`), which makes `IsReplicationSwitchoverRequired()` true, and `shouldReconcileMaintenance` already returns `false` on that and on `IsSwitchingPrimary()` (`pkg/controller/maintenance/controller.go:63-65`).

The operator can reach a not-Ready pod: the internal Service is headless with `PublishNotReadyAddresses = true` (`pkg/builder/service_builder.go:72`) and `NewInternalClientWithPodIndex` dials the per-pod FQDN.

## Change

One condition in `shouldReconcileReadOnly` (`pkg/controller/maintenance/read_only.go:88`): the `!mdb.IsReady()` guard now applies only when `spec.maxScaleRef` is set.

- **With MaxScale** — evaluates exactly as before; the failover race guard is preserved verbatim.
- **Without MaxScale** — returns `true`, so readonly drift is corrected even while the replica is unhealthy.

## Not fixed by this PR

The 1236 divergence itself; privileged writers (`root` holds `READ ONLY ADMIN`); the startup window until the operator reaches the pod; MaxScale-attached instances (unchanged by design).

Possible follow-ups: persisting `read_only=ON` in `0-replication.cnf` for non-primary pods (the only thing that helps MaxScale-attached instances and closes the startup window); emitting a Warning Event / status field / metric when a replica is found writable; setting `enforce_read_only_servers` on MaxScale monitors.

## Verification

- New table-driven `TestShouldReconcileReadOnly` (`pkg/controller/maintenance/read_only_test.go:331`) covering `{MaxScale, no MaxScale}` × `{ready, not ready, cordoned, no conditions}` — 8/8 pass.
- **Regression check**: reverting only `read_only.go` and re-running the test flips exactly the two expected cases — `no_MaxScale_and_not_ready` and `no_MaxScale_without_conditions`. All MaxScale cases stay green, confirming that path is untouched.
- `make lint` → `0 issues.`
- `make test` → `Test Suite Passed`. (`internal/helmtest` initially failed on a missing `mariadb-operator-crds` subchart; `make helm-crds` — the documented CI prerequisite — resolves it, and the suite then passes.)
- `make gen` not run: no API types, RBAC markers or chart templates touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)