### PR TITLE
fix: Do not leave the new primary half configured on switchover

### DIFF
--- a/internal/controller/mariadb_controller_replication_test.go
+++ b/internal/controller/mariadb_controller_replication_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"time"
 
 	volumesnapshotv1 "github.com/kubernetes-csi/external-snapshotter/client/v8/apis/volumesnapshot/v1"
@@ -225,6 +226,64 @@ var _ = Describe("MariaDB replication", Ordered, func() {
 			}
 			return svc.Spec.Selector["statefulset.kubernetes.io/pod-name"] == stsobj.PodName(mdb.ObjectMeta, podIndex)
 		}, testTimeout, testInterval).Should(BeTrue())
+	})
+
+	// Consecutive switchovers promote nodes that may have retained binary logs from a previous primary term of their
+	// own, e.g. whenever 'RESET MASTER;' is skipped as part of the replica configuration to keep the binary logs
+	// around (see 'configureReplicaOpts' in the replication controller): clearing gtid_slave_pos in
+	// 'ConfigurePrimary' fails with Error 1948 for such nodes, and that path must still leave the primary fully
+	// configured, i.e. read_only disabled and the replication user SQL reconciled, so that gtid_binlog_pos advances
+	// past the leftover binary logs.
+	//
+	// Regression test for the switchover wedge where the promoted primary was left half configured on Error 1948:
+	// its stale gtid_binlog_pos was then set as the demoted primary's gtid_slave_pos, rejected with Error 1947, and
+	// the switchover was aborted for good, leaving every node in read_only.
+	//
+	// This spec is self-contained: it discovers the current primary, switches over to another node and then back to
+	// the original one, regardless of the state left by other specs.
+	It("should switch over primary consecutively", func() {
+		By("Expecting MariaDB to be ready eventually")
+		Eventually(func() bool {
+			if err := k8sClient.Get(testCtx, key, mdb); err != nil {
+				return false
+			}
+			return mdb.IsReady() && mdb.Status.CurrentPrimaryPodIndex != nil
+		}, testHighTimeout, testInterval).Should(BeTrue())
+
+		switchPrimaryTo := func(podIndex int) {
+			By(fmt.Sprintf("Expecting MariaDB to eventually update primary to index '%d'", podIndex))
+			Eventually(func(g Gomega) bool {
+				g.Expect(k8sClient.Get(testCtx, key, mdb)).To(Succeed())
+				mdb.Spec.Replication.Primary.PodIndex = &podIndex
+				g.Expect(k8sClient.Update(testCtx, mdb)).To(Succeed())
+				return true
+			}, testTimeout, testInterval).Should(BeTrue())
+
+			By(fmt.Sprintf("Expecting MariaDB to eventually change primary to index '%d'", podIndex))
+			Eventually(func() bool {
+				if err := k8sClient.Get(testCtx, key, mdb); err != nil {
+					return false
+				}
+				if !mdb.IsReady() || mdb.Status.CurrentPrimaryPodIndex == nil {
+					return false
+				}
+				return *mdb.Status.CurrentPrimaryPodIndex == podIndex
+			}, testHighTimeout, testInterval).Should(BeTrue())
+		}
+
+		originalPrimary := *mdb.Status.CurrentPrimaryPodIndex
+		var newPrimary int
+		for i := 0; i < int(mdb.Spec.Replicas); i++ {
+			if i != originalPrimary {
+				newPrimary = i
+				break
+			}
+		}
+
+		switchPrimaryTo(newPrimary)
+		// The original primary was serving as primary until the switchover above, so it may have retained binary logs
+		// from its own primary term: promoting it back exercises the Error 1948 path in 'ConfigurePrimary'.
+		switchPrimaryTo(originalPrimary)
 	})
 
 	It("should update", func() {

--- a/pkg/controller/replication/switchover.go
+++ b/pkg/controller/replication/switchover.go
@@ -432,6 +432,19 @@ func (r *ReplicationReconciler) changePrimaryToReplica(ctx context.Context, req 
 	)
 }
 
+// configureReplicaOpts returns the options used to configure the replicas as part of a switchover.
+//
+// Synced replicas are configured with the new primary's gtid_binlog_pos, i.e. the tip of the binary log they are about
+// to stream from. It must be the new primary's, and not the position the replicas were synced to: log_slave_updates is
+// only enabled in multi-cluster topologies (see 'defaultConfig' in the MariaDB controller), so a promoted primary's
+// binary log has no history prior to its promotion, and a replica requesting an earlier GTID is rejected by it:
+//
+//	Got fatal error 1236 from master when reading data from binary log: 'Error: connecting slave requested to start
+//	from GTID 0-10-9, which is not in the master's binlog. Since the master's binlog contains GTIDs with higher
+//	sequence numbers, it probably means that the slave has diverged due to executing extra erroneous transactions'
+//
+// This relies on 'ConfigurePrimary' having advanced the new primary's gtid_binlog_pos past any binary log left over
+// from a previous primary term of its own.
 func (r *ReplicationReconciler) configureReplicaOpts(ctx context.Context, req *ReconcileRequest, primaryClient *sql.Client,
 	logger logr.Logger) ([]ConfigureReplicaOpt, error) {
 	var replicaOpts []ConfigureReplicaOpt

--- a/pkg/controller/replication/topology.go
+++ b/pkg/controller/replication/topology.go
@@ -146,10 +146,18 @@ func (r *singleClusterTopology) ConfigurePrimary(ctx context.Context, client *sq
 			// replication domain 0. This conflicts with the binary log which contains GTID
 			// 0-11-1176. If MASTER_GTID_POS=CURRENT_POS is used, the binlog position will
 			// override the new value of @@gtid_slave_pos'
-			if sql.IsGtidSlavePosNoValueForDomain(err) {
-				return nil
+			if !sql.IsGtidSlavePosNoValueForDomain(err) {
+				return fmt.Errorf("error resetting slave position: %v", err)
 			}
-			return fmt.Errorf("error resetting slave position: %v", err)
+			// Not being able to reset gtid_slave_pos is harmless, gtid_current_pos falls back to gtid_binlog_pos,
+			// but the primary must not be left half configured: read_only would stay enabled and, more importantly,
+			// the replication user SQL below is the benign DDL write that advances gtid_binlog_pos past the leftover
+			// binary logs. Skipping it leaves gtid_binlog_pos frozen at the previous primary term of this very node,
+			// which is then handed to the demoted primary as its gtid_slave_pos, and rejected by the server:
+			//
+			//	Error 1947 (HY000): Specified GTID 0-10-3989949 conflicts with the binary log which contains a more
+			//	recent GTID 0-11-6156191.
+			r.logger.V(1).Info("Unable to reset gtid_slave_pos in the new primary", "err", err)
 		}
 	}
 	if err := client.DisableReadOnly(ctx); err != nil {


### PR DESCRIPTION
## What

When promoting a node that already has binary logs, clearing `gtid_slave_pos` fails with:

```
Error 1948 (HY000): Specified value for @@gtid_slave_pos contains no value for replication domain 0
```

`ConfigurePrimary` already tolerated that error, but by `return nil`, which skipped everything after it: `DisableReadOnly` never ran (the promoted primary stayed `read_only=ON`) and `reconcileReplUserSql` never ran — that `ALTER USER` / `GRANT` pair is the benign DDL write that advances `gtid_binlog_pos` past the leftover binary log. The stale position was then handed to the demoted primary as its `gtid_slave_pos` and rejected with `Error 1947`, aborting the switchover with every node left in `read_only`.

This error path is reached whenever binary logs are retained on a node that is later promoted, i.e. when `ConfigureReplica` is called with `WithResetMaster(false)` — PITR-enabled clusters (`configureReplicaOpts`) and multi-cluster topologies (`multiClusterTopology.ConfigureReplica`, which also runs with `log_slave_updates=ON`).

## Changes

- `pkg/controller/replication/topology.go:141` — tolerate error 1948 without skipping the rest of `ConfigurePrimary`, so `read_only` is cleared and the replication user SQL runs and advances `gtid_binlog_pos`. Logged at `V(1)`.
- `pkg/controller/replication/switchover.go:435` — document why the demoted primary must be given the new primary's `gtid_binlog_pos` rather than the position replicas were synced to: with `log_slave_updates` only enabled in multi-cluster topologies, a promoted primary's binary log has no history prior to its promotion, so an earlier GTID is rejected with `1236 ... slave has diverged`.
- `internal/controller/mariadb_controller_replication_test.go:230` — new `should switch over primary consecutively` spec. Self-contained: discovers the current primary, switches over to another node and back, exercising consecutive switchovers (previously only covered incidentally inside `should fail and switch over primary`).

## Verification

- `make lint` — 0 issues.
- `go test ./pkg/controller/replication/...` — ok.
- Focused integration run against KIND: `make test-int TEST_ARGS="--focus='should switch over primary consecutively'"` → `Ran 1 of 193 Specs in 134.531 seconds — 1 Passed`.

Closes MDB-12
