### PR TITLE
Demote rejoining nodes with self-owned GTIDs via MASTER_DEMOTE_TO_SLAVE

### DIFF
--- a/make/dev.mk
+++ b/make/dev.mk
@@ -249,7 +249,7 @@ dump:  ## Dump cluster state for debugging purposes
 	@for pod in $$($(KUBECTL) get pods -n $(DUMP_NAMESPACE) -o jsonpath='{.items[*].metadata.name}'); do \
 		if [[ "$$pod" == csi* ]]; then continue; fi; \
 		printf "\n---- Logs for $$pod ----\n\n"; \
-		$(KUBECTL) logs $$pod -n $(DUMP_NAMESPACE) --all-containers=true; \
+		$(KUBECTL) logs $$pod -n $(DUMP_NAMESPACE) --all-containers=true || true; \
 	done
 
 ##@ Profile

--- a/pkg/agent/handler/replication/probe.go
+++ b/pkg/agent/handler/replication/probe.go
@@ -72,8 +72,10 @@ func (p *ReplicationProbe) Liveness(w http.ResponseWriter, r *http.Request) {
 
 		replicaIORunning := ptr.Deref(status.SlaveIORunning, false)
 		if !replicaIORunning {
-			p.livenessLogger.Error(nil, "Replica IO thread not running")
-			p.responseWriter.WriteError(w, "Replica IO thread not running")
+			p.livenessLogger.Error(nil, "Replica IO thread not running",
+				"Last_IO_Errno", ptr.Deref(status.LastIOErrno, 0),
+				"Last_IO_Error", ptr.Deref(status.LastIOError, ""))
+			p.responseWriter.WriteErrorf(w, "Replica IO thread not running (Last_IO_Errno: %d)", ptr.Deref(status.LastIOErrno, 0))
 			return
 		}
 		replicaSQLRunning := ptr.Deref(status.SlaveSQLRunning, false)

--- a/pkg/controller/replication/topology.go
+++ b/pkg/controller/replication/topology.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/refresolver"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/sql"
 	"github.com/mariadb-operator/mariadb-operator/v26/pkg/statefulset"
+	"github.com/mariadb-operator/mariadb-operator/v26/pkg/version"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -238,12 +239,47 @@ func (r *singleClusterTopology) changeMaster(ctx context.Context, mariadb *maria
 		changeMasterOpts = append(changeMasterOpts, sql.WithChangeMasterRetries(*replication.Replica.ConnectionRetrySeconds))
 	}
 
+	// A node that retained self-originated GTIDs from a previous primary term (a
+	// non-empty gtid_binlog_pos) is being demoted to a replica, not freshly
+	// configured. MASTER_USE_GTID cannot reconcile those self-owned GTIDs, so
+	// emit MASTER_DEMOTE_TO_SLAVE=1 instead, which merges gtid_binlog_pos in gtid_slave_pos.
+	// See: https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/replication-statements/change-master-to#master_demote_to_slave
+	gtidBinlogPos, err := client.GtidBinlogPos(ctx)
+	if err != nil {
+		return fmt.Errorf("error getting gtid_binlog_pos: %v", err)
+	}
+	if gtidBinlogPos != "" {
+		demote, derr := demoteToSlaveSupported(mariadb.Spec.Image)
+		if derr != nil {
+			r.logger.Info("Falling back to MASTER_USE_GTID: unable to infer MariaDB version from image",
+				"image", mariadb.Spec.Image, "error", derr)
+		} else if demote {
+			changeMasterOpts = append(changeMasterOpts, sql.WithChangeMasterDemote(true))
+		} else {
+			r.logger.Info("Falling back to MASTER_USE_GTID: MASTER_DEMOTE_TO_SLAVE requires MariaDB 10.10 or later",
+				"image", mariadb.Spec.Image)
+		}
+	}
+
 	changeMasterOpts = append(changeMasterOpts, opts...)
 
 	if err := client.ChangeMaster(ctx, changeMasterOpts...); err != nil {
 		return fmt.Errorf("error changing master: %v", err)
 	}
 	return nil
+}
+
+// demoteToSlaveSupported reports whether the MariaDB version of the given image
+// supports MASTER_DEMOTE_TO_SLAVE (available from MariaDB 10.10 onwards).
+// See: https://mariadb.com/docs/server/reference/sql-statements/administrative-sql-statements/replication-statements/change-master-to#master_demote_to_slave
+// The error is non-nil when the version cannot be inferred from the image (e.g. a
+// sha256 digest), in which case the caller falls back to MASTER_USE_GTID.
+func demoteToSlaveSupported(image string) (bool, error) {
+	v, err := version.NewVersion(image)
+	if err != nil {
+		return false, err
+	}
+	return v.GreaterThanOrEqual("10.10.0")
 }
 
 type multiClusterTopology struct {

--- a/pkg/controller/replication/topology_test.go
+++ b/pkg/controller/replication/topology_test.go
@@ -1,0 +1,77 @@
+package replication
+
+import (
+	"testing"
+)
+
+func TestDemoteToSlaveSupported(t *testing.T) {
+	tests := []struct {
+		name    string
+		image   string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:  "mariadb 11.x supports demote",
+			image: "mariadb:11.8.8",
+			want:  true,
+		},
+		{
+			name:  "mariadb 10.11 supports demote",
+			image: "mariadb:10.11.6",
+			want:  true,
+		},
+		{
+			name:  "mariadb 10.10 supports demote",
+			image: "mariadb:10.10.3",
+			want:  true,
+		},
+		{
+			name:  "mariadb 10.9 does not support demote",
+			image: "mariadb:10.9.13",
+			want:  false,
+		},
+		{
+			name:  "mariadb 10.5 does not support demote",
+			image: "mariadb:10.5.22",
+			want:  false,
+		},
+		{
+			name:    "sha256 digest cannot be inferred",
+			image:   "mariadb@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "image without tag cannot be inferred",
+			image:   "mariadb",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "non-semver tag cannot be inferred",
+			image:   "mariadb:latest",
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := demoteToSlaveSupported(tt.image)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("expected %v, got %v", tt.want, got)
+			}
+		})
+	}
+}

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -1020,6 +1020,7 @@ type ChangeMasterOpts struct {
 	Password string
 	Gtid     string
 	Retries  int
+	Demote   bool
 
 	SSLEnabled  bool
 	SSLCertPath string
@@ -1063,6 +1064,12 @@ func WithChangeMasterGtid(gtid string) ChangeMasterOpt {
 func WithChangeMasterRetries(retries int) ChangeMasterOpt {
 	return func(cmo *ChangeMasterOpts) {
 		cmo.Retries = retries
+	}
+}
+
+func WithChangeMasterDemote(demote bool) ChangeMasterOpt {
+	return func(cmo *ChangeMasterOpts) {
+		cmo.Demote = demote
 	}
 }
 
@@ -1119,7 +1126,11 @@ MASTER_PASSWORD='{{ .Password }}',
 {{- with .Retries }}
 MASTER_CONNECT_RETRY={{ . }},
 {{- end }}
+{{- if .Demote }}
+MASTER_DEMOTE_TO_SLAVE=1;
+{{- else }}
 MASTER_USE_GTID={{ .Gtid }};
+{{- end }}
 `)
 	buf := new(bytes.Buffer)
 	err := tpl.Execute(buf, opts)

--- a/pkg/sql/sql_test.go
+++ b/pkg/sql/sql_test.go
@@ -51,6 +51,24 @@ MASTER_USE_GTID=CurrentPos;
 			wantErr: false,
 		},
 		{
+			name: "valid without SSL and demoted to slave",
+			options: []ChangeMasterOpt{
+				WithChangeMasterHost("127.0.0.1"),
+				WithChangeMasterPort(3306),
+				WithChangeMasterCredentials("repl", "password"),
+				WithChangeMasterGtid("CurrentPos"),
+				WithChangeMasterDemote(true),
+			},
+			wantQuery: `CHANGE MASTER  TO
+MASTER_HOST='127.0.0.1',
+MASTER_PORT=3306,
+MASTER_USER='repl',
+MASTER_PASSWORD='password',
+MASTER_DEMOTE_TO_SLAVE=1;
+`,
+			wantErr: false,
+		},
+		{
 			name: "missing SSL paths",
 			options: []ChangeMasterOpt{
 				WithChangeMasterHost("127.0.0.1"),


### PR DESCRIPTION
## Summary

Follow-up to #1883 (removal of `RESET MASTER`). Fixes the hard-failover wedge: when a primary is hard-failed (pod deleted) and recreates as a replica, it keeps its self-originated GTIDs (non-empty `gtid_binlog_pos`). Re-pointing it with `MASTER_USE_GTID` cannot reconcile those self-owned GTIDs, so the node never converges — `Enabling readonly` loops and the pod's readiness churns.

## Change

In `changeMaster`, read `gtid_binlog_pos` and, when it is non-empty, emit `CHANGE MASTER ... MASTER_DEMOTE_TO_SLAVE=1` instead of `MASTER_USE_GTID`. That merges `gtid_binlog_pos` into `gtid_slave_pos` — the non-destructive replacement for the `RESET MASTER` that used to run here.

Fresh replicas (empty `gtid_binlog_pos`) are untouched and keep the `MASTER_USE_GTID` path.

## Files

- `pkg/controller/replication/topology.go:241` — read `gtid_binlog_pos`; gate demote on non-empty
- `pkg/sql/sql.go` — `Demote` field, `WithChangeMasterDemote`; mutually-exclusive template clause (`MASTER_DEMOTE_TO_SLAVE=1` or `MASTER_USE_GTID=...`)
- `pkg/sql/sql_test.go` — demote query case

## Verification

- `go build ./...`, `go test ./pkg/sql/... ./pkg/controller/replication/...`, `make lint` — all green.
- Operator-failover matrix across 4 scenarios (empty / with-data × `log_slave_updates` OFF/ON) evaluated on a local KIND cluster — results in the comment below.

Closes MDB-21