### PR TITLE
feat(physical-backup): SELinux improvements

### DIFF
--- a/docs/physical_backup.md
+++ b/docs/physical_backup.md
@@ -3,25 +3,35 @@
 ## Table of contents
 
 <!-- toc -->
-- [What is a physical backup?](#what-is-a-physical-backup)
-- [Backup strategies](#backup-strategies)
-- [Storage types](#storage-types)
-- [Scheduling](#scheduling)
-- [Compression](#compression)
-- [Server-Side Encryption with Customer-Provided Keys (SSE-C) For S3](#server-side-encryption-with-customer-provided-keys-sse-c-for-s3)
-- [Retention policy](#retention-policy)
-- [Target policy](#target-policy)
-- [Restoration](#restoration)
-- [Target recovery time](#target-recovery-time)
-- [Timeout](#timeout)
-- [Log level](#log-level)
-- [Extra options](#extra-options)
-- [Azure Blob Storage Credentials](#azure-blob-storage-credentials)
-- [S3 credentials](#s3-credentials)
-- [Staging area](#staging-area)
-- [`VolumeSnapshots`](#volumesnapshots)
-- [Important considerations and limitations](#important-considerations-and-limitations)
-- [Troubleshooting](#troubleshooting)
+- [Physical backups](#physical-backups)
+  - [Table of contents](#table-of-contents)
+  - [What is a physical backup?](#what-is-a-physical-backup)
+  - [Backup strategies](#backup-strategies)
+  - [Storage types](#storage-types)
+  - [Scheduling](#scheduling)
+  - [Compression](#compression)
+  - [Server-Side Encryption with Customer-Provided Keys (SSE-C) For S3](#server-side-encryption-with-customer-provided-keys-sse-c-for-s3)
+  - [Retention policy](#retention-policy)
+  - [Target policy](#target-policy)
+  - [Restoration](#restoration)
+  - [Target recovery time](#target-recovery-time)
+  - [Timeout](#timeout)
+  - [Log level](#log-level)
+  - [Extra options](#extra-options)
+  - [Azure Blob Storage Credentials](#azure-blob-storage-credentials)
+  - [S3 credentials](#s3-credentials)
+  - [Staging area](#staging-area)
+  - [`VolumeSnapshots`](#volumesnapshots)
+  - [Important considerations and limitations](#important-considerations-and-limitations)
+    - [Root credentials](#root-credentials)
+    - [Restore `Job`](#restore-job)
+    - [`ReadWriteOncePod` access mode partially supported](#readwriteoncepod-access-mode-partially-supported)
+    - [`PhysicalBackup` `Jobs` scheduling](#physicalbackup-jobs-scheduling)
+    - [SELinux Enforcement](#selinux-enforcement)
+  - [Troubleshooting](#troubleshooting)
+    - [Common errors](#common-errors)
+      - [`mariadb-backup` log copy incomplete: consider increasing `innodb_log_file_size`](#mariadb-backup-log-copy-incomplete-consider-increasing-innodb_log_file_size)
+      - [`mariadb-backup` `Job` fails to start because the `Pod` cannot mount `MariaDB` PVC created with openebs/lvm-localpv `StorageClass` provider](#mariadb-backup-job-fails-to-start-because-the-pod-cannot-mount-mariadb-pvc-created-with-openebslvm-localpv-storageclass-provider)
 <!-- /toc -->
 
 ## What is a physical backup?
@@ -602,6 +612,9 @@ spec:
 ```
 
 This configuration may be suitable when using the `ReadWriteMany` access mode, which allows multiple `Pods` across different nodes to mount the volume simultaneously.
+
+### SELinux Enforcement
+`PhysicalBackup` `Jobs` must mount the data PVC used by a `MariaDB` `Pod`, this is typically a replica however that can be configured via `.spec.target`. In order to allow these `Jobs` to run on nodes with SELinux being enforced, the MCS labels must match. Currently, the only way to achieve this is to manually set the MCS labels via `.spec.podSecurityContext.seLinuxOptions.level` ensuring that the values either match between the `PhysicalBackup`  and `MariaDB` config, or only configuring via `MariaDB` config. Previously this needed to be manually configured in both the `PhysicalBackup` `Job` as well as the `MariaDB`.
 
 ## Troubleshooting
 

--- a/pkg/builder/batch_builder.go
+++ b/pkg/builder/batch_builder.go
@@ -267,6 +267,10 @@ func (b *Builder) BuildPhysicalBackupJob(key types.NamespacedName, backup *maria
 	if err != nil {
 		return nil, err
 	}
+	// This Job co-mounts the MariaDB data volume, so it must share the MariaDB Pod's
+	// SELinux context. Otherwise, on SELinux-enforcing nodes the volume is relabelled
+	// and the running mariadbd loses access to its own data directory (Errcode: 13).
+	inheritMariadbSELinuxOptions(securityContext, mariadb)
 
 	var affinity *corev1.Affinity
 	if ptr.Deref(backup.Spec.PodAffinity, true) {

--- a/pkg/builder/batch_builder_test.go
+++ b/pkg/builder/batch_builder_test.go
@@ -1028,6 +1028,98 @@ func TestPhysicalBackupJobInitContainers(t *testing.T) {
 	}
 }
 
+func TestPhysicalBackupJobSELinuxOptions(t *testing.T) {
+	builder := newDefaultTestBuilder(t)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mariadb-0",
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "node-1",
+		},
+	}
+	mariadbSELinux := &corev1.SELinuxOptions{
+		Level: "s0:c100,c200",
+	}
+	backupSELinux := &corev1.SELinuxOptions{
+		Level: "s0:c300,c400",
+	}
+	storage := mariadbv1alpha1.PhysicalBackupStorage{
+		Volume: &mariadbv1alpha1.StorageVolumeSource{
+			EmptyDir: &mariadbv1alpha1.EmptyDirVolumeSource{},
+		},
+	}
+
+	tests := []struct {
+		name        string
+		mariadb     *mariadbv1alpha1.MariaDB
+		backup      *mariadbv1alpha1.PhysicalBackup
+		wantSELinux *corev1.SELinuxOptions
+	}{
+		{
+			name:        "no SELinux options anywhere",
+			mariadb:     &mariadbv1alpha1.MariaDB{Spec: mariadbv1alpha1.MariaDBSpec{}},
+			backup:      &mariadbv1alpha1.PhysicalBackup{Spec: mariadbv1alpha1.PhysicalBackupSpec{Storage: storage}},
+			wantSELinux: nil,
+		},
+		{
+			name: "Job inherits MariaDB SELinux options",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+						PodSecurityContext: &mariadbv1alpha1.PodSecurityContext{
+							SELinuxOptions: mariadbSELinux,
+						},
+					},
+				},
+			},
+			backup:      &mariadbv1alpha1.PhysicalBackup{Spec: mariadbv1alpha1.PhysicalBackupSpec{Storage: storage}},
+			wantSELinux: mariadbSELinux,
+		},
+		{
+			name: "explicit Job SELinux options take precedence over MariaDB",
+			mariadb: &mariadbv1alpha1.MariaDB{
+				Spec: mariadbv1alpha1.MariaDBSpec{
+					MariaDBPodTemplate: mariadbv1alpha1.MariaDBPodTemplate{
+						PodSecurityContext: &mariadbv1alpha1.PodSecurityContext{
+							SELinuxOptions: mariadbSELinux,
+						},
+					},
+				},
+			},
+			backup: &mariadbv1alpha1.PhysicalBackup{
+				Spec: mariadbv1alpha1.PhysicalBackupSpec{
+					Storage: storage,
+					PhysicalBackupPodTemplate: mariadbv1alpha1.PhysicalBackupPodTemplate{
+						PodSecurityContext: &mariadbv1alpha1.PodSecurityContext{
+							SELinuxOptions: backupSELinux,
+						},
+					},
+				},
+			},
+			wantSELinux: backupSELinux,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			job, err := builder.BuildPhysicalBackupJob(
+				client.ObjectKeyFromObject(tt.backup),
+				tt.backup,
+				tt.mariadb,
+				pod,
+				"backupfile",
+			)
+			if err != nil {
+				t.Fatalf("unexpected error building PhysicalBackup Job: %v", err)
+			}
+			psc := job.Spec.Template.Spec.SecurityContext
+			assert.NotNil(t, psc, "expected pod security context to be set")
+			assert.Equal(t, tt.wantSELinux, psc.SELinuxOptions)
+		})
+	}
+}
+
 func TestRestoreJobImagePullSecrets(t *testing.T) {
 	builder := newDefaultTestBuilder(t)
 	objMeta := metav1.ObjectMeta{

--- a/pkg/builder/securitycontext_builder.go
+++ b/pkg/builder/securitycontext_builder.go
@@ -65,3 +65,18 @@ func (b *Builder) buildPodSecurityContextWithUserGroup(podSecurityContext *maria
 		FSGroup:      &group,
 	}, nil
 }
+
+// inheritMariadbSELinuxOptions makes a Job that co-mounts the MariaDB data volume
+// (e.g. a PhysicalBackup Job) share the SELinux context of the MariaDB Pod.
+//
+// An SELinux context explicitly configured on the Job's own PodSecurityContext
+// takes precedence and is left untouched.
+func inheritMariadbSELinuxOptions(securityContext *corev1.PodSecurityContext, mariadb *mariadbv1alpha1.MariaDB) {
+	if securityContext == nil || securityContext.SELinuxOptions != nil {
+		return
+	}
+	if mariadb.Spec.PodSecurityContext == nil || mariadb.Spec.PodSecurityContext.SELinuxOptions == nil {
+		return
+	}
+	securityContext.SELinuxOptions = mariadb.Spec.PodSecurityContext.SELinuxOptions
+}


### PR DESCRIPTION
Close MDB-20

## Summary
- PhysicalBackup Jobs now inherit `podSecurityContext.seLinuxOptions` from the referenced MariaDB when the Job doesn't set its own, fixing the SELinux-enforced `Errcode: 13` data loss from #1592.
- Fixed a doc typo (`Physicalbackup` -> `PhysicalBackup`) in docs/physical_backup.md.

Supersedes #1793, which was blocked because its head was the fork's entire `main` branch (68 unrelated commits) rather than a dedicated branch. This PR carries just the single SELinux commit, rebased cleanly onto current `main`.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/builder/...` (includes `TestPhysicalBackupJobSELinuxOptions`)
- [ ] CI green