### PR TITLE
build: run helm-docs natively instead of via Docker

### DIFF
--- a/make/deps.mk
+++ b/make/deps.mk
@@ -21,6 +21,7 @@ GO_LICENSES = $(LOCALBIN)/go-licenses
 CRD_REF_DOCS = $(LOCALBIN)/crd-ref-docs
 FLUX ?= $(LOCALBIN)/flux
 YQ ?= $(LOCALBIN)/yq
+HELM_DOCS ?= $(LOCALBIN)/helm-docs
 
 ## Tool Versions
 KUBERNETES_VERSION ?= 1.36.x
@@ -37,6 +38,7 @@ CRD_REF_DOCS_VERSION ?= v0.2.0
 FLUX_VERSION ?= 0.40.1
 JQ_VERSION ?= jq-1.7
 YQ_VERSION ?= v4.18.1
+HELM_DOCS_VERSION ?= v1.14.2
 
 .PHONY: kind
 kind: $(KIND) ## Download kind locally if necessary.
@@ -98,6 +100,9 @@ $(GO_LICENSES): $(LOCALBIN)
 crd-ref-docs: $(CRD_REF_DOCS) ## Download crd-ref-docs locally if necessary.
 $(CRD_REF_DOCS): $(LOCALBIN)
 	GOBIN=$(LOCALBIN) $(GO) install github.com/elastic/crd-ref-docs@$(CRD_REF_DOCS_VERSION)
+
+$(HELM_DOCS): $(LOCALBIN)
+	GOBIN=$(LOCALBIN) $(GO) install github.com/norwoodj/helm-docs/cmd/helm-docs@$(HELM_DOCS_VERSION)
 
 .PHONY: flux
 flux: ## Download flux locally if necessary.

--- a/make/helm.mk
+++ b/make/helm.mk
@@ -45,17 +45,10 @@ helm-config: yq ## Update operator config in the Helm chart.
 	$(YQ) e -i '.config.exporterMaxscaleImage.repository = "$(RELATED_IMAGE_EXPORTER_MAXSCALE_NAME)"' $(HELM_VALUES_FILE)
 	$(YQ) e -i '.config.exporterMaxscaleImage.tag = "$(RELATED_IMAGE_EXPORTER_MAXSCALE_VERSION)"' $(HELM_VALUES_FILE)
 
-HELM_DOCS_IMG ?= jnorwood/helm-docs:v1.14.2
 .PHONY: helm-docs
-helm-docs: ## Generate Helm chart docs.
-	$(DOCKER) run --rm \
-		-u $(shell id -u) \
-		-v $(shell pwd)/$(HELM_DIR):/helm-docs \
-		$(HELM_DOCS_IMG)
-	$(DOCKER) run --rm \
-		-u $(shell id -u) \
-		-v $(shell pwd)/$(HELM_CLUSTER_DIR):/helm-docs \
-		$(HELM_DOCS_IMG)
+helm-docs: $(HELM_DOCS) ## Generate Helm chart docs.
+	$(HELM_DOCS) --chart-search-root $(HELM_DIR)
+	$(HELM_DOCS) --chart-search-root $(HELM_CLUSTER_DIR)
 
 .PHONY: helm-gen
 helm-gen: helm-crds helm-config helm-docs ## Generate manifests and documentation for the Helm chart.


### PR DESCRIPTION
Closes MDB-22 (Multica issue `01a05edc-4b3d-704b-8f29-daabf8e15687`)

The `helm-docs` target ran the `jnorwood/helm-docs` image with the chart dir bind-mounted. In environments where the Docker daemon does not share the workspace filesystem (e.g. the daemon runs in its own container on a Talos node), the bind-mount source does not exist for the daemon and Docker silently auto-creates an empty directory — helm-docs finds no charts, no-ops, and exits 0, so chart READMEs never regenerate locally and the CI `Artifacts` job fails (observed on release-26.6.1, PR #1888).

Replace the `docker run` invocation with the pinned `helm-docs` binary (v1.14.2) installed via `go install` into `./bin`, following the pattern `make/deps.mk` already uses for kind, kustomize, controller-gen, ginkgo, etc. `--chart-search-root` keeps the old semantics (the image ran with workdir = chart dir). `HELM_DOCS_IMG` had no other references; `helm-gen`/`gen` keep calling the same `helm-docs` target.

Verified:
- `make helm-docs` installs the binary and regenerates both chart READMEs (`Found Chart directories [.]`).
- Output is byte-identical to the `jnorwood/helm-docs:v1.14.2` image for both `mariadb-operator` and `mariadb-cluster` charts (empty diff).
- Running on a branch with up-to-date READMEs leaves the tree clean (idempotent).
- No new CI prerequisites: Go + module proxy access are already required by 7 tools in `make/deps.mk`.